### PR TITLE
CLI 2.0: Electric Boogaloo

### DIFF
--- a/src/frontend/qt_sdl/CLI.cpp
+++ b/src/frontend/qt_sdl/CLI.cpp
@@ -1,0 +1,91 @@
+/*
+    Copyright 2021-2022 melonDS team
+
+    This file is part of melonDS.
+
+    melonDS is free software: you can redistribute it and/or modify it under
+    the terms of the GNU General Public License as published by the Free
+    Software Foundation, either version 3 of the License, or (at your option)
+    any later version.
+
+    melonDS is distributed in the hope that it will be useful, but WITHOUT ANY
+    WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+    FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with melonDS. If not, see http://www.gnu.org/licenses/.
+*/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <QStringList>
+#include <QCommandLineParser>
+
+#include "CLI.h"
+
+namespace CLI
+{
+
+QStringList DSRomPath = {};
+QStringList GBARomPath = {};
+bool StartOnFullscreen = false;
+
+void ManageArgs(int argc, char** argv)
+{
+
+    int posArgCount = 0;
+    
+    for (int i = 1; i < argc; i++)
+    {
+        char* arg = argv[i];
+        bool isFlag;
+        if (arg[0] == '-')
+        {
+            if (!strcasecmp(arg, "-h") || !strcasecmp(arg, "--help"))
+            {
+                //TODO: QT options
+                printf(
+                   "usage: melonDS [options] ... [dspath] [gbapath]\n"
+                   "Options:\n"
+                   "    -h / --help         display this help message and quit\n"
+                   "    -v / --verbose      toggle verbose mode\n"
+                   "    -f / --fullscreen   opens melonDS on fullscreen\n"
+                   "Arguments:\n"
+                   "    dspath              path to a DS ROM you want to run\n"
+                   "    gbapath             path to a GBA ROM you want to load in the emulated Slot 2\n"
+                );
+                exit(0);
+            }
+            else if (!strcasecmp(arg, "-f") || !strcasecmp(arg, "--fullscreen"))
+            {
+                StartOnFullscreen = true;
+            }
+            else
+            {
+                printf("Unrecognized option %s - run '%s --help' for more details \n", arg, argv[0]);
+                exit(1);
+            }
+        } 
+        else
+        {
+            switch (posArgCount)
+            {
+                case 0:
+                    DSRomPath = QString(arg).split("|");
+                    printf("DS ROM path: %s\n", arg);
+                    break;
+                case 1:
+                    GBARomPath = QString(arg).split("|");
+                    printf("GBA ROM path: %s\n", arg);
+                    break;
+                default:
+                    printf("Too many arguments, arg '%s' will be ignored\n", arg);
+            }
+            posArgCount++;
+        }
+    }
+}
+
+}

--- a/src/frontend/qt_sdl/CLI.cpp
+++ b/src/frontend/qt_sdl/CLI.cpp
@@ -101,7 +101,10 @@ CommandLineOptions* ManageArgs(QApplication& melon)
         QStringList paths = options->dsRomPath[0].split("|");
         printf("shits ;; %s\n", paths.join("__URMOM__").toStdString().c_str());
         if (paths.size() >= 2)
+        {
+            printf("Warning: use the a.zip|b.nds format at your own risk!\n");
             options->dsRomPath = paths;
+        }
     }
 
     if (parser.isSet("archive-file-gba"))
@@ -120,7 +123,10 @@ CommandLineOptions* ManageArgs(QApplication& melon)
         //TODO-CLI: try to automatically find ROM
         QStringList paths = options->gbaRomPath[0].split("|");
         if (paths.size() >= 2)
+        {
+            printf("Warning: use the a.zip|b.gba format at your own risk!\n");
             options->gbaRomPath = paths;
+        }
     }
 #endif
 

--- a/src/frontend/qt_sdl/CLI.cpp
+++ b/src/frontend/qt_sdl/CLI.cpp
@@ -99,7 +99,6 @@ CommandLineOptions* ManageArgs(QApplication& melon)
     {
         //TODO-CLI: try to automatically find ROM
         QStringList paths = options->dsRomPath[0].split("|");
-        printf("shits ;; %s\n", paths.join("__URMOM__").toStdString().c_str());
         if (paths.size() >= 2)
         {
             printf("Warning: use the a.zip|b.nds format at your own risk!\n");

--- a/src/frontend/qt_sdl/CLI.cpp
+++ b/src/frontend/qt_sdl/CLI.cpp
@@ -25,7 +25,6 @@
 #include <QStringList>
 
 #include "CLI.h"
-#include "main.h"
 
 namespace CLI
 {

--- a/src/frontend/qt_sdl/CLI.cpp
+++ b/src/frontend/qt_sdl/CLI.cpp
@@ -95,7 +95,7 @@ CommandLineOptions* ManageArgs(QApplication& melon)
             options->dsRomPath += parser.value("archive-file");
         }
     } 
-    else if(!options->dsRomPath.isEmpty())
+    else if (!options->dsRomPath.isEmpty())
     {
         //TODO-CLI: try to automatically find ROM
         QStringList paths = options->dsRomPath[0].split("|");
@@ -117,7 +117,7 @@ CommandLineOptions* ManageArgs(QApplication& melon)
             options->gbaRomPath += parser.value("archive-file-gba");
         }
     }
-    else if(!options->gbaRomPath.isEmpty())
+    else if (!options->gbaRomPath.isEmpty())
     {
         //TODO-CLI: try to automatically find ROM
         QStringList paths = options->gbaRomPath[0].split("|");

--- a/src/frontend/qt_sdl/CLI.h
+++ b/src/frontend/qt_sdl/CLI.h
@@ -24,7 +24,10 @@
 
 namespace CLI {
 
-struct CommandLineOptions {
+struct CommandLineOptions
+{
+    QStringList errorsToDisplay = {};
+
     QStringList dsRomPath;
     QStringList gbaRomPath;
     bool fullscreen;

--- a/src/frontend/qt_sdl/CLI.h
+++ b/src/frontend/qt_sdl/CLI.h
@@ -19,15 +19,19 @@
 #ifndef CLI_H
 #define CLI_H
 
+#include <QApplication>
 #include <QStringList>
 
 namespace CLI {
 
-extern QStringList DSRomPath;
-extern QStringList GBARomPath;
-extern bool StartOnFullscreen;
+struct CommandLineOptions {
+    QStringList dsRomPath;
+    QStringList gbaRomPath;
+    bool fullscreen;
+    bool boot;
+};
 
-extern void ManageArgs(int argc, char** argv);
+extern CommandLineOptions* ManageArgs(QApplication& melon);
 
 }
 

--- a/src/frontend/qt_sdl/CLI.h
+++ b/src/frontend/qt_sdl/CLI.h
@@ -1,0 +1,34 @@
+/*
+    Copyright 2021-2022 melonDS team
+
+    This file is part of melonDS.
+
+    melonDS is free software: you can redistribute it and/or modify it under
+    the terms of the GNU General Public License as published by the Free
+    Software Foundation, either version 3 of the License, or (at your option)
+    any later version.
+
+    melonDS is distributed in the hope that it will be useful, but WITHOUT ANY
+    WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+    FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+    
+    You should have received a copy of the GNU General Public License along
+    with melonDS. If not, see http://www.gnu.org/licenses/.
+*/
+
+#ifndef CLI_H
+#define CLI_H
+
+#include <QStringList>
+
+namespace CLI {
+
+extern QStringList DSRomPath;
+extern QStringList GBARomPath;
+extern bool StartOnFullscreen;
+
+extern void ManageArgs(int argc, char** argv);
+
+}
+
+#endif

--- a/src/frontend/qt_sdl/CMakeLists.txt
+++ b/src/frontend/qt_sdl/CMakeLists.txt
@@ -49,6 +49,9 @@ set(SOURCES_QT_SDL
     ../duckstation/gl/context.cpp
 
     ${CMAKE_SOURCE_DIR}/res/melon.qrc
+
+    CLI.h
+    CLI.cpp
 )
 
 if (APPLE)

--- a/src/frontend/qt_sdl/ROMManager.cpp
+++ b/src/frontend/qt_sdl/ROMManager.cpp
@@ -490,10 +490,8 @@ bool LoadROM(QStringList filepath, bool reset)
     std::string romname;
 
     int num = filepath.count();
-    printf("fucks\n");
     if (num == 1)
     {
-        printf("fucks\n");
         // regular file
 
         std::string filename = filepath.at(0).toStdString();

--- a/src/frontend/qt_sdl/ROMManager.cpp
+++ b/src/frontend/qt_sdl/ROMManager.cpp
@@ -490,8 +490,10 @@ bool LoadROM(QStringList filepath, bool reset)
     std::string romname;
 
     int num = filepath.count();
+    printf("fucks\n");
     if (num == 1)
     {
+        printf("fucks\n");
         // regular file
 
         std::string filename = filepath.at(0).toStdString();
@@ -503,6 +505,7 @@ bool LoadROM(QStringList filepath, bool reset)
         if (len > 0x40000000)
         {
             fclose(f);
+            delete[] filedata;
             return false;
         }
 
@@ -528,14 +531,14 @@ bool LoadROM(QStringList filepath, bool reset)
     {
         // file inside archive
 
-        u32 lenread = Archive::ExtractFileFromArchive(filepath.at(0), filepath.at(1), &filedata, &filelen);
-        if (lenread < 0) return false;
-        if (!filedata) return false;
-        if (lenread != filelen)
-        {
-            delete[] filedata;
-            return false;
-        }
+            s32 lenread = Archive::ExtractFileFromArchive(filepath.at(0), filepath.at(1), &filedata, &filelen);
+            if (lenread < 0) return false;
+            if (!filedata) return false;
+            if (lenread != filelen)
+            {
+                delete[] filedata;
+                return false;
+            }
 
         std::string std_archivepath = filepath.at(0).toStdString();
         basepath = std_archivepath.substr(0, LastSep(std_archivepath));

--- a/src/frontend/qt_sdl/main.cpp
+++ b/src/frontend/qt_sdl/main.cpp
@@ -3126,8 +3126,7 @@ void MainWindow::onTitleUpdate(QString title)
     setWindowTitle(title);
 }
 
-void MainWindow::onFullscreenToggled()
-{
+void ToggleFullscreen(MainWindow* mainWindow) {
     if (!mainWindow->isFullScreen())
     {
         mainWindow->showFullScreen();
@@ -3139,6 +3138,11 @@ void MainWindow::onFullscreenToggled()
         int menuBarHeight = mainWindow->menuBar()->sizeHint().height();
         mainWindow->menuBar()->setFixedHeight(menuBarHeight);
     }
+}
+
+void MainWindow::onFullscreenToggled()
+{
+    ToggleFullscreen(this);
 }
 
 void MainWindow::onEmuStart()
@@ -3357,11 +3361,7 @@ int main(int argc, char** argv)
 
     mainWindow = new MainWindow();
     if (options->fullscreen)
-    {
-        // onFullscreenToggled is private and I don't know if I should copy what's inside it or make it public
-        mainWindow->showFullScreen();
-        mainWindow->menuBar()->setFixedHeight(0); // Don't use hide() as menubar actions stop working
-    }
+        ToggleFullscreen(mainWindow);
 
     emuThread = new EmuThread();
     emuThread->start();

--- a/src/frontend/qt_sdl/main.h
+++ b/src/frontend/qt_sdl/main.h
@@ -238,7 +238,7 @@ public:
     bool hasOGL;
     GL::Context* getOGLContext();
 
-    bool preloadROMs(QString filename, QString gbafilename);
+    bool preloadROMs(QStringList file, QStringList gbafile, bool boot);
 
     void onAppStateChanged(Qt::ApplicationState state);
 


### PR DESCRIPTION
New CLI implementation cause hyperfixation go brr. Still a WIP but should be usable. Uses Qt's QCommandLineParser this time!

Supersedes #1280 and #1402.
Fixes #1108, fixes #1459 (and probably #1393 too)

Seems to build on both Qt5 and Qt6 right now, but I can't actually test outside of Linux so enabling Actions would be appreciated (apparently I can't have them outside master on my fork).

Feel free to review, although may be better to wait 'till I'm done.

Planned shit:
- [x] Load ROMs as usual
  - [x] Load NDS and GBA roms
  - [x] Reimplement (undocumented) support for x.zip|y.nds syntax
  - [x] Load from archive (+ try to find .nds file without having to explicitly give --archive file)
  - [x] --archive-file option
- [x] Choose whether you want to run the game immediately/boot firmware or not
  - Using option `--boot=<always/never/auto>`; `always` and `never` being as expected and `auto` running the game only if a DS ROM is supplied
- [x] Start on fullscreen
- [ ] whatever else the peoples want me to add as long as it's not too much for me