### PR TITLE
Fix: Some errors in Ram Search

### DIFF
--- a/src/frontend/qt_sdl/RAMInfoDialog.cpp
+++ b/src/frontend/qt_sdl/RAMInfoDialog.cpp
@@ -201,16 +201,12 @@ void RAMInfoDialog::on_ramTable_itemChanged(QTableWidgetItem *item)
     s32 newValue = item->text().toInt();
 
     if (rowData.Value != newValue)
+    {
         rowData.Value = newValue;
-}
 
-void RAMInfoDialog::on_ramTable_currentItemChanged(QTableWidgetItem *item)
-{
-    ramInfo_RowData& rowData = SearchThread->GetResults()->at(item->row());
-    s32 newValue = item->text().toInt();
-
-    if (rowData.Value != newValue)
-        NDS::MainRAM[rowData.Address&NDS::MainRAMMask] = (u32)newValue;
+        if (item->isSelected())
+            NDS::MainRAM[rowData.Address&NDS::MainRAMMask] = (u32)newValue;
+    }
 }
 
 /**

--- a/src/frontend/qt_sdl/RAMInfoDialog.cpp
+++ b/src/frontend/qt_sdl/RAMInfoDialog.cpp
@@ -114,7 +114,7 @@ void RAMInfoDialog::ShowRowsInTable()
         else
         {
             // A row that exists
-            ui->ramTable->item(row, ramInfo_Address)->setText(QString("%1").arg(rowData.Address, 8, 16));
+            ui->ramTable->item(row, ramInfo_Address)->setText(QString("%1").arg(rowData.Address, 8, 16, QChar('0')));
             ui->ramTable->item(row, ramInfo_Value)->setText(QString("%1").arg(rowData.Value));
             ui->ramTable->item(row, ramInfo_Previous)->setText(QString("%1").arg(rowData.Previous));
             if (rowData.Value != rowData.Previous) 

--- a/src/frontend/qt_sdl/RAMInfoDialog.cpp
+++ b/src/frontend/qt_sdl/RAMInfoDialog.cpp
@@ -198,10 +198,19 @@ void RAMInfoDialog::on_radiobtn4bytes_clicked()
 void RAMInfoDialog::on_ramTable_itemChanged(QTableWidgetItem *item)
 {
     ramInfo_RowData& rowData = SearchThread->GetResults()->at(item->row());
-    s32 itemValue = item->text().toInt();
+    s32 newValue = item->text().toInt();
 
-    if (rowData.Value != itemValue)
-        rowData.SetValue(itemValue);
+    if (rowData.Value != newValue)
+        rowData.Value = newValue;
+}
+
+void RAMInfoDialog::on_ramTable_currentItemChanged(QTableWidgetItem *item)
+{
+    ramInfo_RowData& rowData = SearchThread->GetResults()->at(item->row());
+    s32 newValue = item->text().toInt();
+
+    if (rowData.Value != newValue)
+        NDS::MainRAM[rowData.Address&NDS::MainRAMMask] = (u32)newValue;
 }
 
 /**

--- a/src/frontend/qt_sdl/RAMInfoDialog.cpp
+++ b/src/frontend/qt_sdl/RAMInfoDialog.cpp
@@ -258,9 +258,6 @@ void RAMSearchThread::run()
     SearchRunning = true;
     u32 progress = 0;
 
-    // // Pause game running
-    // emuThread->emuPause();
-
     // For following search modes below, RowDataVector must be filled.
     if (SearchMode == ramInfoSTh_SearchAll || RowDataVector->size() == 0)
     {
@@ -304,9 +301,6 @@ void RAMSearchThread::run()
         delete RowDataVector;
         RowDataVector = newRowDataVector;
     }
-
-    // // Unpause game running
-    // emuThread->emuUnpause();
 
     SearchRunning = false;
 }

--- a/src/frontend/qt_sdl/RAMInfoDialog.cpp
+++ b/src/frontend/qt_sdl/RAMInfoDialog.cpp
@@ -84,10 +84,14 @@ void RAMInfoDialog::OnSearchFinished()
 
 void RAMInfoDialog::ShowRowsInTable()
 {
-    const u32& scrollValue = ui->ramTable->verticalScrollBar()->sliderPosition();
     std::vector<ramInfo_RowData>* RowDataVector = SearchThread->GetResults();
 
-    for (u32 row = scrollValue; row < std::min<u32>(scrollValue+25, RowDataVector->size()); row++)
+    const s32 currRowIdx = GetCurrentRowIndex();
+
+    const s32 srtRowIdx = std::max<s32>(currRowIdx-20, 0);
+    const s32 endRowIdx = std::min<s32>(currRowIdx+100, RowDataVector->size());
+
+    for (u32 row = srtRowIdx; row < endRowIdx; row++)
     {
         ramInfo_RowData& rowData = RowDataVector->at(row);
         rowData.Update(SearchThread->GetSearchByteType());
@@ -128,6 +132,18 @@ void RAMInfoDialog::ClearTableContents()
 void RAMInfoDialog::SetProgressbarValue(const u32& value)
 {
     ui->progressBar->setValue(value);
+}
+
+s32 RAMInfoDialog::GetCurrentRowIndex()
+{
+    std::vector<ramInfo_RowData>* RowDataVector = SearchThread->GetResults();
+
+    const s32 scrollPositionMaximum = ui->ramTable->verticalScrollBar()->maximum();
+    const s32 scrollPosition = ui->ramTable->verticalScrollBar()->sliderPosition();
+
+    const s32 currRowIdx = RowDataVector->size() * ((float)scrollPosition / scrollPositionMaximum);
+
+    return currRowIdx;
 }
 
 void RAMInfoDialog::done(int r)
@@ -233,8 +249,8 @@ void RAMSearchThread::run()
     SearchRunning = true;
     u32 progress = 0;
 
-    // Pause game running
-    emuThread->emuPause();
+    // // Pause game running
+    // emuThread->emuPause();
 
     // For following search modes below, RowDataVector must be filled.
     if (SearchMode == ramInfoSTh_SearchAll || RowDataVector->size() == 0)
@@ -280,8 +296,8 @@ void RAMSearchThread::run()
         RowDataVector = newRowDataVector;
     }
 
-    // Unpause game running
-    emuThread->emuUnpause();
+    // // Unpause game running
+    // emuThread->emuUnpause();
 
     SearchRunning = false;
 }

--- a/src/frontend/qt_sdl/RAMInfoDialog.h
+++ b/src/frontend/qt_sdl/RAMInfoDialog.h
@@ -60,11 +60,6 @@ struct ramInfo_RowData
     u32 Address;
     s32 Value;
     s32 Previous;
-
-    void Update(const ramInfo_ByteType& byteType)
-    {
-        Value = GetMainRAMValue(Address, byteType);
-    }
 };
 
 class RAMInfoDialog : public QDialog

--- a/src/frontend/qt_sdl/RAMInfoDialog.h
+++ b/src/frontend/qt_sdl/RAMInfoDialog.h
@@ -106,7 +106,6 @@ private slots:
     void on_radiobtn2bytes_clicked();
     void on_radiobtn4bytes_clicked();
     void on_ramTable_itemChanged(QTableWidgetItem *item);
-    void on_ramTable_currentItemChanged(QTableWidgetItem *item);
 
     void OnSearchFinished();
     void ShowRowsInTable();

--- a/src/frontend/qt_sdl/RAMInfoDialog.h
+++ b/src/frontend/qt_sdl/RAMInfoDialog.h
@@ -145,7 +145,7 @@ private:
 
     ramInfoSTh_SearchMode SearchMode;
     s32 SearchValue;
-    ramInfo_ByteType SearchByteType = ramInfo_OneByte;
+    ramInfo_ByteType SearchByteType = ramInfo_FourBytes;
     std::vector<ramInfo_RowData>* RowDataVector = nullptr;
 
     void ClearTableContents();

--- a/src/frontend/qt_sdl/RAMInfoDialog.h
+++ b/src/frontend/qt_sdl/RAMInfoDialog.h
@@ -65,12 +65,6 @@ struct ramInfo_RowData
     {
         Value = GetMainRAMValue(Address, byteType);
     }
-
-    void SetValue(const s32& value)
-    {
-        NDS::MainRAM[Address&NDS::MainRAMMask] = (u32)value;
-        Value = value;
-    }
 };
 
 class RAMInfoDialog : public QDialog
@@ -112,6 +106,7 @@ private slots:
     void on_radiobtn2bytes_clicked();
     void on_radiobtn4bytes_clicked();
     void on_ramTable_itemChanged(QTableWidgetItem *item);
+    void on_ramTable_currentItemChanged(QTableWidgetItem *item);
 
     void OnSearchFinished();
     void ShowRowsInTable();

--- a/src/frontend/qt_sdl/RAMInfoDialog.h
+++ b/src/frontend/qt_sdl/RAMInfoDialog.h
@@ -116,6 +116,8 @@ private slots:
     void OnSearchFinished();
     void ShowRowsInTable();
     void SetProgressbarValue(const u32& value);
+    
+    s32 GetCurrentRowIndex();
 
 private:
     Ui::RAMInfoDialog* ui;

--- a/src/frontend/qt_sdl/RAMInfoDialog.ui
+++ b/src/frontend/qt_sdl/RAMInfoDialog.ui
@@ -223,7 +223,7 @@
     <rect>
      <x>10</x>
      <y>10</y>
-     <width>101</width>
+     <width>200</width>
      <height>16</height>
     </rect>
    </property>

--- a/src/frontend/qt_sdl/RAMInfoDialog.ui
+++ b/src/frontend/qt_sdl/RAMInfoDialog.ui
@@ -107,9 +107,6 @@
     <property name="text">
      <string>1byte</string>
     </property>
-    <property name="checked">
-     <bool>true</bool>
-    </property>
    </widget>
    <widget class="QRadioButton" name="radiobtn2bytes">
     <property name="geometry">
@@ -135,6 +132,9 @@
     </property>
     <property name="text">
      <string>4bytes</string>
+    </property>
+    <property name="checked">
+     <bool>true</bool>
     </property>
    </widget>
   </widget>


### PR DESCRIPTION
## 🛠 Fix some errors

### Avoiding too many memory updates (#1406)
Each time a row in the table was updated, the RAM was updated.
So accessing memory that is frequently modified will break your program.

Currently the RAM is updated when the user changes the value.

### Fixed error that some rows are partially invisible in mac (like below)
<img width="662" alt="image" src="https://user-images.githubusercontent.com/7973448/200175328-0d7cd720-598a-4c9d-8edd-c46c598af310.png">

### Fixed an error where rows were accumulated
There was an error where existing information was accumulated even when searching for a new one.

## 📌 Others
Updated default search byte type from One to Four.