### PR TITLE
DSi: add option to boot the full boot ROMs

### DIFF
--- a/src/DSi.cpp
+++ b/src/DSi.cpp
@@ -82,6 +82,14 @@ DSi_SDHost* SDIO;
 u64 ConsoleID;
 u8 eMMC_CID[16];
 
+// FIXME: these currently have no effect (and aren't stored in a savestate)
+//        ... not that they matter all that much
+u8 GPIO_Data;
+u8 GPIO_Dir;
+u8 GPIO_IEdgeSel;
+u8 GPIO_IE;
+u8 GPIO_WiFi;
+
 
 void Set_SCFG_Clock9(u16 val);
 void Set_SCFG_MC(u32 val);
@@ -159,7 +167,14 @@ void Reset()
 
     DSi_AES::Reset();
 
-    SCFG_BIOS = 0x0101; // TODO: should be zero when booting from BIOS
+    if (Platform::GetConfigBool(Platform::DSi_FullBIOSBoot))
+    {
+        SCFG_BIOS = 0x0000;
+    }
+    else
+    {
+        SCFG_BIOS = 0x0101;
+    }
     SCFG_Clock9 = 0x0187; // CHECKME
     SCFG_Clock7 = 0x0187;
     SCFG_EXT[0] = 0x8307F100;
@@ -673,7 +688,14 @@ void SoftReset()
 
     DSi_AES::Reset();
 
-    SCFG_BIOS = 0x0101; // TODO: should be zero when booting from BIOS
+    if (Platform::GetConfigBool(Platform::DSi_FullBIOSBoot))
+    {
+        SCFG_BIOS = 0x0000;
+    }
+    else
+    {
+        SCFG_BIOS = 0x0101;
+    }
     SCFG_Clock9 = 0x0187; // CHECKME
     SCFG_Clock7 = 0x0187;
     SCFG_EXT[0] = 0x8307F100;
@@ -733,12 +755,16 @@ bool LoadBIOS()
         fclose(f);
     }
 
-    // herp
-    *(u32*)&ARM9iBIOS[0] = 0xEAFFFFFE;
-    *(u32*)&ARM7iBIOS[0] = 0xEAFFFFFE;
+    if (!Platform::GetConfigBool(Platform::DSi_FullBIOSBoot))
+    {
+        // herp
+        *(u32*)&ARM9iBIOS[0] = 0xEAFFFFFE;
+        *(u32*)&ARM7iBIOS[0] = 0xEAFFFFFE;
 
-    // TODO!!!!
-    // hax the upper 32K out of the goddamn DSi
+        // TODO!!!!
+        // hax the upper 32K out of the goddamn DSi
+        // done that :)  -pcy
+    }
 
     return true;
 }
@@ -775,115 +801,138 @@ bool LoadNAND()
     memset(NWRAMMask, 0, sizeof(NWRAMMask));
 
     u32 bootparams[8];
-    fseek(nand, 0x220, SEEK_SET);
-    fread(bootparams, 4, 8, nand);
-
-    Log(LogLevel::Debug, "ARM9: offset=%08X size=%08X RAM=%08X size_aligned=%08X\n",
-           bootparams[0], bootparams[1], bootparams[2], bootparams[3]);
-    Log(LogLevel::Debug, "ARM7: offset=%08X size=%08X RAM=%08X size_aligned=%08X\n",
-           bootparams[4], bootparams[5], bootparams[6], bootparams[7]);
-
-    // read and apply new-WRAM settings
-
-    MBK[0][8] = 0;
-    MBK[1][8] = 0;
-
-    u32 mbk[12];
-    fseek(nand, 0x380, SEEK_SET);
-    fread(mbk, 4, 12, nand);
-
-    MapNWRAM_A(0, mbk[0] & 0xFF);
-    MapNWRAM_A(1, (mbk[0] >> 8) & 0xFF);
-    MapNWRAM_A(2, (mbk[0] >> 16) & 0xFF);
-    MapNWRAM_A(3, mbk[0] >> 24);
-
-    MapNWRAM_B(0, mbk[1] & 0xFF);
-    MapNWRAM_B(1, (mbk[1] >> 8) & 0xFF);
-    MapNWRAM_B(2, (mbk[1] >> 16) & 0xFF);
-    MapNWRAM_B(3, mbk[1] >> 24);
-    MapNWRAM_B(4, mbk[2] & 0xFF);
-    MapNWRAM_B(5, (mbk[2] >> 8) & 0xFF);
-    MapNWRAM_B(6, (mbk[2] >> 16) & 0xFF);
-    MapNWRAM_B(7, mbk[2] >> 24);
-
-    MapNWRAM_C(0, mbk[3] & 0xFF);
-    MapNWRAM_C(1, (mbk[3] >> 8) & 0xFF);
-    MapNWRAM_C(2, (mbk[3] >> 16) & 0xFF);
-    MapNWRAM_C(3, mbk[3] >> 24);
-    MapNWRAM_C(4, mbk[4] & 0xFF);
-    MapNWRAM_C(5, (mbk[4] >> 8) & 0xFF);
-    MapNWRAM_C(6, (mbk[4] >> 16) & 0xFF);
-    MapNWRAM_C(7, mbk[4] >> 24);
-
-    MapNWRAMRange(0, 0, mbk[5]);
-    MapNWRAMRange(0, 1, mbk[6]);
-    MapNWRAMRange(0, 2, mbk[7]);
-
-    MapNWRAMRange(1, 0, mbk[8]);
-    MapNWRAMRange(1, 1, mbk[9]);
-    MapNWRAMRange(1, 2, mbk[10]);
-
-    // TODO: find out why it is 0xFF000000
-    mbk[11] &= 0x00FFFF0F;
-    MBK[0][8] = mbk[11];
-    MBK[1][8] = mbk[11];
-
-    // load boot2 binaries
-
-    AES_ctx ctx;
-    const u8 boot2key[16] = {0xAD, 0x34, 0xEC, 0xF9, 0x62, 0x6E, 0xC2, 0x3A, 0xF6, 0xB4, 0x6C, 0x00, 0x80, 0x80, 0xEE, 0x98};
-    u8 boot2iv[16];
-    u8 tmp[16];
-    u32 dstaddr;
-
-    *(u32*)&tmp[0] = bootparams[3];
-    *(u32*)&tmp[4] = -bootparams[3];
-    *(u32*)&tmp[8] = ~bootparams[3];
-    *(u32*)&tmp[12] = 0;
-    for (int i = 0; i < 16; i++) boot2iv[i] = tmp[15-i];
-
-    AES_init_ctx_iv(&ctx, boot2key, boot2iv);
-
-    fseek(nand, bootparams[0], SEEK_SET);
-    dstaddr = bootparams[2];
-    for (u32 i = 0; i < bootparams[3]; i += 16)
+    if (Platform::GetConfigBool(Platform::DSi_FullBIOSBoot))
     {
-        u8 data[16];
-        fread(data, 16, 1, nand);
-
-        for (int j = 0; j < 16; j++) tmp[j] = data[15-j];
-        AES_CTR_xcrypt_buffer(&ctx, tmp, 16);
-        for (int j = 0; j < 16; j++) data[j] = tmp[15-j];
-
-        ARM9Write32(dstaddr, *(u32*)&data[0]); dstaddr += 4;
-        ARM9Write32(dstaddr, *(u32*)&data[4]); dstaddr += 4;
-        ARM9Write32(dstaddr, *(u32*)&data[8]); dstaddr += 4;
-        ARM9Write32(dstaddr, *(u32*)&data[12]); dstaddr += 4;
+        // TODO: figure out default MBK mapping
+        // MBK1..5: disable mappings
+        for (int i = 0; i < 8; ++i)
+        {
+            if (i < 4)
+                MapNWRAM_A(i, 0);
+            MapNWRAM_B(i, 0);
+            MapNWRAM_C(i, 0);
+        }
+        // MBK6..8: address mappings: nothing mapped
+        for (int i = 0; i < 6; ++i)
+        {
+            MapNWRAMRange(i & 1, i >> 1, 0);
+        }
+        // MBK9: ARM9 allowed to write
+        MBK[0][8] = 0;
+        MBK[1][8] = 0;
     }
-
-    *(u32*)&tmp[0] = bootparams[7];
-    *(u32*)&tmp[4] = -bootparams[7];
-    *(u32*)&tmp[8] = ~bootparams[7];
-    *(u32*)&tmp[12] = 0;
-    for (int i = 0; i < 16; i++) boot2iv[i] = tmp[15-i];
-
-    AES_init_ctx_iv(&ctx, boot2key, boot2iv);
-
-    fseek(nand, bootparams[4], SEEK_SET);
-    dstaddr = bootparams[6];
-    for (u32 i = 0; i < bootparams[7]; i += 16)
+    else
     {
-        u8 data[16];
-        fread(data, 16, 1, nand);
+        fseek(nand, 0x220, SEEK_SET);
+        fread(bootparams, 4, 8, nand);
 
-        for (int j = 0; j < 16; j++) tmp[j] = data[15-j];
-        AES_CTR_xcrypt_buffer(&ctx, tmp, 16);
-        for (int j = 0; j < 16; j++) data[j] = tmp[15-j];
+        Log(LogLevel::Debug, "ARM9: offset=%08X size=%08X RAM=%08X size_aligned=%08X\n",
+               bootparams[0], bootparams[1], bootparams[2], bootparams[3]);
+        Log(LogLevel::Debug, "ARM7: offset=%08X size=%08X RAM=%08X size_aligned=%08X\n",
+               bootparams[4], bootparams[5], bootparams[6], bootparams[7]);
 
-        ARM7Write32(dstaddr, *(u32*)&data[0]); dstaddr += 4;
-        ARM7Write32(dstaddr, *(u32*)&data[4]); dstaddr += 4;
-        ARM7Write32(dstaddr, *(u32*)&data[8]); dstaddr += 4;
-        ARM7Write32(dstaddr, *(u32*)&data[12]); dstaddr += 4;
+        // read and apply new-WRAM settings
+
+        MBK[0][8] = 0;
+        MBK[1][8] = 0;
+
+        u32 mbk[12];
+        fseek(nand, 0x380, SEEK_SET);
+        fread(mbk, 4, 12, nand);
+
+        MapNWRAM_A(0, mbk[0] & 0xFF);
+        MapNWRAM_A(1, (mbk[0] >> 8) & 0xFF);
+        MapNWRAM_A(2, (mbk[0] >> 16) & 0xFF);
+        MapNWRAM_A(3, mbk[0] >> 24);
+
+        MapNWRAM_B(0, mbk[1] & 0xFF);
+        MapNWRAM_B(1, (mbk[1] >> 8) & 0xFF);
+        MapNWRAM_B(2, (mbk[1] >> 16) & 0xFF);
+        MapNWRAM_B(3, mbk[1] >> 24);
+        MapNWRAM_B(4, mbk[2] & 0xFF);
+        MapNWRAM_B(5, (mbk[2] >> 8) & 0xFF);
+        MapNWRAM_B(6, (mbk[2] >> 16) & 0xFF);
+        MapNWRAM_B(7, mbk[2] >> 24);
+
+        MapNWRAM_C(0, mbk[3] & 0xFF);
+        MapNWRAM_C(1, (mbk[3] >> 8) & 0xFF);
+        MapNWRAM_C(2, (mbk[3] >> 16) & 0xFF);
+        MapNWRAM_C(3, mbk[3] >> 24);
+        MapNWRAM_C(4, mbk[4] & 0xFF);
+        MapNWRAM_C(5, (mbk[4] >> 8) & 0xFF);
+        MapNWRAM_C(6, (mbk[4] >> 16) & 0xFF);
+        MapNWRAM_C(7, mbk[4] >> 24);
+
+        MapNWRAMRange(0, 0, mbk[5]);
+        MapNWRAMRange(0, 1, mbk[6]);
+        MapNWRAMRange(0, 2, mbk[7]);
+
+        MapNWRAMRange(1, 0, mbk[8]);
+        MapNWRAMRange(1, 1, mbk[9]);
+        MapNWRAMRange(1, 2, mbk[10]);
+
+        // TODO: find out why it is 0xFF000000
+        mbk[11] &= 0x00FFFF0F;
+        MBK[0][8] = mbk[11];
+        MBK[1][8] = mbk[11];
+
+        // load boot2 binaries
+
+        AES_ctx ctx;
+        const u8 boot2key[16] = {0xAD, 0x34, 0xEC, 0xF9, 0x62, 0x6E, 0xC2, 0x3A, 0xF6, 0xB4, 0x6C, 0x00, 0x80, 0x80, 0xEE, 0x98};
+        u8 boot2iv[16];
+        u8 tmp[16];
+        u32 dstaddr;
+
+        *(u32*)&tmp[0] = bootparams[3];
+        *(u32*)&tmp[4] = -bootparams[3];
+        *(u32*)&tmp[8] = ~bootparams[3];
+        *(u32*)&tmp[12] = 0;
+        for (int i = 0; i < 16; i++) boot2iv[i] = tmp[15-i];
+
+        AES_init_ctx_iv(&ctx, boot2key, boot2iv);
+
+        fseek(nand, bootparams[0], SEEK_SET);
+        dstaddr = bootparams[2];
+        for (u32 i = 0; i < bootparams[3]; i += 16)
+        {
+            u8 data[16];
+            fread(data, 16, 1, nand);
+
+            for (int j = 0; j < 16; j++) tmp[j] = data[15-j];
+            AES_CTR_xcrypt_buffer(&ctx, tmp, 16);
+            for (int j = 0; j < 16; j++) data[j] = tmp[15-j];
+
+            ARM9Write32(dstaddr, *(u32*)&data[0]); dstaddr += 4;
+            ARM9Write32(dstaddr, *(u32*)&data[4]); dstaddr += 4;
+            ARM9Write32(dstaddr, *(u32*)&data[8]); dstaddr += 4;
+            ARM9Write32(dstaddr, *(u32*)&data[12]); dstaddr += 4;
+        }
+
+        *(u32*)&tmp[0] = bootparams[7];
+        *(u32*)&tmp[4] = -bootparams[7];
+        *(u32*)&tmp[8] = ~bootparams[7];
+        *(u32*)&tmp[12] = 0;
+        for (int i = 0; i < 16; i++) boot2iv[i] = tmp[15-i];
+
+        AES_init_ctx_iv(&ctx, boot2key, boot2iv);
+
+        fseek(nand, bootparams[4], SEEK_SET);
+        dstaddr = bootparams[6];
+        for (u32 i = 0; i < bootparams[7]; i += 16)
+        {
+            u8 data[16];
+            fread(data, 16, 1, nand);
+
+            for (int j = 0; j < 16; j++) tmp[j] = data[15-j];
+            AES_CTR_xcrypt_buffer(&ctx, tmp, 16);
+            for (int j = 0; j < 16; j++) data[j] = tmp[15-j];
+
+            ARM7Write32(dstaddr, *(u32*)&data[0]); dstaddr += 4;
+            ARM7Write32(dstaddr, *(u32*)&data[4]); dstaddr += 4;
+            ARM7Write32(dstaddr, *(u32*)&data[8]); dstaddr += 4;
+            ARM7Write32(dstaddr, *(u32*)&data[12]); dstaddr += 4;
+        }
     }
 
 #define printhex(str, size) { for (int z = 0; z < (size); z++) printf("%02X", (str)[z]); printf("\n"); }
@@ -894,35 +943,44 @@ bool LoadNAND()
     Log(LogLevel::Debug, "eMMC CID: "); printhex(eMMC_CID, 16);
     Log(LogLevel::Debug, "Console ID: %" PRIx64 "\n", ConsoleID);
 
-    u32 eaddr = 0x03FFE6E4;
-    ARM7Write32(eaddr+0x00, *(u32*)&eMMC_CID[0]);
-    ARM7Write32(eaddr+0x04, *(u32*)&eMMC_CID[4]);
-    ARM7Write32(eaddr+0x08, *(u32*)&eMMC_CID[8]);
-    ARM7Write32(eaddr+0x0C, *(u32*)&eMMC_CID[12]);
-    ARM7Write16(eaddr+0x2C, 0x0001);
-    ARM7Write16(eaddr+0x2E, 0x0001);
-    ARM7Write16(eaddr+0x3C, 0x0100);
-    ARM7Write16(eaddr+0x3E, 0x40E0);
-    ARM7Write16(eaddr+0x42, 0x0001);
+    if (Platform::GetConfigBool(Platform::DSi_FullBIOSBoot))
+    {
+        // point CPUs to boot ROM reset vectors
+        NDS::ARM9->JumpTo(0xFFFF0000);
+        NDS::ARM7->JumpTo(0x00000000);
+    }
+    else
+    {
+        u32 eaddr = 0x03FFE6E4;
+        ARM7Write32(eaddr+0x00, *(u32*)&eMMC_CID[0]);
+        ARM7Write32(eaddr+0x04, *(u32*)&eMMC_CID[4]);
+        ARM7Write32(eaddr+0x08, *(u32*)&eMMC_CID[8]);
+        ARM7Write32(eaddr+0x0C, *(u32*)&eMMC_CID[12]);
+        ARM7Write16(eaddr+0x2C, 0x0001);
+        ARM7Write16(eaddr+0x2E, 0x0001);
+        ARM7Write16(eaddr+0x3C, 0x0100);
+        ARM7Write16(eaddr+0x3E, 0x40E0);
+        ARM7Write16(eaddr+0x42, 0x0001);
 
-    memcpy(&NDS::ARM9->ITCM[0x4400], &ARM9iBIOS[0x87F4], 0x400);
-    memcpy(&NDS::ARM9->ITCM[0x4800], &ARM9iBIOS[0x9920], 0x80);
-    memcpy(&NDS::ARM9->ITCM[0x4894], &ARM9iBIOS[0x99A0], 0x1048);
-    memcpy(&NDS::ARM9->ITCM[0x58DC], &ARM9iBIOS[0xA9E8], 0x1048);
+        memcpy(&NDS::ARM9->ITCM[0x4400], &ARM9iBIOS[0x87F4], 0x400);
+        memcpy(&NDS::ARM9->ITCM[0x4800], &ARM9iBIOS[0x9920], 0x80);
+        memcpy(&NDS::ARM9->ITCM[0x4894], &ARM9iBIOS[0x99A0], 0x1048);
+        memcpy(&NDS::ARM9->ITCM[0x58DC], &ARM9iBIOS[0xA9E8], 0x1048);
 
-    u8 ARM7Init[0x3C00];
-    memset(ARM7Init, 0, 0x3C00);
-    memcpy(&ARM7Init[0x0000], &ARM7iBIOS[0x8188], 0x200);
-    memcpy(&ARM7Init[0x0200], &ARM7iBIOS[0xB5D8], 0x40);
-    memcpy(&ARM7Init[0x0254], &ARM7iBIOS[0xC6D0], 0x1048);
-    memcpy(&ARM7Init[0x129C], &ARM7iBIOS[0xD718], 0x1048);
+        u8 ARM7Init[0x3C00];
+        memset(ARM7Init, 0, 0x3C00);
+        memcpy(&ARM7Init[0x0000], &ARM7iBIOS[0x8188], 0x200);
+        memcpy(&ARM7Init[0x0200], &ARM7iBIOS[0xB5D8], 0x40);
+        memcpy(&ARM7Init[0x0254], &ARM7iBIOS[0xC6D0], 0x1048);
+        memcpy(&ARM7Init[0x129C], &ARM7iBIOS[0xD718], 0x1048);
 
-    for (u32 i = 0; i < 0x3C00; i+=4)
-        ARM7Write32(0x03FFC400+i, *(u32*)&ARM7Init[i]);
+        for (u32 i = 0; i < 0x3C00; i+=4)
+            ARM7Write32(0x03FFC400+i, *(u32*)&ARM7Init[i]);
 
-    // repoint the CPUs to the boot2 binaries
-    NDS::ARM9->JumpTo(bootparams[2]);
-    NDS::ARM7->JumpTo(bootparams[6]);
+        // repoint the CPUs to the boot2 binaries
+        NDS::ARM9->JumpTo(bootparams[2]);
+        NDS::ARM7->JumpTo(bootparams[6]);
+    }
 
     DSi_NAND::PatchUserData();
 
@@ -2680,6 +2738,7 @@ u8 ARM7IORead8(u32 addr)
     case 0x04004000:
         return SCFG_BIOS & 0xFF;
     case 0x04004001: return SCFG_BIOS >> 8;
+    case 0x04004002: return 0; // SCFG_ROMWE, always 0
 
     CASE_READ8_32BIT(0x04004040, MBK[1][0])
     CASE_READ8_32BIT(0x04004044, MBK[1][1])
@@ -2706,6 +2765,13 @@ u8 ARM7IORead8(u32 addr)
 
     case 0x4004700: return DSi_DSP::SNDExCnt;
     case 0x4004701: return DSi_DSP::SNDExCnt >> 8;
+
+    case 0x04004C00: return GPIO_Data;
+    case 0x04004C01: return GPIO_Dir;
+    case 0x04004C02: return GPIO_IEdgeSel;
+    case 0x04004C03: return GPIO_IE;
+    case 0x04004C04: return GPIO_WiFi & 0xff;
+    case 0x04004C05: return GPIO_WiFi >> 8;
     }
 
     return NDS::ARM7IORead8(addr);
@@ -2719,6 +2785,7 @@ u16 ARM7IORead16(u32 addr)
     case 0x0400021C: return NDS::IF2;
 
     case 0x04004000: return SCFG_BIOS;
+    case 0x04004002: return 0; // SCFG_ROMWE, always 0
     case 0x04004004: return SCFG_Clock7;
     case 0x04004006: return 0; // JTAG register
     case 0x04004010: return SCFG_MC & 0xFFFF;
@@ -2740,6 +2807,10 @@ u16 ARM7IORead16(u32 addr)
     case 0x04004D08: return 0;
 
     case 0x4004700: return DSi_DSP::SNDExCnt;
+
+    case 0x04004C00: return GPIO_Data | ((u16)GPIO_Dir << 8);
+    case 0x04004C02: return GPIO_IEdgeSel | ((u16)GPIO_IE << 8);
+    case 0x04004C04: return GPIO_WiFi;
     }
 
     if (addr >= 0x04004800 && addr < 0x04004A00)
@@ -2845,6 +2916,9 @@ void ARM7IOWrite8(u32 addr, u8 val)
             return;
         SCFG_BIOS |= ((val & 0x07) << 8);
         return;
+    case 0x04004002:
+        // SCFG_ROMWE. ignored, as it always reads as 0
+        return;
     case 0x04004060:
     case 0x04004061:
     case 0x04004062:
@@ -2868,6 +2942,22 @@ void ARM7IOWrite8(u32 addr, u8 val)
         return;
     case 0x4004701:
         DSi_DSP::WriteSNDExCnt(((u16)val << 8) | (DSi_DSP::SNDExCnt & 0x00FF));
+        return;
+
+    case 0x04004C00:
+        GPIO_Data = val;
+        return;
+    case 0x04004C01:
+        GPIO_Dir = val;
+        return;
+    case 0x04004C02:
+        GPIO_IEdgeSel = val;
+        return;
+    case 0x04004C03:
+        GPIO_IE = val;
+        return;
+    case 0x04004C04:
+        GPIO_WiFi = val | (GPIO_WiFi & 0xff00);
         return;
     }
 
@@ -2919,6 +3009,9 @@ void ARM7IOWrite16(u32 addr, u16 val)
                 return;
             SCFG_BIOS |= (val & 0x0703);
             return;
+        case 0x04004002:
+            // SCFG_ROMWE. ignored, as it always reads as 0
+            return;
         case 0x04004004:
             if (!(SCFG_EXT[1] & (1 << 31))) /* no access to SCFG Registers if disabled*/
                 return;
@@ -2942,8 +3035,24 @@ void ARM7IOWrite16(u32 addr, u16 val)
             }
             return;
 
+        case 0x04004406:
+            DSi_AES::WriteBlkCnt(val<<16);
+            return;
+
         case 0x4004700:
             DSi_DSP::WriteSNDExCnt(val);
+            return;
+
+        case 0x04004C00:
+            GPIO_Data = val & 0xff;
+            GPIO_Dir = val >> 8;
+            return;
+        case 0x04004C02:
+            GPIO_IEdgeSel = val & 0xff;
+            GPIO_IE = val >> 8;
+            return;
+        case 0x04004C04:
+            GPIO_WiFi = val;
             return;
     }
 

--- a/src/DSi.cpp
+++ b/src/DSi.cpp
@@ -184,6 +184,12 @@ void Reset()
 
     DSi_DSP::SetRstLine(false);
 
+    GPIO_Data = 0xff; // these actually initialize to high after reset
+    GPIO_Dir = 0x80; // enable sound out, all others input
+    GPIO_IEdgeSel = 0;
+    GPIO_IE = 0;
+    GPIO_WiFi = 0;
+
     // LCD init flag
     GPU::DispStat[0] |= (1<<6);
     GPU::DispStat[1] |= (1<<6);

--- a/src/Platform.h
+++ b/src/Platform.h
@@ -83,6 +83,8 @@ enum ConfigEntry
     Firm_MAC,
 
     AudioBitDepth,
+
+    DSi_FullBIOSBoot
 };
 
 int GetConfigInt(ConfigEntry entry);

--- a/src/SPI.cpp
+++ b/src/SPI.cpp
@@ -119,6 +119,8 @@ u32 FixFirmwareLength(u32 originalLength)
 
 void LoadDefaultFirmware()
 {
+    Log(LogLevel::Debug, "Using default firmware image...\n");
+
     FirmwareLength = 0x20000;
     Firmware = new u8[FirmwareLength];
     memset(Firmware, 0xFF, FirmwareLength);
@@ -132,6 +134,10 @@ void LoadDefaultFirmware()
         Firmware[0x2F] = 0x0F;
         Firmware[0x1FD] = 0x01;
         Firmware[0x1FE] = 0x20;
+        Firmware[0x2FF] = 0x80; // boot0: use NAND as stage2 medium
+
+        // these need to be zero (part of the stage2 firmware signature!)
+        memset(&Firmware[0x22], 0, 8);
     }
     else
     {
@@ -337,6 +343,8 @@ void Reset()
             FirmwarePath = Platform::GetConfigString(Platform::DSi_FirmwarePath);
         else
             FirmwarePath = Platform::GetConfigString(Platform::FirmwarePath);
+
+        Log(LogLevel::Debug, "SPI firmware: loading from file %s\n", FirmwarePath.c_str());
 
         bool makecopy = false;
         std::string origpath = FirmwarePath;

--- a/src/frontend/qt_sdl/Config.cpp
+++ b/src/frontend/qt_sdl/Config.cpp
@@ -143,6 +143,8 @@ bool DSBatteryLevelOkay;
 int DSiBatteryLevel;
 bool DSiBatteryCharging;
 
+bool DSiFullBIOSBoot;
+
 CameraConfig Camera[2];
 
 
@@ -331,6 +333,8 @@ ConfigEntry ConfigFile[] =
     {"DSBatteryLevelOkay",   1, &DSBatteryLevelOkay, true, true},
     {"DSiBatteryLevel",    0, &DSiBatteryLevel, 0xF, true},
     {"DSiBatteryCharging", 1, &DSiBatteryCharging, true, true},
+
+    {"DSiFullBIOSBoot", 1, &DSiFullBIOSBoot, false, true},
 
     // TODO!!
     // we need a more elegant way to deal with this

--- a/src/frontend/qt_sdl/Config.h
+++ b/src/frontend/qt_sdl/Config.h
@@ -199,6 +199,8 @@ extern bool DSBatteryLevelOkay;
 extern int DSiBatteryLevel;
 extern bool DSiBatteryCharging;
 
+extern bool DSiFullBIOSBoot;
+
 extern CameraConfig Camera[2];
 
 

--- a/src/frontend/qt_sdl/EmuSettingsDialog.cpp
+++ b/src/frontend/qt_sdl/EmuSettingsDialog.cpp
@@ -122,6 +122,8 @@ EmuSettingsDialog::EmuSettingsDialog(QWidget* parent) : QDialog(parent), ui(new 
     ui->txtDLDIFolder->setText(QString::fromStdString(Config::DLDIFolderPath));
     on_cbDLDIEnable_toggled();
 
+    ui->cbDSiFullBIOSBoot->setChecked(Config::DSiFullBIOSBoot);
+
     ui->cbDSiSDEnable->setChecked(Config::DSiSDEnable);
     ui->txtDSiSDPath->setText(QString::fromStdString(Config::DSiSDPath));
     ui->cbxDSiSDSize->setCurrentIndex(Config::DSiSDSize);
@@ -211,6 +213,7 @@ void EmuSettingsDialog::done(int r)
         std::string dsiBios7Path = ui->txtDSiBIOS7Path->text().toStdString();
         std::string dsiFirmwarePath = ui->txtDSiFirmwarePath->text().toStdString();
         std::string dsiNANDPath = ui->txtDSiNANDPath->text().toStdString();
+        bool dsiFullBiosBoot = ui->cbDSiFullBIOSBoot->isChecked();
 
         bool dsiSDEnable = ui->cbDSiSDEnable->isChecked();
         std::string dsiSDPath = ui->txtDSiSDPath->text().toStdString();
@@ -242,6 +245,7 @@ void EmuSettingsDialog::done(int r)
             || dsiBios7Path != Config::DSiBIOS7Path
             || dsiFirmwarePath != Config::DSiFirmwarePath
             || dsiNANDPath != Config::DSiNANDPath
+            || dsiFullBiosBoot != Config::DSiFullBIOSBoot
             || dsiSDEnable != Config::DSiSDEnable
             || dsiSDPath != Config::DSiSDPath
             || dsiSDSize != Config::DSiSDSize
@@ -271,6 +275,7 @@ void EmuSettingsDialog::done(int r)
             Config::DSiBIOS7Path = dsiBios7Path;
             Config::DSiFirmwarePath = dsiFirmwarePath;
             Config::DSiNANDPath = dsiNANDPath;
+            Config::DSiFullBIOSBoot = dsiFullBiosBoot;
 
             Config::DSiSDEnable = dsiSDEnable;
             Config::DSiSDPath = dsiSDPath;

--- a/src/frontend/qt_sdl/EmuSettingsDialog.ui
+++ b/src/frontend/qt_sdl/EmuSettingsDialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>575</width>
-    <height>370</height>
+    <height>416</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -206,155 +206,6 @@
        <string>DSi-mode</string>
       </attribute>
       <layout class="QGridLayout" name="gridLayout_2">
-       <item row="9" column="0">
-        <widget class="QCheckBox" name="cbDSiSDReadOnly">
-         <property name="whatsThis">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Make the emulated SD card read-only.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-         </property>
-         <property name="text">
-          <string>Read-only SD</string>
-         </property>
-        </widget>
-       </item>
-       <item row="10" column="2">
-        <widget class="QPushButton" name="btnDSiSDFolderBrowse">
-         <property name="text">
-          <string>Browse...</string>
-         </property>
-        </widget>
-       </item>
-       <item row="5" column="0" colspan="3">
-        <widget class="QLabel" name="label_14">
-         <property name="text">
-          <string/>
-         </property>
-        </widget>
-       </item>
-       <item row="10" column="0">
-        <widget class="QCheckBox" name="cbDSiSDFolder">
-         <property name="whatsThis">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Sync the emulated SD card to the given folder. The folder's contents will be copied to the SD image, and any change made to the SD image will be reflected to the folder.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-         </property>
-         <property name="text">
-          <string>Sync SD to folder:</string>
-         </property>
-        </widget>
-       </item>
-       <item row="8" column="1">
-        <widget class="QComboBox" name="cbxDSiSDSize">
-         <property name="whatsThis">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Size of the SD image.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;If set to Auto:&lt;/p&gt;&lt;p&gt;* if an image file exists, the volume size will be that of the image file&lt;/p&gt;&lt;p&gt;* if no image file exists and folder sync is enabled, the volume size will be determined from the synced folder's contents&lt;/p&gt;&lt;p&gt;* otherwise, the volume size will default to 512 MB&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-         </property>
-        </widget>
-       </item>
-       <item row="10" column="1">
-        <widget class="QLineEdit" name="txtDSiSDFolder">
-         <property name="whatsThis">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Sync the emulated SD card to the given folder. The folder's contents will be copied to the SD image, and any change made to the SD image will be reflected to the folder.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-         </property>
-        </widget>
-       </item>
-       <item row="3" column="0">
-        <widget class="QLabel" name="label_7">
-         <property name="text">
-          <string>DSi firmware:</string>
-         </property>
-        </widget>
-       </item>
-       <item row="3" column="2">
-        <widget class="QPushButton" name="btnDSiFirmwareBrowse">
-         <property name="text">
-          <string>Browse...</string>
-         </property>
-        </widget>
-       </item>
-       <item row="2" column="0">
-        <widget class="QLabel" name="label_6">
-         <property name="text">
-          <string>DSi ARM7 BIOS:</string>
-         </property>
-        </widget>
-       </item>
-       <item row="4" column="1">
-        <widget class="QPathInput" name="txtDSiNANDPath">
-         <property name="whatsThis">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;DSi NAND dump&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;Should have 'nocash footer' at the end&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-         </property>
-        </widget>
-       </item>
-       <item row="7" column="1">
-        <widget class="QPathInput" name="txtDSiSDPath">
-         <property name="whatsThis">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;SD image file for emulating the DSi's SD card. A blank image file will be created if it doesn't already exist.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-         </property>
-        </widget>
-       </item>
-       <item row="3" column="1">
-        <widget class="QPathInput" name="txtDSiFirmwarePath">
-         <property name="whatsThis">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;DSi-mode firmware (used for DS-mode backwards compatibility)&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;Size should be 128 KB&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-         </property>
-        </widget>
-       </item>
-       <item row="1" column="0">
-        <widget class="QLabel" name="label_5">
-         <property name="text">
-          <string>DSi ARM9 BIOS:</string>
-         </property>
-        </widget>
-       </item>
-       <item row="8" column="0">
-        <widget class="QLabel" name="label_13">
-         <property name="text">
-          <string>Image size:</string>
-         </property>
-        </widget>
-       </item>
-       <item row="6" column="0" colspan="3">
-        <widget class="QCheckBox" name="cbDSiSDEnable">
-         <property name="whatsThis">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Simulate a SD card being inserted in the DSi's SD slot.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-         </property>
-         <property name="text">
-          <string>Enable DSi SD card</string>
-         </property>
-        </widget>
-       </item>
-       <item row="7" column="2">
-        <widget class="QPushButton" name="btnDSiSDBrowse">
-         <property name="text">
-          <string>Browse...</string>
-         </property>
-        </widget>
-       </item>
-       <item row="2" column="2">
-        <widget class="QPushButton" name="btnDSiBIOS7Browse">
-         <property name="text">
-          <string>Browse...</string>
-         </property>
-        </widget>
-       </item>
-       <item row="2" column="1">
-        <widget class="QPathInput" name="txtDSiBIOS7Path">
-         <property name="whatsThis">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;DSi-mode ARM7 BIOS&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;Size should be 64 KB&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-         </property>
-        </widget>
-       </item>
-       <item row="7" column="0">
-        <widget class="QLabel" name="label_10">
-         <property name="text">
-          <string>SD card image:</string>
-         </property>
-        </widget>
-       </item>
-       <item row="1" column="2">
-        <widget class="QPushButton" name="btnDSiBIOS9Browse">
-         <property name="text">
-          <string>Browse...</string>
-         </property>
-        </widget>
-       </item>
        <item row="4" column="0">
         <widget class="QLabel" name="label_8">
          <property name="text">
@@ -375,10 +226,48 @@
          </property>
         </widget>
        </item>
-       <item row="4" column="2">
-        <widget class="QPushButton" name="btnDSiNANDBrowse">
+       <item row="12" column="1">
+        <widget class="QLineEdit" name="txtDSiSDFolder">
+         <property name="whatsThis">
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Sync the emulated SD card to the given folder. The folder's contents will be copied to the SD image, and any change made to the SD image will be reflected to the folder.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         </property>
+        </widget>
+       </item>
+       <item row="12" column="0">
+        <widget class="QCheckBox" name="cbDSiSDFolder">
+         <property name="whatsThis">
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Sync the emulated SD card to the given folder. The folder's contents will be copied to the SD image, and any change made to the SD image will be reflected to the folder.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         </property>
+         <property name="text">
+          <string>Sync SD to folder:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="7" column="0" colspan="3">
+        <widget class="QLabel" name="label_14">
+         <property name="text">
+          <string/>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="0">
+        <widget class="QLabel" name="label_5">
+         <property name="text">
+          <string>DSi ARM9 BIOS:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="2">
+        <widget class="QPushButton" name="btnDSiBIOS9Browse">
          <property name="text">
           <string>Browse...</string>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="1">
+        <widget class="QPathInput" name="txtDSiBIOS7Path">
+         <property name="whatsThis">
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;DSi-mode ARM7 BIOS&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;Size should be 64 KB&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
          </property>
         </widget>
        </item>
@@ -386,6 +275,127 @@
         <widget class="QLabel" name="label_15">
          <property name="text">
           <string>DSi mode requires external DSi BIOS/firmware/NAND</string>
+         </property>
+        </widget>
+       </item>
+       <item row="10" column="0">
+        <widget class="QLabel" name="label_13">
+         <property name="text">
+          <string>Image size:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="0">
+        <widget class="QLabel" name="label_6">
+         <property name="text">
+          <string>DSi ARM7 BIOS:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="2">
+        <widget class="QPushButton" name="btnDSiBIOS7Browse">
+         <property name="text">
+          <string>Browse...</string>
+         </property>
+        </widget>
+       </item>
+       <item row="9" column="2">
+        <widget class="QPushButton" name="btnDSiSDBrowse">
+         <property name="text">
+          <string>Browse...</string>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="0">
+        <widget class="QLabel" name="label_7">
+         <property name="text">
+          <string>DSi firmware:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="11" column="0">
+        <widget class="QCheckBox" name="cbDSiSDReadOnly">
+         <property name="whatsThis">
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Make the emulated SD card read-only.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         </property>
+         <property name="text">
+          <string>Read-only SD</string>
+         </property>
+        </widget>
+       </item>
+       <item row="8" column="0" colspan="3">
+        <widget class="QCheckBox" name="cbDSiSDEnable">
+         <property name="whatsThis">
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Simulate a SD card being inserted in the DSi's SD slot.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         </property>
+         <property name="text">
+          <string>Enable DSi SD card</string>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="2">
+        <widget class="QPushButton" name="btnDSiFirmwareBrowse">
+         <property name="text">
+          <string>Browse...</string>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="2">
+        <widget class="QPushButton" name="btnDSiNANDBrowse">
+         <property name="text">
+          <string>Browse...</string>
+         </property>
+        </widget>
+       </item>
+       <item row="9" column="1">
+        <widget class="QPathInput" name="txtDSiSDPath">
+         <property name="whatsThis">
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;SD image file for emulating the DSi's SD card. A blank image file will be created if it doesn't already exist.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="1">
+        <widget class="QPathInput" name="txtDSiFirmwarePath">
+         <property name="whatsThis">
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;DSi-mode firmware (used for DS-mode backwards compatibility)&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;Size should be 128 KB&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="1">
+        <widget class="QPathInput" name="txtDSiNANDPath">
+         <property name="whatsThis">
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;DSi NAND dump&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;Should have 'nocash footer' at the end&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         </property>
+        </widget>
+       </item>
+       <item row="10" column="1">
+        <widget class="QComboBox" name="cbxDSiSDSize">
+         <property name="whatsThis">
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Size of the SD image.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;If set to Auto:&lt;/p&gt;&lt;p&gt;* if an image file exists, the volume size will be that of the image file&lt;/p&gt;&lt;p&gt;* if no image file exists and folder sync is enabled, the volume size will be determined from the synced folder's contents&lt;/p&gt;&lt;p&gt;* otherwise, the volume size will default to 512 MB&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         </property>
+        </widget>
+       </item>
+       <item row="9" column="0">
+        <widget class="QLabel" name="label_10">
+         <property name="text">
+          <string>SD card image:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="12" column="2">
+        <widget class="QPushButton" name="btnDSiSDFolderBrowse">
+         <property name="text">
+          <string>Browse...</string>
+         </property>
+        </widget>
+       </item>
+       <item row="5" column="0" colspan="3">
+        <widget class="QCheckBox" name="cbDSiFullBIOSBoot">
+         <property name="whatsThis">
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Boot the system from scratch by running the full boot ROMs, instead of starting with the second-stage loader. Requires a full BIOS/bootROM dump.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         </property>
+         <property name="text">
+          <string>Full BIOS boot</string>
          </property>
         </widget>
        </item>

--- a/src/frontend/qt_sdl/Platform.cpp
+++ b/src/frontend/qt_sdl/Platform.cpp
@@ -219,6 +219,7 @@ bool GetConfigBool(ConfigEntry entry)
     case DSiSD_FolderSync: return Config::DSiSDFolderSync != 0;
 
     case Firm_OverrideSettings: return Config::FirmwareOverrideSettings != 0;
+    case DSi_FullBIOSBoot: return Config::DSiFullBIOSBoot != 0;
     }
 
     return false;


### PR DESCRIPTION
Added a config option for this so that this can be enabled or disabled, while for now it's not very useful for most people.

However, more importantly, it fixes the default SPI firmware/settings image as well, as it was slightly wrong before (though it's only noticeable when you try to get the bootroms to boot anything with it).

Also added IO regs for DSi GPIO, but those don't do anything yet.