### PR TITLE
Configure the FPS limit

### DIFF
--- a/src/frontend/qt_sdl/PlatformConfig.cpp
+++ b/src/frontend/qt_sdl/PlatformConfig.cpp
@@ -57,6 +57,7 @@ int GL_ScaleFactor;
 int GL_BetterPolygons;
 
 int LimitFPS;
+int FPSRate;
 int AudioSync;
 int ShowOSD;
 
@@ -166,6 +167,7 @@ ConfigEntry PlatformConfigFile[] =
     {"GL_BetterPolygons", 0, &GL_BetterPolygons, 0, NULL, 0},
 
     {"LimitFPS", 0, &LimitFPS, 1, NULL, 0},
+    {"FPSRate", 0, &FPSRate, 60, NULL, 0},
     {"AudioSync", 0, &AudioSync, 0, NULL, 0},
     {"ShowOSD", 0, &ShowOSD, 1, NULL, 0},
 

--- a/src/frontend/qt_sdl/PlatformConfig.h
+++ b/src/frontend/qt_sdl/PlatformConfig.h
@@ -73,6 +73,7 @@ extern int GL_ScaleFactor;
 extern int GL_BetterPolygons;
 
 extern int LimitFPS;
+extern int FPSRate;
 extern int AudioSync;
 extern int ShowOSD;
 

--- a/src/frontend/qt_sdl/main.cpp
+++ b/src/frontend/qt_sdl/main.cpp
@@ -579,7 +579,10 @@ void EmuThread::run()
                 SDL_UnlockMutex(audioSyncLock);
             }
 
-            double frametimeStep = nlines / (60.0 * 263.0);
+            double fpsrate = (double)Config::FPSRate;
+            if (fpsrate < 1) fpsrate = 60.0;
+
+            double frametimeStep = nlines / (fpsrate * 263.0);
 
             {
                 bool limitfps = Config::LimitFPS && !fastforward;


### PR DESCRIPTION
Adds a new setting to the ini to control the FPS to target when the framerate limit is on. Allows the user to set a specific playback speed instead of only choosing between "normal" and "as fast as possible".