### PR TITLE
Fix nocash Char Out debug register

### DIFF
--- a/src/NDS.cpp
+++ b/src/NDS.cpp
@@ -3664,7 +3664,7 @@ void ARM9IOWrite32(u32 addr, u32 val)
         }
 
     // NO$GBA debug register "Char Out"
-    case 0x04FFFA1C: printf("%" PRIu32, val); return;
+    case 0x04FFFA1C: printf("%c", val & 0xFF); return;
     }
 
     if (addr >= 0x04000000 && addr < 0x04000060)


### PR DESCRIPTION
To match no$gba, this register should output any ASCII character written to it, not print the number as it currently does.