### PR TITLE
Fix tab order in Qt dialogs

### DIFF
--- a/src/frontend/qt_sdl/AudioSettingsDialog.ui
+++ b/src/frontend/qt_sdl/AudioSettingsDialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>482</width>
-    <height>230</height>
+    <width>502</width>
+    <height>257</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -136,6 +136,15 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>slVolume</tabstop>
+  <tabstop>rbMicNone</tabstop>
+  <tabstop>rbMicExternal</tabstop>
+  <tabstop>rbMicNoise</tabstop>
+  <tabstop>rbMicWav</tabstop>
+  <tabstop>txtMicWavPath</tabstop>
+  <tabstop>btnMicWavBrowse</tabstop>
+ </tabstops>
  <resources/>
  <connections>
   <connection>

--- a/src/frontend/qt_sdl/EmuSettingsDialog.ui
+++ b/src/frontend/qt_sdl/EmuSettingsDialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>575</width>
-    <height>254</height>
+    <height>275</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -392,13 +392,10 @@
        <string>DLDI</string>
       </attribute>
       <layout class="QGridLayout" name="gridLayout_4">
-       <item row="0" column="0" colspan="3">
-        <widget class="QCheckBox" name="cbDLDIEnable">
-         <property name="whatsThis">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Enable the built-in DLDI driver, to let homebrew access files from a given SD image.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-         </property>
+       <item row="1" column="0">
+        <widget class="QLabel" name="label_11">
          <property name="text">
-          <string>Enable DLDI (for homebrew)</string>
+          <string>DLDI SD card:</string>
          </property>
         </widget>
        </item>
@@ -412,13 +409,6 @@
        <item row="1" column="1">
         <widget class="QLineEdit" name="txtDLDISDPath"/>
        </item>
-       <item row="1" column="0">
-        <widget class="QLabel" name="label_11">
-         <property name="text">
-          <string>DLDI SD card:</string>
-         </property>
-        </widget>
-       </item>
        <item row="2" column="0">
         <spacer name="verticalSpacer_3">
          <property name="orientation">
@@ -431,6 +421,16 @@
           </size>
          </property>
         </spacer>
+       </item>
+       <item row="0" column="0" colspan="3">
+        <widget class="QCheckBox" name="cbDLDIEnable">
+         <property name="whatsThis">
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Enable the built-in DLDI driver, to let homebrew access files from a given SD image.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         </property>
+         <property name="text">
+          <string>Enable DLDI (for homebrew)</string>
+         </property>
+        </widget>
        </item>
       </layout>
      </widget>
@@ -451,8 +451,32 @@
  <tabstops>
   <tabstop>cbxConsoleType</tabstop>
   <tabstop>chkDirectBoot</tabstop>
+  <tabstop>tabWidget</tabstop>
+  <tabstop>txtBIOS9Path</tabstop>
+  <tabstop>btnBIOS9Browse</tabstop>
+  <tabstop>txtBIOS7Path</tabstop>
+  <tabstop>btnBIOS7Browse</tabstop>
+  <tabstop>txtFirmwarePath</tabstop>
+  <tabstop>btnFirmwareBrowse</tabstop>
+  <tabstop>txtDSiBIOS9Path</tabstop>
+  <tabstop>btnDSiBIOS9Browse</tabstop>
+  <tabstop>txtDSiBIOS7Path</tabstop>
+  <tabstop>btnDSiBIOS7Browse</tabstop>
+  <tabstop>txtDSiFirmwarePath</tabstop>
+  <tabstop>btnDSiFirmwareBrowse</tabstop>
+  <tabstop>txtDSiNANDPath</tabstop>
+  <tabstop>btnDSiNANDBrowse</tabstop>
+  <tabstop>cbDSiSDEnable</tabstop>
+  <tabstop>txtDSiSDPath</tabstop>
+  <tabstop>btnDSiSDBrowse</tabstop>
   <tabstop>chkEnableJIT</tabstop>
   <tabstop>spnJITMaximumBlockSize</tabstop>
+  <tabstop>chkJITBranchOptimisations</tabstop>
+  <tabstop>chkJITLiteralOptimisations</tabstop>
+  <tabstop>chkJITFastMemory</tabstop>
+  <tabstop>cbDLDIEnable</tabstop>
+  <tabstop>txtDLDISDPath</tabstop>
+  <tabstop>btnDLDISDBrowse</tabstop>
  </tabstops>
  <resources/>
  <connections>

--- a/src/frontend/qt_sdl/VideoSettingsDialog.ui
+++ b/src/frontend/qt_sdl/VideoSettingsDialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>482</width>
-    <height>244</height>
+    <height>276</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -201,6 +201,16 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>rb3DSoftware</tabstop>
+  <tabstop>rb3DOpenGL</tabstop>
+  <tabstop>cbGLDisplay</tabstop>
+  <tabstop>cbVSync</tabstop>
+  <tabstop>sbVSyncInterval</tabstop>
+  <tabstop>cbSoftwareThreaded</tabstop>
+  <tabstop>cbxGLResolution</tabstop>
+  <tabstop>cbBetterPolygons</tabstop>
+ </tabstops>
  <resources/>
  <connections>
   <connection>


### PR DESCRIPTION
So that pressing the tab key will actually move the cursor to the next UI element, instead of having a seemingly random order.