### PR TITLE
Add ability to change FPS Rate and move Framerate settings

### DIFF
--- a/src/frontend/qt_sdl/CMakeLists.txt
+++ b/src/frontend/qt_sdl/CMakeLists.txt
@@ -20,6 +20,7 @@ set(SOURCES_QT_SDL
     VideoSettingsDialog.cpp
     CameraSettingsDialog.cpp
     AudioSettingsDialog.cpp
+    FramerateSettingsDialog.cpp
     FirmwareSettingsDialog.cpp
     PathSettingsDialog.cpp
     MPSettingsDialog.cpp

--- a/src/frontend/qt_sdl/Config.cpp
+++ b/src/frontend/qt_sdl/Config.cpp
@@ -61,6 +61,7 @@ int GL_ScaleFactor;
 bool GL_BetterPolygons;
 
 bool LimitFPS;
+int FPSRate;
 bool AudioSync;
 bool ShowOSD;
 
@@ -251,6 +252,7 @@ ConfigEntry ConfigFile[] =
     {"GL_BetterPolygons", 1, &GL_BetterPolygons, false, false},
 
     {"LimitFPS", 1, &LimitFPS, true, false},
+    {"FPSRate", 0, &FPSRate, 60},
     {"AudioSync", 1, &AudioSync, false},
     {"ShowOSD", 1, &ShowOSD, true, false},
 

--- a/src/frontend/qt_sdl/Config.h
+++ b/src/frontend/qt_sdl/Config.h
@@ -105,6 +105,7 @@ extern int GL_ScaleFactor;
 extern bool GL_BetterPolygons;
 
 extern bool LimitFPS;
+extern int FPSRate;
 extern bool AudioSync;
 extern bool ShowOSD;
 

--- a/src/frontend/qt_sdl/EmuThread.cpp
+++ b/src/frontend/qt_sdl/EmuThread.cpp
@@ -86,7 +86,6 @@ EmuThread::EmuThread(QObject* parent) : QThread(parent)
     connect(this, SIGNAL(windowEmuPause()), mainWindow->actPause, SLOT(trigger()));
     connect(this, SIGNAL(windowEmuReset()), mainWindow->actReset, SLOT(trigger()));
     connect(this, SIGNAL(windowEmuFrameStep()), mainWindow->actFrameStep, SLOT(trigger()));
-    connect(this, SIGNAL(windowLimitFPSChange()), mainWindow->actLimitFramerate, SLOT(trigger()));
     connect(this, SIGNAL(screenLayoutChange()), mainWindow->panel, SLOT(onScreenLayoutChanged()));
     connect(this, SIGNAL(windowFullscreenToggle()), mainWindow, SLOT(onFullscreenToggled()));
     connect(this, SIGNAL(swapScreensToggle()), mainWindow->actScreenSwap, SLOT(trigger()));

--- a/src/frontend/qt_sdl/EmuThread.cpp
+++ b/src/frontend/qt_sdl/EmuThread.cpp
@@ -363,7 +363,7 @@ void EmuThread::run()
     {
         Input::Process();
 
-        if (Input::HotkeyPressed(HK_FastForwardToggle)) emit windowLimitFPSChange();
+        if (Input::HotkeyPressed(HK_FastForwardToggle)) Config::LimitFPS = !Config::LimitFPS;
 
         if (Input::HotkeyPressed(HK_Pause)) emit windowEmuPause();
         if (Input::HotkeyPressed(HK_Reset)) emit windowEmuReset();

--- a/src/frontend/qt_sdl/EmuThread.cpp
+++ b/src/frontend/qt_sdl/EmuThread.cpp
@@ -572,7 +572,11 @@ void EmuThread::run()
             if (Config::AudioSync && !fastforward)
                 AudioInOut::AudioSync(*this->NDS);
 
-            double frametimeStep = nlines / (60.0 * 263.0);
+            double fpsrate = (double)Config::FPSRate;
+            if (fpsrate < 1)
+                fpsrate = 60.0;
+
+            double frametimeStep = nlines / (fpsrate * 263.0);
 
             {
                 bool limitfps = Config::LimitFPS && !fastforward;

--- a/src/frontend/qt_sdl/EmuThread.h
+++ b/src/frontend/qt_sdl/EmuThread.h
@@ -82,8 +82,6 @@ signals:
     void windowEmuReset();
     void windowEmuFrameStep();
 
-    void windowLimitFPSChange();
-
     void screenLayoutChange();
 
     void windowFullscreenToggle();

--- a/src/frontend/qt_sdl/FramerateSettingsDialog.cpp
+++ b/src/frontend/qt_sdl/FramerateSettingsDialog.cpp
@@ -1,0 +1,85 @@
+/*
+    Copyright 2016-2022 melonDS team
+
+    This file is part of melonDS.
+
+    melonDS is free software: you can redistribute it and/or modify it under
+    the terms of the GNU General Public License as published by the Free
+    Software Foundation, either version 3 of the License, or (at your option)
+    any later version.
+
+    melonDS is distributed in the hope that it will be useful, but WITHOUT ANY
+    WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+    FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with melonDS. If not, see http://www.gnu.org/licenses/.
+*/
+
+#include <stdio.h>
+
+#include "types.h"
+#include "Platform.h"
+#include "Config.h"
+
+#include "FramerateSettingsDialog.h"
+#include "ui_FramerateSettingsDialog.h"
+
+
+FramerateSettingsDialog* FramerateSettingsDialog::currentDlg = nullptr;
+
+
+FramerateSettingsDialog::FramerateSettingsDialog(QWidget* parent) : QDialog(parent), ui(new Ui::FramerateSettingsDialog)
+{
+    ui->setupUi(this);
+    setAttribute(Qt::WA_DeleteOnClose);
+
+    ui->spinFPSRate->setRange(0, 9999);
+
+    ui->cbLimitFPS->setChecked(Config::LimitFPS);
+    ui->spinFPSRate->setValue(Config::FPSRate);
+
+    if (Config::LimitFPS)
+    {
+        ui->spinFPSRate->setEnabled(true);
+    }
+    else
+    {
+        ui->spinFPSRate->setEnabled(false);
+    }
+}
+
+FramerateSettingsDialog::~FramerateSettingsDialog()
+{
+    delete ui;
+}
+
+void FramerateSettingsDialog::on_cbLimitFPS_clicked()
+{
+    if (ui->spinFPSRate->isEnabled())
+    {
+        ui->spinFPSRate->setEnabled(false);
+    }
+    else
+    {
+        ui->spinFPSRate->setEnabled(true);
+    }
+
+    Config::LimitFPS = ui->cbLimitFPS->isChecked() ? 1:0;
+    Config::FPSRate = ui->spinFPSRate->value();
+}
+
+void FramerateSettingsDialog::on_spinFPSRate_valueChanged(int arg)
+{
+    Config::FPSRate = ui->spinFPSRate->value();
+}
+
+void FramerateSettingsDialog::on_FramerateSettingsDialog_accepted()
+{
+    closeDlg();
+}
+
+void FramerateSettingsDialog::on_FramerateSettingsDialog_rejected()
+{
+    closeDlg();
+}

--- a/src/frontend/qt_sdl/FramerateSettingsDialog.cpp
+++ b/src/frontend/qt_sdl/FramerateSettingsDialog.cpp
@@ -36,17 +36,27 @@ FramerateSettingsDialog::FramerateSettingsDialog(QWidget* parent) : QDialog(pare
 
     ui->spinFPSRate->setRange(0, 9999);
 
-    ui->cbLimitFPS->setChecked(Config::LimitFPS);
-    ui->spinFPSRate->setValue(Config::FPSRate);
 
     if (Config::LimitFPS)
     {
         ui->spinFPSRate->setEnabled(true);
+        Config::AudioSync = 0;
     }
     else
     {
         ui->spinFPSRate->setEnabled(false);
     }
+
+    if (Config::AudioSync)
+    {
+        Config::LimitFPS = 0;
+        ui->spinFPSRate->setEnabled(false);
+    }
+
+    ui->cbLimitFPS->setChecked(Config::LimitFPS);
+    ui->spinFPSRate->setValue(Config::FPSRate);
+    ui->cbAudioSync->setChecked(Config::AudioSync);
+
 }
 
 FramerateSettingsDialog::~FramerateSettingsDialog()
@@ -56,17 +66,35 @@ FramerateSettingsDialog::~FramerateSettingsDialog()
 
 void FramerateSettingsDialog::on_cbLimitFPS_clicked()
 {
-    if (ui->spinFPSRate->isEnabled())
+    if (ui->cbLimitFPS->isChecked())
     {
-        ui->spinFPSRate->setEnabled(false);
+        Config::LimitFPS = 1;
+        ui->spinFPSRate->setEnabled(true);
+        Config::AudioSync = 0;
+        ui->cbAudioSync->setChecked(Config::AudioSync);
     }
     else
     {
-        ui->spinFPSRate->setEnabled(true);
+        Config::LimitFPS = 0;
+        ui->spinFPSRate->setEnabled(false);
     }
 
-    Config::LimitFPS = ui->cbLimitFPS->isChecked() ? 1:0;
     Config::FPSRate = ui->spinFPSRate->value();
+}
+
+void FramerateSettingsDialog::on_cbAudioSync_clicked()
+{
+    if (ui->cbAudioSync->isChecked())
+    {
+        Config::LimitFPS = 0;
+        ui->cbLimitFPS->setChecked(Config::LimitFPS);
+        ui->spinFPSRate->setEnabled(false);
+        Config::AudioSync = 1;
+    }
+    else
+    {
+        Config::AudioSync = 0;
+    }
 }
 
 void FramerateSettingsDialog::on_spinFPSRate_valueChanged(int arg)

--- a/src/frontend/qt_sdl/FramerateSettingsDialog.h
+++ b/src/frontend/qt_sdl/FramerateSettingsDialog.h
@@ -1,0 +1,63 @@
+/*
+    Copyright 2016-2022 melonDS team
+
+    This file is part of melonDS.
+
+    melonDS is free software: you can redistribute it and/or modify it under
+    the terms of the GNU General Public License as published by the Free
+    Software Foundation, either version 3 of the License, or (at your option)
+    any later version.
+
+    melonDS is distributed in the hope that it will be useful, but WITHOUT ANY
+    WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+    FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with melonDS. If not, see http://www.gnu.org/licenses/.
+*/
+
+#ifndef FRAMERATESETTINGSDIALOG_H
+#define FRAMERATESETTINGSDIALOG_H
+
+#include <QDialog>
+
+namespace Ui { class FramerateSettingsDialog; }
+class FramerateSettingsDialog;
+
+class FramerateSettingsDialog : public QDialog
+{
+    Q_OBJECT
+
+public:
+    explicit FramerateSettingsDialog(QWidget* parent);
+    ~FramerateSettingsDialog();
+
+    static FramerateSettingsDialog* currentDlg;
+    static FramerateSettingsDialog* openDlg(QWidget* parent)
+    {
+        if (currentDlg)
+        {
+            currentDlg->activateWindow();
+            return currentDlg;
+        }
+
+        currentDlg = new FramerateSettingsDialog(parent);
+        currentDlg->show();
+        return currentDlg;
+    }
+    static void closeDlg()
+    {
+        currentDlg = nullptr;
+    }
+
+private slots:
+    void on_cbLimitFPS_clicked();
+    void on_spinFPSRate_valueChanged(int arg);
+    void on_FramerateSettingsDialog_accepted();
+    void on_FramerateSettingsDialog_rejected();
+
+private:
+    Ui::FramerateSettingsDialog* ui;
+};
+
+#endif // FRAMERATESETTINGSDIALOG_H

--- a/src/frontend/qt_sdl/FramerateSettingsDialog.h
+++ b/src/frontend/qt_sdl/FramerateSettingsDialog.h
@@ -52,6 +52,7 @@ public:
 
 private slots:
     void on_cbLimitFPS_clicked();
+    void on_cbAudioSync_clicked();
     void on_spinFPSRate_valueChanged(int arg);
     void on_FramerateSettingsDialog_accepted();
     void on_FramerateSettingsDialog_rejected();

--- a/src/frontend/qt_sdl/FramerateSettingsDialog.ui
+++ b/src/frontend/qt_sdl/FramerateSettingsDialog.ui
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>FramerateSettingsDialog</class>
+ <widget class="QDialog" name="FramerateSettingsDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>572</width>
+    <height>273</height>
+   </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="windowTitle">
+   <string>Framerate settings - melonDS</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <property name="sizeConstraint">
+    <enum>QLayout::SetFixedSize</enum>
+   </property>
+   <item>
+    <widget class="QGroupBox" name="groupBox">
+     <property name="title">
+      <string>Framerate</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout">
+      <item row="0" column="0">
+       <widget class="QCheckBox" name="cbLimitFPS">
+        <property name="whatsThis">
+         <string>Enabling this limits the framerate</string>
+        </property>
+        <property name="text">
+         <string>Limit framerate</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0" alignment="Qt::AlignLeft">
+       <widget class="QSpinBox" name="spinFPSRate">
+       </widget>
+      </item>
+      <item row="1" column="1" alignment="Qt::AlignRight">
+       <widget class="QLabel" name="label">
+        <property name="text">
+         <string> frames per second</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>FramerateSettingsDialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>248</x>
+     <y>254</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>FramerateSettingsDialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>316</x>
+     <y>260</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/src/frontend/qt_sdl/FramerateSettingsDialog.ui
+++ b/src/frontend/qt_sdl/FramerateSettingsDialog.ui
@@ -50,6 +50,16 @@
         </property>
        </widget>
       </item>
+      <item row="3" column="0">
+       <widget class="QCheckBox" name="cbAudioSync">
+        <property name="whatsThis">
+         <string>Enabling this syncs the framerate to the audio</string>
+        </property>
+        <property name="text">
+         <string>Audio sync</string>
+        </property>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>

--- a/src/frontend/qt_sdl/Window.cpp
+++ b/src/frontend/qt_sdl/Window.cpp
@@ -569,10 +569,6 @@ MainWindow::MainWindow(QWidget* parent) : QMainWindow(parent)
         connect(actShowOSD, &QAction::triggered, this, &MainWindow::onChangeShowOSD);
 
         menu->addSeparator();
-
-        actAudioSync = menu->addAction("Audio sync");
-        actAudioSync->setCheckable(true);
-        connect(actAudioSync, &QAction::triggered, this, &MainWindow::onChangeAudioSync);
     }
     setMenuBar(menubar);
 
@@ -658,8 +654,6 @@ MainWindow::MainWindow(QWidget* parent) : QMainWindow(parent)
 
     actScreenFiltering->setChecked(Config::ScreenFilter);
     actShowOSD->setChecked(Config::ShowOSD);
-
-    actAudioSync->setChecked(Config::AudioSync);
 
     if (inst > 0)
     {
@@ -1961,11 +1955,6 @@ void MainWindow::onChangeShowOSD(bool checked)
 {
     Config::ShowOSD = checked?1:0;
     panel->osdSetEnabled(Config::ShowOSD);
-}
-
-void MainWindow::onChangeAudioSync(bool checked)
-{
-    Config::AudioSync = checked?1:0;
 }
 
 

--- a/src/frontend/qt_sdl/Window.cpp
+++ b/src/frontend/qt_sdl/Window.cpp
@@ -570,10 +570,6 @@ MainWindow::MainWindow(QWidget* parent) : QMainWindow(parent)
 
         menu->addSeparator();
 
-        actLimitFramerate = menu->addAction("Limit framerate");
-        actLimitFramerate->setCheckable(true);
-        connect(actLimitFramerate, &QAction::triggered, this, &MainWindow::onChangeLimitFramerate);
-
         actAudioSync = menu->addAction("Audio sync");
         actAudioSync->setCheckable(true);
         connect(actAudioSync, &QAction::triggered, this, &MainWindow::onChangeAudioSync);
@@ -663,7 +659,6 @@ MainWindow::MainWindow(QWidget* parent) : QMainWindow(parent)
     actScreenFiltering->setChecked(Config::ScreenFilter);
     actShowOSD->setChecked(Config::ShowOSD);
 
-    actLimitFramerate->setChecked(Config::LimitFPS);
     actAudioSync->setChecked(Config::AudioSync);
 
     if (inst > 0)
@@ -1966,11 +1961,6 @@ void MainWindow::onChangeShowOSD(bool checked)
 {
     Config::ShowOSD = checked?1:0;
     panel->osdSetEnabled(Config::ShowOSD);
-}
-
-void MainWindow::onChangeLimitFramerate(bool checked)
-{
-    Config::LimitFPS = checked?1:0;
 }
 
 void MainWindow::onChangeAudioSync(bool checked)

--- a/src/frontend/qt_sdl/Window.cpp
+++ b/src/frontend/qt_sdl/Window.cpp
@@ -59,6 +59,7 @@
 #include "VideoSettingsDialog.h"
 #include "CameraSettingsDialog.h"
 #include "AudioSettingsDialog.h"
+#include "FramerateSettingsDialog.h"
 #include "FirmwareSettingsDialog.h"
 #include "PathSettingsDialog.h"
 #include "MPSettingsDialog.h"
@@ -410,6 +411,9 @@ MainWindow::MainWindow(QWidget* parent) : QMainWindow(parent)
 
         actAudioSettings = menu->addAction("Audio settings");
         connect(actAudioSettings, &QAction::triggered, this, &MainWindow::onOpenAudioSettings);
+
+        actFramerateSettings = menu->addAction("Framerate settings");
+        connect(actFramerateSettings, &QAction::triggered, this, &MainWindow::onOpenFramerateSettings);
 
         actMPSettings = menu->addAction("Multiplayer settings");
         connect(actMPSettings, &QAction::triggered, this, &MainWindow::onOpenMPSettings);
@@ -1752,6 +1756,11 @@ void MainWindow::onOpenAudioSettings()
     connect(emuThread, &EmuThread::windowEmuStart, dlg, &AudioSettingsDialog::onConsoleReset);
     connect(dlg, &AudioSettingsDialog::updateAudioSettings, this, &MainWindow::onUpdateAudioSettings);
     connect(dlg, &AudioSettingsDialog::finished, this, &MainWindow::onAudioSettingsFinished);
+}
+
+void MainWindow::onOpenFramerateSettings()
+{
+    FramerateSettingsDialog* dlg = FramerateSettingsDialog::openDlg(this);
 }
 
 void MainWindow::onOpenFirmwareSettings()

--- a/src/frontend/qt_sdl/Window.h
+++ b/src/frontend/qt_sdl/Window.h
@@ -172,6 +172,7 @@ private slots:
     void onOpenAudioSettings();
     void onUpdateAudioSettings();
     void onAudioSettingsFinished(int res);
+    void onOpenFramerateSettings();
     void onOpenMPSettings();
     void onMPSettingsFinished(int res);
     void onOpenWifiSettings();
@@ -267,6 +268,7 @@ public:
     QAction* actVideoSettings;
     QAction* actCameraSettings;
     QAction* actAudioSettings;
+    QAction* actFramerateSettings;
     QAction* actMPSettings;
     QAction* actWifiSettings;
     QAction* actFirmwareSettings;

--- a/src/frontend/qt_sdl/Window.h
+++ b/src/frontend/qt_sdl/Window.h
@@ -195,7 +195,6 @@ private slots:
     void onChangeIntegerScaling(bool checked);
     void onChangeScreenFiltering(bool checked);
     void onChangeShowOSD(bool checked);
-    void onChangeLimitFramerate(bool checked);
     void onChangeAudioSync(bool checked);
 
     void onTitleUpdate(QString title);
@@ -292,7 +291,6 @@ public:
     QAction** actScreenAspectBot;
     QAction* actScreenFiltering;
     QAction* actShowOSD;
-    QAction* actLimitFramerate;
     QAction* actAudioSync;
 };
 

--- a/src/frontend/qt_sdl/Window.h
+++ b/src/frontend/qt_sdl/Window.h
@@ -195,7 +195,6 @@ private slots:
     void onChangeIntegerScaling(bool checked);
     void onChangeScreenFiltering(bool checked);
     void onChangeShowOSD(bool checked);
-    void onChangeAudioSync(bool checked);
 
     void onTitleUpdate(QString title);
 
@@ -291,7 +290,6 @@ public:
     QAction** actScreenAspectBot;
     QAction* actScreenFiltering;
     QAction* actShowOSD;
-    QAction* actAudioSync;
 };
 
 void ToggleFullscreen(MainWindow* mainWindow);

--- a/src/frontend/qt_sdl/main.cpp
+++ b/src/frontend/qt_sdl/main.cpp
@@ -64,6 +64,7 @@
 #include "VideoSettingsDialog.h"
 #include "CameraSettingsDialog.h"
 #include "AudioSettingsDialog.h"
+#include "FramerateSettingsDialog.h"
 #include "FirmwareSettingsDialog.h"
 #include "PathSettingsDialog.h"
 #include "MPSettingsDialog.h"


### PR DESCRIPTION
Closes #947
Closes #1553
Supersedes and closes #1247 

This PR adds the capability of changing the LimitFPS value via the GUI interface.
I built off of @klathem's logic and added the GUI portion that @RSDuck requested.

I also moved the checkbox for LimitFPS from the Menu into the DialogBox so that all framerate settings can be set in one DialogBox. WIth @nadiaholmquist's suggestions moved AudioSync to the new DialogBox as well.

Please feel free to check it out!

To see some pics:

![menu-dialog](https://user-images.githubusercontent.com/17132214/164279510-d5c909de-9c38-4324-bf4a-588f26deadbb.png)


Notice that the Limit Framerate and Audio Sync checkbox is removed in the main Config Menu and the Framerate settings option is added.
When clicking the framerate settings options the following dialog box appears. When Limit Framerate checkbox is disabled then the spinbox is disabled as well. Either Audio Sync or Limit Framerate can be checked at once, not both.


![framerate-dialog](https://user-images.githubusercontent.com/17132214/164278136-dc2cd26d-b913-421e-b1cc-0257ae65c543.png)


