### PR TITLE
Allow import/export of .pub/.prv/.bnr saves

### DIFF
--- a/src/frontend/qt_sdl/TitleManagerDialog.cpp
+++ b/src/frontend/qt_sdl/TitleManagerDialog.cpp
@@ -266,12 +266,22 @@ void TitleManagerDialog::onImportTitleData()
         return;
     }
 
+    QString extensions = "*.sav";
     u32 wantedsize;
     switch (type)
     {
-    case DSi_NAND::TitleData_PublicSav:  wantedsize = cur->data(Qt::UserRole+1).toUInt(); break;
-    case DSi_NAND::TitleData_PrivateSav: wantedsize = cur->data(Qt::UserRole+2).toUInt(); break;
-    case DSi_NAND::TitleData_BannerSav:  wantedsize = cur->data(Qt::UserRole+3).toUInt(); break;
+    case DSi_NAND::TitleData_PublicSav:
+        extensions += " *.pub";
+        wantedsize = cur->data(Qt::UserRole+1).toUInt();
+        break;
+    case DSi_NAND::TitleData_PrivateSav:
+        extensions += " *.prv";
+        wantedsize = cur->data(Qt::UserRole+2).toUInt();
+        break;
+    case DSi_NAND::TitleData_BannerSav:
+        extensions += " *.bnr";
+        wantedsize = cur->data(Qt::UserRole+3).toUInt();
+        break;
     default:
         printf("what??\n");
         return;
@@ -280,7 +290,7 @@ void TitleManagerDialog::onImportTitleData()
     QString file = QFileDialog::getOpenFileName(this,
                                                 "Select file to import...",
                                                 QString::fromStdString(EmuDirectory),
-                                                "Title data files (*.sav);;Any file (*.*)");
+                                                "Title data files (" + extensions + ");;Any file (*.*)");
 
     if (file.isEmpty()) return;
 
@@ -327,19 +337,23 @@ void TitleManagerDialog::onExportTitleData()
     }
 
     QString exportname;
+    QString extensions = "*.sav";
     u32 wantedsize;
     switch (type)
     {
     case DSi_NAND::TitleData_PublicSav:
         exportname = "/public.sav";
+        extensions += " *.pub";
         wantedsize = cur->data(Qt::UserRole+1).toUInt();
         break;
     case DSi_NAND::TitleData_PrivateSav:
         exportname = "/private.sav";
+        extensions += " *.prv";
         wantedsize = cur->data(Qt::UserRole+2).toUInt();
         break;
     case DSi_NAND::TitleData_BannerSav:
         exportname = "/banner.sav";
+        extensions += " *.bnr";
         wantedsize = cur->data(Qt::UserRole+3).toUInt();
         break;
     default:
@@ -350,7 +364,7 @@ void TitleManagerDialog::onExportTitleData()
     QString file = QFileDialog::getSaveFileName(this,
                                                 "Select path to export to...",
                                                 QString::fromStdString(EmuDirectory) + exportname,
-                                                "Title data files (*.sav);;Any file (*.*)");
+                                                "Title data files (" + extensions + ");;Any file (*.*)");
 
     if (file.isEmpty()) return;
 


### PR DESCRIPTION
Makes the title manager allow import and export of the standard homebrew extensions for DSiWare (`.pub` == `public.sav`, `.prv` == `private.sav`, and `.bnr` == `banner.sav`) in addition to the normal `.sav` extension without having to switch to All Files mode.

Tested on macOS 10.15.7 using saves from TWiLight Menu++.