### PR TITLE
Command-line interface

### DIFF
--- a/src/frontend/qt_sdl/CLI.cpp
+++ b/src/frontend/qt_sdl/CLI.cpp
@@ -19,40 +19,65 @@
 #include <stdio.h>
 #include <string.h>
 
-#include "../../dolphin/CommonFuncs.h"
+#include "../FrontendUtil.h"
 
 #include "CLI.h"
 
 namespace CLI
 {
 
-//TODO: don't make it a function, add it into the ManageArgs function
-bool IsFlag (int arg)
+char* GetNextArg (int argc, char** argv, int argp)
 {
-    switch (arg) {
-        case cliArg_GBARomPath:
-            return false;
-        case cliArg_UseFreeBios:
-            return true;
-        case cliArg_FirmwareLanguage:
-            return false;
-        case cliArg_Renderer:
-            return false;
-    }
-    return false;
+    // returns argv[argp] if it exists, nullptr if it doesn't
+    if (argp >= argc)
+        return nullptr;
+    else
+        return argv[argp];
 }
 
-void ManageArgs (int argc, char** argv)
+bool ManageArgs (int argc, char** argv)
 {
+    // returns true if a ROM was successfully loaded
+
     // easter egg - not worth checking other cases for something so dumb
     if (strcasecmp(argv[0], "derpDS") || strcasecmp(argv[0], "./derpDS"))
+        //TODO: seems to always be doing this, research strcasecmp
         printf("did you just call me a derp???\n");
 
+    int posArgCount = 0;
+    bool romLoaded = false;
+    
     for (int i = 1; i < argc; i++)
     {
         char* arg = argv[i];
-        printf("%s\n", arg);
+        bool isFlag;
+        if (arg[0] == '-')
+        {
+            // manage options(?), so arguments like these: -h --help
+        } 
+        else
+        {
+            switch (posArgCount)
+            {
+                case 0:
+                    {
+                        int res = Frontend::LoadROM(arg, Frontend::ROMSlot_NDS);
+                        if (res == Frontend::Load_OK)
+                            romLoaded = true;
+                        break;
+                    }
+                case 1:
+                    //TODO: check if it's possible to load a GBA ROM without a DS ROM loaded
+                    Frontend::LoadROM(arg, Frontend::ROMSlot_GBA);
+                    break;
+                default:
+                    printf("Too many arguments, arg '%s' will be ignored\n", arg);
+            }
+            posArgCount++;
+        }
     }
+
+    return romLoaded;
 }
 
 }

--- a/src/frontend/qt_sdl/CLI.cpp
+++ b/src/frontend/qt_sdl/CLI.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright 2016-2021 patataofcourse
+    Copyright 2021 patataofcourse
 
     This file is part of melonDS.
 
@@ -28,8 +28,8 @@ namespace CLI
 {
 
 char* DSRomPath = new char[128];
-
 char* GBARomPath = new char[128];
+bool Verbosity = false;
 
 char* GetNextArg (int argc, char** argv, int argp)
 {
@@ -42,6 +42,14 @@ char* GetNextArg (int argc, char** argv, int argp)
 
 void ManageArgs (int argc, char** argv)
 {
+    //TODO: there has to be a better way to handle this, right?
+    DSRomPath = "";
+    GBARomPath = "";
+
+    // don't think this will ever happen but i don't wanna risk a random segfault
+    if (argc == 0)
+        return;
+
     // easter egg - not worth checking other cases for something so dumb
     if (!strcasecmp(argv[0], "derpDS") || !strcasecmp(argv[0], "./derpDS"))
         printf("did you just call me a derp???\n");
@@ -56,20 +64,22 @@ void ManageArgs (int argc, char** argv)
         {
             if (!strcasecmp(arg, "-h") || !strcasecmp(arg, "--help"))
             {
-                //TODO: QT arguments
+                //TODO: QT options
                 printf(
                     "usage: melonDS [options] ... [dspath] [gbapath]\n"
                     "Options:\n"
-                    "  -h / --help  display this help message and quit"
+                    "  -h / --help      display this help message and quit\n"
+                    "  -v / --verbose   toggle verbose mode\n"
+                    // "  -a / --archive   opens dspath as an archive containing the ROM\n"
                     "Arguments:\n"
-                    "  dspath       path to a DS ROM you want to run\n"
-                    "  gbapath      path to a GBA ROM you want to load in the emulated Slot 2\n"
+                    "  dspath           path to a DS ROM you want to run\n"
+                    "  gbapath          path to a GBA ROM you want to load in the emulated Slot 2\n"
                 );
                 exit(0);
             }
             else
             {
-                printf("Unrecognized command line option %s - aborting.\n", arg);
+                printf("Unrecognized option %s - run '%s --help' for more details \n", arg, argv[0]);
                 exit(1);
             }
         } 

--- a/src/frontend/qt_sdl/CLI.cpp
+++ b/src/frontend/qt_sdl/CLI.cpp
@@ -27,9 +27,9 @@
 namespace CLI
 {
 
-char* DSRomPath = new char[128];
-char* GBARomPath = new char[128];
-bool Verbosity = false;
+char* DSRomPath = new char[1024];
+char* GBARomPath = new char[1024];
+bool StartOnFullscreen = false;
 
 char* GetNextArg (int argc, char** argv, int argp)
 {
@@ -66,16 +66,20 @@ void ManageArgs (int argc, char** argv)
             {
                 //TODO: QT options
                 printf(
-                    "usage: melonDS [options] ... [dspath] [gbapath]\n"
-                    "Options:\n"
-                    "  -h / --help      display this help message and quit\n"
-                    "  -v / --verbose   toggle verbose mode\n"
-                    // "  -a / --archive   opens dspath as an archive containing the ROM\n"
-                    "Arguments:\n"
-                    "  dspath           path to a DS ROM you want to run\n"
-                    "  gbapath          path to a GBA ROM you want to load in the emulated Slot 2\n"
+                   "usage: melonDS [options] ... [dspath] [gbapath]\n"
+                   "Options:\n"
+                   "    -h / --help         display this help message and quit\n"
+                   "    -v / --verbose      toggle verbose mode\n"
+                   "    -f / --fullscreen   opens melonDS on fullscreen\n"
+                   "Arguments:\n"
+                   "    dspath              path to a DS ROM you want to run\n"
+                   "    gbapath             path to a GBA ROM you want to load in the emulated Slot 2\n"
                 );
                 exit(0);
+            }
+            else if (!strcasecmp(arg, "-f") || !strcasecmp(arg, "--fullscreen"))
+            {
+                StartOnFullscreen = true;
             }
             else
             {

--- a/src/frontend/qt_sdl/CLI.cpp
+++ b/src/frontend/qt_sdl/CLI.cpp
@@ -56,6 +56,7 @@ void ManageArgs (int argc, char** argv)
         {
             if (!strcasecmp(arg, "-h") || !strcasecmp(arg, "--help"))
             {
+                //TODO: QT arguments
                 printf(
                     "usage: melonDS [options] ... [dspath] [gbapath]\n"
                     "Options:\n"

--- a/src/frontend/qt_sdl/CLI.cpp
+++ b/src/frontend/qt_sdl/CLI.cpp
@@ -1,0 +1,58 @@
+/*
+    Copyright 2016-2021 patataofcourse
+
+    This file is part of melonDS.
+
+    melonDS is free software: you can redistribute it and/or modify it under
+    the terms of the GNU General Public License as published by the Free
+    Software Foundation, either version 3 of the License, or (at your option)
+    any later version.
+
+    melonDS is distributed in the hope that it will be useful, but WITHOUT ANY
+    WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+    FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with melonDS. If not, see http://www.gnu.org/licenses/.
+*/
+
+#include <stdio.h>
+#include <string.h>
+
+#include "../../dolphin/CommonFuncs.h"
+
+#include "CLI.h"
+
+namespace CLI
+{
+
+//TODO: don't make it a function, add it into the ManageArgs function
+bool IsFlag (int arg)
+{
+    switch (arg) {
+        case cliArg_GBARomPath:
+            return false;
+        case cliArg_UseFreeBios:
+            return true;
+        case cliArg_FirmwareLanguage:
+            return false;
+        case cliArg_Renderer:
+            return false;
+    }
+    return false;
+}
+
+void ManageArgs (int argc, char** argv)
+{
+    // easter egg - not worth checking other cases for something so dumb
+    if (strcasecmp(argv[0], "derpDS") || strcasecmp(argv[0], "./derpDS"))
+        printf("did you just call me a derp???\n");
+
+    for (int i = 1; i < argc; i++)
+    {
+        char* arg = argv[i];
+        printf("%s\n", arg);
+    }
+}
+
+}

--- a/src/frontend/qt_sdl/CLI.cpp
+++ b/src/frontend/qt_sdl/CLI.cpp
@@ -33,7 +33,7 @@ QStringList DSRomPath = {};
 QStringList GBARomPath = {};
 bool StartOnFullscreen = false;
 
-char* GetNextArg (int argc, char** argv, int argp)
+char* GetNextArg(int argc, char** argv, int argp)
 {
     // returns argv[argp] if it exists, nullptr if it doesn't
     if (argp >= argc)
@@ -42,7 +42,7 @@ char* GetNextArg (int argc, char** argv, int argp)
         return argv[argp];
 }
 
-void ManageArgs (int argc, char** argv)
+void ManageArgs(int argc, char** argv)
 {
 
     // don't think this will ever happen but i don't wanna risk a random segfault

--- a/src/frontend/qt_sdl/CLI.cpp
+++ b/src/frontend/qt_sdl/CLI.cpp
@@ -20,6 +20,8 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include <QStringList>
+
 #include "../FrontendUtil.h"
 
 #include "CLI.h"
@@ -27,8 +29,8 @@
 namespace CLI
 {
 
-char* DSRomPath = new char[1024];
-char* GBARomPath = new char[1024];
+QStringList DSRomPath = {};
+QStringList GBARomPath = {};
 bool StartOnFullscreen = false;
 
 char* GetNextArg (int argc, char** argv, int argp)
@@ -42,9 +44,6 @@ char* GetNextArg (int argc, char** argv, int argp)
 
 void ManageArgs (int argc, char** argv)
 {
-    //TODO: there has to be a better way to handle this, right?
-    DSRomPath = "";
-    GBARomPath = "";
 
     // don't think this will ever happen but i don't wanna risk a random segfault
     if (argc == 0)
@@ -92,12 +91,12 @@ void ManageArgs (int argc, char** argv)
             switch (posArgCount)
             {
                 case 0:
-                    {
-                        DSRomPath = arg;
-                        break;
-                    }
+                    DSRomPath = QString(arg).split("|");
+                    printf("DS ROM path: %s\n", arg);
+                    break;
                 case 1:
-                    GBARomPath = arg;
+                    GBARomPath = QString(arg).split("|");
+                    printf("GBA ROM path: %s\n", arg);
                     break;
                 default:
                     printf("Too many arguments, arg '%s' will be ignored\n", arg);

--- a/src/frontend/qt_sdl/CLI.cpp
+++ b/src/frontend/qt_sdl/CLI.cpp
@@ -37,10 +37,8 @@ char* GetNextArg (int argc, char** argv, int argp)
 
 bool ManageArgs (int argc, char** argv)
 {
-    // returns true if a ROM was successfully loaded
-
     // easter egg - not worth checking other cases for something so dumb
-    if (strcasecmp(argv[0], "derpDS") || strcasecmp(argv[0], "./derpDS"))
+    if (!strcasecmp(argv[0], "derpDS") || !strcasecmp(argv[0], "./derpDS"))
         //TODO: seems to always be doing this, research strcasecmp
         printf("did you just call me a derp???\n");
 

--- a/src/frontend/qt_sdl/CLI.cpp
+++ b/src/frontend/qt_sdl/CLI.cpp
@@ -17,6 +17,7 @@
 */
 
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 
 #include "../FrontendUtil.h"
@@ -25,6 +26,10 @@
 
 namespace CLI
 {
+
+char* DSRomPath = new char[128];
+
+char* GBARomPath = new char[128];
 
 char* GetNextArg (int argc, char** argv, int argp)
 {
@@ -35,15 +40,13 @@ char* GetNextArg (int argc, char** argv, int argp)
         return argv[argp];
 }
 
-bool ManageArgs (int argc, char** argv)
+void ManageArgs (int argc, char** argv)
 {
     // easter egg - not worth checking other cases for something so dumb
     if (!strcasecmp(argv[0], "derpDS") || !strcasecmp(argv[0], "./derpDS"))
-        //TODO: seems to always be doing this, research strcasecmp
         printf("did you just call me a derp???\n");
 
     int posArgCount = 0;
-    bool romLoaded = false;
     
     for (int i = 1; i < argc; i++)
     {
@@ -51,7 +54,23 @@ bool ManageArgs (int argc, char** argv)
         bool isFlag;
         if (arg[0] == '-')
         {
-            // manage options(?), so arguments like these: -h --help
+            if (!strcasecmp(arg, "-h") || !strcasecmp(arg, "--help"))
+            {
+                printf(
+                    "usage: melonDS [options] ... [dspath] [gbapath]\n"
+                    "Options:\n"
+                    "  -h / --help  display this help message and quit"
+                    "Arguments:\n"
+                    "  dspath       path to a DS ROM you want to run\n"
+                    "  gbapath      path to a GBA ROM you want to load in the emulated Slot 2\n"
+                );
+                exit(0);
+            }
+            else
+            {
+                printf("Unrecognized command line option %s - aborting.\n", arg);
+                exit(1);
+            }
         } 
         else
         {
@@ -59,14 +78,11 @@ bool ManageArgs (int argc, char** argv)
             {
                 case 0:
                     {
-                        int res = Frontend::LoadROM(arg, Frontend::ROMSlot_NDS);
-                        if (res == Frontend::Load_OK)
-                            romLoaded = true;
+                        DSRomPath = arg;
                         break;
                     }
                 case 1:
-                    //TODO: check if it's possible to load a GBA ROM without a DS ROM loaded
-                    Frontend::LoadROM(arg, Frontend::ROMSlot_GBA);
+                    GBARomPath = arg;
                     break;
                 default:
                     printf("Too many arguments, arg '%s' will be ignored\n", arg);
@@ -74,8 +90,6 @@ bool ManageArgs (int argc, char** argv)
             posArgCount++;
         }
     }
-
-    return romLoaded;
 }
 
 }

--- a/src/frontend/qt_sdl/CLI.h
+++ b/src/frontend/qt_sdl/CLI.h
@@ -15,10 +15,12 @@
 #ifndef CLI_H
 #define CLI_H
 
+#include <QStringList>
+
 namespace CLI {
 
-extern char* DSRomPath;
-extern char* GBARomPath;
+extern QStringList DSRomPath;
+extern QStringList GBARomPath;
 extern bool StartOnFullscreen;
 
 extern char* GetNextArg(int argc, char** argv, int argp);

--- a/src/frontend/qt_sdl/CLI.h
+++ b/src/frontend/qt_sdl/CLI.h
@@ -10,11 +10,12 @@ enum
     cliArg_UseFreeBios,
     cliArg_FirmwareLanguage,
     cliArg_Renderer,
+    cliArg_DSiMode,
 };
 
-extern bool IsArgFlag(int arg);
+extern char* GetNextArg(int argc, char** argv, int argp);
 
-extern void ManageArgs(int argc, char** argv);
+extern bool ManageArgs(int argc, char** argv);
 
 }
 

--- a/src/frontend/qt_sdl/CLI.h
+++ b/src/frontend/qt_sdl/CLI.h
@@ -5,6 +5,7 @@ namespace CLI {
 
 extern char* DSRomPath;
 extern char* GBARomPath;
+extern bool StartOnFullscreen;
 
 extern char* GetNextArg(int argc, char** argv, int argp);
 

--- a/src/frontend/qt_sdl/CLI.h
+++ b/src/frontend/qt_sdl/CLI.h
@@ -1,3 +1,18 @@
+
+/*
+    Copyright 2021 patataofcourse
+    This file is part of melonDS.
+    melonDS is free software: you can redistribute it and/or modify it under
+    the terms of the GNU General Public License as published by the Free
+    Software Foundation, either version 3 of the License, or (at your option)
+    any later version.
+    melonDS is distributed in the hope that it will be useful, but WITHOUT ANY
+    WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+    FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+    You should have received a copy of the GNU General Public License along
+    with melonDS. If not, see http://www.gnu.org/licenses/.
+*/
+
 #ifndef CLI_H
 #define CLI_H
 

--- a/src/frontend/qt_sdl/CLI.h
+++ b/src/frontend/qt_sdl/CLI.h
@@ -1,0 +1,21 @@
+#ifndef CLI_H
+#define CLI_H
+
+namespace CLI {
+
+enum
+{
+    cliArg_Help,
+    cliArg_GBARomPath,
+    cliArg_UseFreeBios,
+    cliArg_FirmwareLanguage,
+    cliArg_Renderer,
+};
+
+extern bool IsArgFlag(int arg);
+
+extern void ManageArgs(int argc, char** argv);
+
+}
+
+#endif

--- a/src/frontend/qt_sdl/CLI.h
+++ b/src/frontend/qt_sdl/CLI.h
@@ -3,19 +3,12 @@
 
 namespace CLI {
 
-enum
-{
-    cliArg_Help,
-    cliArg_GBARomPath,
-    cliArg_UseFreeBios,
-    cliArg_FirmwareLanguage,
-    cliArg_Renderer,
-    cliArg_DSiMode,
-};
+extern char* DSRomPath;
+extern char* GBARomPath;
 
 extern char* GetNextArg(int argc, char** argv, int argp);
 
-extern bool ManageArgs(int argc, char** argv);
+extern void ManageArgs(int argc, char** argv);
 
 }
 

--- a/src/frontend/qt_sdl/CLI.h
+++ b/src/frontend/qt_sdl/CLI.h
@@ -1,13 +1,17 @@
 /*
     Copyright 2021 patataofcourse
+
     This file is part of melonDS.
+
     melonDS is free software: you can redistribute it and/or modify it under
     the terms of the GNU General Public License as published by the Free
     Software Foundation, either version 3 of the License, or (at your option)
     any later version.
+
     melonDS is distributed in the hope that it will be useful, but WITHOUT ANY
     WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
     FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+    
     You should have received a copy of the GNU General Public License along
     with melonDS. If not, see http://www.gnu.org/licenses/.
 */

--- a/src/frontend/qt_sdl/CLI.h
+++ b/src/frontend/qt_sdl/CLI.h
@@ -1,4 +1,3 @@
-
 /*
     Copyright 2021 patataofcourse
     This file is part of melonDS.

--- a/src/frontend/qt_sdl/CMakeLists.txt
+++ b/src/frontend/qt_sdl/CMakeLists.txt
@@ -49,6 +49,9 @@ set(SOURCES_QT_SDL
     ../duckstation/gl/context.cpp
 
     ${CMAKE_SOURCE_DIR}/res/melon.qrc
+
+    CLI.h
+    CLI.cpp
 )
 
 if (APPLE)

--- a/src/frontend/qt_sdl/main.cpp
+++ b/src/frontend/qt_sdl/main.cpp
@@ -3354,17 +3354,14 @@ int main(int argc, char** argv)
 
     QObject::connect(&melon, &QApplication::applicationStateChanged, mainWindow, &MainWindow::onAppStateChanged);
 
-    if (CLI::DSRomPath != "")
-    {
-        int res = Frontend::LoadROM(CLI::DSRomPath, Frontend::ROMSlot_NDS);
+    if (!CLI::GBARomPath.isEmpty())
+        if (!ROMManager::LoadGBAROM(CLI::GBARomPath))
+            printf("Failed to load GBA ROM: %s\n", CLI::GBARomPath[0].toLatin1().cbegin());
 
-        // should this be moved to *after* the GBA ROM is loaded?
-        if (res == Frontend::Load_OK)
-            emuThread->emuRun();
-    }
 
-    if (CLI::GBARomPath != "")
-        Frontend::LoadROM(CLI::GBARomPath, Frontend::ROMSlot_GBA);
+    if (!CLI::DSRomPath.isEmpty())
+        if (!ROMManager::LoadROM(CLI::DSRomPath, true))
+            printf("Failed to load NDS ROM: %s\n", CLI::DSRomPath[0].toLatin1().cbegin());
 
     int ret = melon.exec();
 

--- a/src/frontend/qt_sdl/main.cpp
+++ b/src/frontend/qt_sdl/main.cpp
@@ -94,6 +94,8 @@
 #include "ArchiveUtil.h"
 #include "CameraManager.h"
 
+#include "CLI.h"
+
 // TODO: uniform variable spelling
 
 bool RunningSomething;
@@ -3229,9 +3231,9 @@ int main(int argc, char** argv)
     printf("melonDS " MELONDS_VERSION "\n");
     printf(MELONDS_URL "\n");
 
-    Platform::Init(argc, argv);
+    Platform::Init(argc, argv); //TODO: check what args do here
 
-    MelonApplication melon(argc, argv);
+    MelonApplication melon(argc, argv); //TODO: check what args do here
 
     // http://stackoverflow.com/questions/14543333/joystick-wont-work-using-sdl
     SDL_SetHint(SDL_HINT_JOYSTICK_ALLOW_BACKGROUND_EVENTS, "1");
@@ -3344,6 +3346,9 @@ int main(int argc, char** argv)
 
     QObject::connect(&melon, &QApplication::applicationStateChanged, mainWindow, &MainWindow::onAppStateChanged);
 
+    CLI::ManageArgs(argc, argv);
+
+    //TODO: remove once it's managed by ManageArgs
     if (argc > 1)
     {
         QString file = argv[1];

--- a/src/frontend/qt_sdl/main.cpp
+++ b/src/frontend/qt_sdl/main.cpp
@@ -3346,17 +3346,10 @@ int main(int argc, char** argv)
 
     QObject::connect(&melon, &QApplication::applicationStateChanged, mainWindow, &MainWindow::onAppStateChanged);
 
-    CLI::ManageArgs(argc, argv);
+    int res = CLI::ManageArgs(argc, argv);
 
-    //TODO: remove once it's managed by ManageArgs
-    if (argc > 1)
-    {
-        QString file = argv[1];
-        QString gbafile = "";
-        if (argc > 2) gbafile = argv[2];
-
-        mainWindow->preloadROMs(file, gbafile);
-    }
+    if (res)
+        emuThread->emuRun();
 
     int ret = melon.exec();
 

--- a/src/frontend/qt_sdl/main.cpp
+++ b/src/frontend/qt_sdl/main.cpp
@@ -3233,9 +3233,9 @@ int main(int argc, char** argv)
 
     CLI::ManageArgs(argc, argv);
 
-    Platform::Init(argc, argv); //TODO: check what args do here
+    Platform::Init(argc, argv);
 
-    MelonApplication melon(argc, argv); //TODO: check what args do here
+    MelonApplication melon(argc, argv);
 
     // http://stackoverflow.com/questions/14543333/joystick-wont-work-using-sdl
     SDL_SetHint(SDL_HINT_JOYSTICK_ALLOW_BACKGROUND_EVENTS, "1");

--- a/src/frontend/qt_sdl/main.cpp
+++ b/src/frontend/qt_sdl/main.cpp
@@ -3339,6 +3339,11 @@ int main(int argc, char** argv)
     Input::OpenJoystick();
 
     mainWindow = new MainWindow();
+    if (CLI::StartOnFullscreen) {
+        // onFullscreenToggled is private and I don't know if I should copy what's inside it or make it public
+        mainWindow->showFullScreen();
+        mainWindow->menuBar()->setFixedHeight(0); // Don't use hide() as menubar actions stop working
+    }
 
     emuThread = new EmuThread();
     emuThread->start();

--- a/src/frontend/qt_sdl/main.cpp
+++ b/src/frontend/qt_sdl/main.cpp
@@ -3231,6 +3231,8 @@ int main(int argc, char** argv)
     printf("melonDS " MELONDS_VERSION "\n");
     printf(MELONDS_URL "\n");
 
+    CLI::ManageArgs(argc, argv);
+
     Platform::Init(argc, argv); //TODO: check what args do here
 
     MelonApplication melon(argc, argv); //TODO: check what args do here
@@ -3346,10 +3348,16 @@ int main(int argc, char** argv)
 
     QObject::connect(&melon, &QApplication::applicationStateChanged, mainWindow, &MainWindow::onAppStateChanged);
 
-    int res = CLI::ManageArgs(argc, argv);
+    if (CLI::DSRomPath != "") {
+        int res = Frontend::LoadROM(CLI::DSRomPath, Frontend::ROMSlot_NDS);
 
-    if (res)
-        emuThread->emuRun();
+        // should this be moved to *after* the GBA ROM is loaded?
+        if (res == Frontend::Load_OK)
+            emuThread->emuRun();
+    }
+
+    if (CLI::GBARomPath != "")
+        Frontend::LoadROM(CLI::GBARomPath, Frontend::ROMSlot_GBA);
 
     int ret = melon.exec();
 

--- a/src/frontend/qt_sdl/main.cpp
+++ b/src/frontend/qt_sdl/main.cpp
@@ -3339,7 +3339,8 @@ int main(int argc, char** argv)
     Input::OpenJoystick();
 
     mainWindow = new MainWindow();
-    if (CLI::StartOnFullscreen) {
+    if (CLI::StartOnFullscreen)
+    {
         // onFullscreenToggled is private and I don't know if I should copy what's inside it or make it public
         mainWindow->showFullScreen();
         mainWindow->menuBar()->setFixedHeight(0); // Don't use hide() as menubar actions stop working
@@ -3353,7 +3354,8 @@ int main(int argc, char** argv)
 
     QObject::connect(&melon, &QApplication::applicationStateChanged, mainWindow, &MainWindow::onAppStateChanged);
 
-    if (CLI::DSRomPath != "") {
+    if (CLI::DSRomPath != "")
+    {
         int res = Frontend::LoadROM(CLI::DSRomPath, Frontend::ROMSlot_NDS);
 
         // should this be moved to *after* the GBA ROM is loaded?


### PR DESCRIPTION
This PR improves the command-line interface, something which has been asked for in issues such as #1108 and #1278

Planned changes:
- [x] Moving everything related to reading command-line arguments (except QT arguments and portable/win32's EmuDirectory) to a `CLI` namespace
- [x] Loading DS/GBA ROMs from command-line (new implementation for new CLI)
- [x] Options (arguments with a `-s` / `--something` format)
    - [x] Help menu (`-h` / `--help`)
    - [ ] Open ROM from archive
    - [ ] Boot firmware (incompatible with loading a ROM, but should it boot the ROM instead or not do anything / return an error?)
    - [ ] Verbosity toggle*
    - [x] Start in fullscreen (`-f` / `--fullscreen`)
- [ ] Config overrides as options
    - [ ] Namespace for overridable config options
    - [ ] Figuring out how config being overridden should affect editing the actual config
    - [ ] Firmware settings: language and MAC address
    - [ ] Toggling usage of FreeBIOS or an external BIOS

This isn't a full list of features the CLI should have by any means, and I'm willing to implement whatever the core team considers necessary, plus some popular community suggestions. (Of course, all this is limited by my skill, and I might leave a stub if there's any option I can't implement.)

*Regarding the verbosity toggle, I'm not very sure what messages should always be displayed and which should be hiding behind that toggle, or even if melonDS would benefit from having multiple levels of verbosity, if having a verbosity toggle isn't worth it, etc... I'd appreciate input about this.

Feel free to submit reviews, everything that isn't implemented yet but is planned to be has a TODO comment.