### PR TITLE
fatfs: Fix -Wstrict-prototypes + -Wimplicit-function-declaration warnings

### DIFF
--- a/src/fatfs/diskio.c
+++ b/src/fatfs/diskio.c
@@ -30,7 +30,7 @@ void ff_disk_open(ff_disk_read_cb readcb, ff_disk_write_cb writecb, LBA_t seccnt
     else          Status &= ~STA_PROTECT;
 }
 
-void ff_disk_close()
+void ff_disk_close(void)
 {
     ReadCb = (void*)0;
     WriteCb = (void*)0;

--- a/src/fatfs/ff.h
+++ b/src/fatfs/ff.h
@@ -421,7 +421,7 @@ typedef UINT (*ff_disk_read_cb)(BYTE* buff, LBA_t sector, UINT count);
 typedef UINT (*ff_disk_write_cb)(BYTE* buff, LBA_t sector, UINT count);
 
 void ff_disk_open(ff_disk_read_cb readcb, ff_disk_write_cb writecb, LBA_t seccnt);
-void ff_disk_close();
+void ff_disk_close(void);
 
 
 #ifdef __cplusplus

--- a/src/fatfs/ffsystem.c
+++ b/src/fatfs/ffsystem.c
@@ -3,6 +3,7 @@
 /* (C)ChaN, 2018                                                          */
 /*------------------------------------------------------------------------*/
 
+#define _POSIX_SOURCE
 #define _POSIX_THREAD_SAFE_FUNCTIONS
 #include <time.h>
 
@@ -103,7 +104,7 @@ void ff_rel_grant (
 #endif
 
 
-DWORD get_fattime()
+DWORD get_fattime(void)
 {
     // TODO: return melonDS time instead of RTC??
 


### PR DESCRIPTION
This will be required for upcoming gcc and clang versions.

Reference: https://archives.gentoo.org/gentoo-dev/message/dd9f2d3082b8b6f8dfbccb0639e6e240