### PR TITLE
Wifi: Fix -Wformat

### DIFF
--- a/src/Wifi.cpp
+++ b/src/Wifi.cpp
@@ -872,7 +872,7 @@ bool ProcessTX(TXSlot* slot, int num)
             }
 
             if ((num != 5) && (RAM[slot->Addr+4] > 0))
-                printf("SLOT %d RETRY COUNTER %d\n", RAM[slot->Addr+4]);
+                printf("SLOT %d RETRY COUNTER %d\n", num, RAM[slot->Addr+4]);
 
             // set TX addr
             IOPORT(W_RXTXAddr) = slot->Addr >> 1;


### PR DESCRIPTION
This PR fixes -Wformat warnings.

The first change adds what I believe is the correct variable to the printf statement -- there is one less argument than there should be.

The other changes may be architecture dependent. I am on a musl-based Linux amd64 distro.