### PR TITLE
Make archive detection more robust and add it to the CLI

### DIFF
--- a/src/frontend/qt_sdl/main.cpp
+++ b/src/frontend/qt_sdl/main.cpp
@@ -88,9 +88,9 @@
 
 // TODO: uniform variable spelling
 
-const QStringList ndsRomExtensions{".nds", ".srl", ".dsi"};
-const QStringList gbaRomExtensions{".gba"};
-const QStringList archiveExtensions{".zip", ".7z", ".rar", ".tar", ".tar.gz", ".tar.xz", ".tar.bz2", ".tar.zst"};
+const QStringList NdsRomExtensions{".nds", ".srl", ".dsi"};
+const QStringList GbaRomExtensions{".gba"};
+const QStringList ArchiveExtensions{".zip", ".7z", ".rar", ".tar", ".tar.gz", ".tar.xz", ".tar.bz2", ".tar.zst"};
 
 bool RunningSomething;
 
@@ -1273,7 +1273,7 @@ void ScreenPanelGL::onScreenLayoutChanged()
     setupScreenLayout();
 }
 
-static bool fileExtensionInList(const QString& filename, const QStringList& extensions)
+static bool FileExtensionInList(const QString& filename, const QStringList& extensions)
 {
     return std::any_of(extensions.cbegin(), extensions.cend(), [&](const auto& ext) {
         return filename.endsWith(ext, Qt::CaseInsensitive);
@@ -1839,8 +1839,8 @@ void MainWindow::dragEnterEvent(QDragEnterEvent* event)
 
     QString filename = urls.at(0).toLocalFile();
 
-    static const QStringList acceptedExts = ndsRomExtensions + gbaRomExtensions + archiveExtensions;
-    if (fileExtensionInList(filename, acceptedExts))
+    static const QStringList acceptedExts = NdsRomExtensions + GbaRomExtensions + ArchiveExtensions;
+    if (FileExtensionInList(filename, acceptedExts))
         event->acceptProposedAction();
 }
 
@@ -1868,7 +1868,7 @@ void MainWindow::dropEvent(QDropEvent* event)
         return;
     }
 
-    if (fileExtensionInList(filename, gbaRomExtensions))
+    if (FileExtensionInList(filename, GbaRomExtensions))
     {
         if (!ROMManager::LoadGBAROM(file))
         {
@@ -2057,7 +2057,7 @@ QStringList MainWindow::splitArchivePath(const QString& filename, bool memberSyn
         return {};
     }
 
-    if (fileExtensionInList(filename, archiveExtensions))
+    if (FileExtensionInList(filename, ArchiveExtensions))
     {
         const QString subfile = pickFileFromArchive(filename);
         if (subfile.isEmpty())
@@ -2072,8 +2072,8 @@ QStringList MainWindow::splitArchivePath(const QString& filename, bool memberSyn
 QStringList MainWindow::pickROM(bool gba)
 {
     const QString console = gba ? "GBA" : "DS";
-    const QStringList& romexts = gba ? gbaRomExtensions : ndsRomExtensions;
-    static const QString filterSuffix = " *" + archiveExtensions.join(" *") + ");;Any file (*.*)";
+    const QStringList& romexts = gba ? GbaRomExtensions : NdsRomExtensions;
+    static const QString filterSuffix = " *" + ArchiveExtensions.join(" *") + ");;Any file (*.*)";
 
     const QString filter = console + " ROMs (*" + romexts.join(" *") + filterSuffix;
     const QString filename = QFileDialog::getOpenFileName(

--- a/src/frontend/qt_sdl/main.cpp
+++ b/src/frontend/qt_sdl/main.cpp
@@ -1830,7 +1830,7 @@ void MainWindow::dragEnterEvent(QDragEnterEvent* event)
     QString filename = urls.at(0).toLocalFile();
 
     QStringList acceptedExts{".nds", ".srl", ".dsi", ".gba", ".rar",
-                             ".zip", ".7z", ".tar", ".tar.gz", ".tar.xz", ".tar.bz2"};
+                             ".zip", ".7z", ".tar", ".tar.gz", ".tar.xz", ".tar.bz2", ".tar.zst"};
 
     for (const QString &ext : acceptedExts)
     {
@@ -1847,7 +1847,7 @@ void MainWindow::dropEvent(QDropEvent* event)
     if (urls.count() > 1) return; // not handling more than one file at once
 
     QString filename = urls.at(0).toLocalFile();
-    QStringList arcexts{".zip", ".7z", ".rar", ".tar", ".tar.gz", ".tar.xz", ".tar.bz2"};
+    QStringList arcexts{".zip", ".7z", ".rar", ".tar", ".tar.gz", ".tar.xz", ".tar.bz2", ".tar.zst"};
 
     emuThread->emuPause();
 
@@ -2019,7 +2019,7 @@ QStringList MainWindow::pickROM(bool gba)
 {
     QString console;
     QStringList romexts;
-    QStringList arcexts{"*.zip", "*.7z", "*.rar", "*.tar", "*.tar.gz", "*.tar.xz", "*.tar.bz2"};
+    QStringList arcexts{"*.zip", "*.7z", "*.rar", "*.tar", "*.tar.gz", "*.tar.xz", "*.tar.bz2", "*.tar.zst"};
     QStringList ret;
 
     if (gba)

--- a/src/frontend/qt_sdl/main.cpp
+++ b/src/frontend/qt_sdl/main.cpp
@@ -90,7 +90,14 @@
 
 const QStringList NdsRomExtensions{".nds", ".srl", ".dsi"};
 const QStringList GbaRomExtensions{".gba"};
-const QStringList ArchiveExtensions{".zip", ".7z", ".rar", ".tar", ".tar.gz", ".tar.xz", ".tar.bz2", ".tar.zst"};
+const QStringList ArchiveExtensions{
+    ".zip", ".7z", ".rar", ".tar",
+    ".tar.gz",  ".tgz",
+    ".tar.xz",  ".txz",
+    ".tar.bz2", ".tbz2",
+    ".tar.lz4", ".tlz4",
+    ".tar.zst", ".tzst",
+};
 
 bool RunningSomething;
 

--- a/src/frontend/qt_sdl/main.h
+++ b/src/frontend/qt_sdl/main.h
@@ -306,6 +306,7 @@ private:
 
     bool verifySetup();
     QString pickFileFromArchive(QString archiveFileName);
+    QStringList splitArchivePath(const QString& filename, bool memberSyntax);
     QStringList pickROM(bool gba);
     void updateCartInserted(bool gba);
 


### PR DESCRIPTION
This PR

- consolidates the list of supported file extensions into three constants (`NdsRomExtensions`, `GbaRomExtensions` and `ArchiveExtensions`),
- enables archive detection for the command line parameters, fixing #1393,
- filters archive members by file extension, just like the default file picker,
- makes the handling of command line paths more robust by adding safety checks to `MainWindow::preloadROMs`,
- thereby fixing some crashes and hangs when calling `melonDS` with invalid parameters, and
- adds `.tar.zst`, `.tar.lz4` and short forms (`.tgz`, `.txz`, `.tzst`, ...) to the list of supported archive file extensions, fixing #1063.

If I have missed something or if `MainWindow::preloadROMs` isn’t the right place to do what I’m trying to do, please let me know.