### PR TITLE
Set LSApplicationCategoryType to games

### DIFF
--- a/res/melon.plist.in
+++ b/res/melon.plist.in
@@ -16,6 +16,8 @@
     <string>${melonDS_VERSION}</string>
     <key>CFBundleShortVersionString</key>
     <string>${melonDS_VERSION}</string> 
+    <key>LSApplicationCategoryType</key>
+    <string>public.app-category.games</string>
     <key>NSHumanReadableCopyright</key>
     <string>Licensed under GPLv3</string>
     <key>NSPrincipalClass</key>


### PR DESCRIPTION
https://developer.apple.com/documentation/bundleresources/information_property_list/lsapplicationcategorytype Adds it to the games folder in the macOS Launchpad