### PR TITLE
Expose SRAM pointers for frontends that manage save data their own way

### DIFF
--- a/src/GBACart.cpp
+++ b/src/GBACart.cpp
@@ -100,6 +100,15 @@ void CartCommon::SRAMWrite(u32 addr, u8 val)
 {
 }
 
+u8* CartCommon::GetSaveMemory() const
+{
+    return nullptr;
+}
+
+u32 CartCommon::GetSaveMemoryLength() const
+{
+    return 0;
+}
 
 CartGame::CartGame(u8* rom, u32 len) : CartCommon()
 {
@@ -332,6 +341,16 @@ void CartGame::SRAMWrite(u32 addr, u8 val)
     default:
         break;
     }
+}
+
+u8* CartGame::GetSaveMemory() const
+{
+    return SRAM;
+}
+
+u32 CartGame::GetSaveMemoryLength() const
+{
+    return SRAMLength;
 }
 
 void CartGame::ProcessGPIO()
@@ -876,6 +895,16 @@ u8 SRAMRead(u32 addr)
 void SRAMWrite(u32 addr, u8 val)
 {
     if (Cart) Cart->SRAMWrite(addr, val);
+}
+
+u8* GetSaveMemory()
+{
+    return Cart ? Cart->GetSaveMemory() : nullptr;
+}
+
+u32 GetSaveMemoryLength()
+{
+    return Cart ? Cart->GetSaveMemoryLength() : 0;
 }
 
 }

--- a/src/GBACart.h
+++ b/src/GBACart.h
@@ -49,6 +49,9 @@ public:
 
     virtual u8 SRAMRead(u32 addr);
     virtual void SRAMWrite(u32 addr, u8 val);
+
+    virtual u8* GetSaveMemory() const;
+    virtual u32 GetSaveMemoryLength() const;
 };
 
 // CartGame -- regular retail game cart (ROM, SRAM)
@@ -74,6 +77,8 @@ public:
     virtual u8 SRAMRead(u32 addr) override;
     virtual void SRAMWrite(u32 addr, u8 val) override;
 
+    virtual u8* GetSaveMemory() const override;
+    virtual u32 GetSaveMemoryLength() const override;
 protected:
     virtual void ProcessGPIO();
 
@@ -206,6 +211,19 @@ void ROMWrite(u32 addr, u16 val);
 
 u8 SRAMRead(u32 addr);
 void SRAMWrite(u32 addr, u8 val);
+
+/// This function is intended to allow frontends to save and load SRAM
+/// without using melonDS APIs.
+/// Modifying the emulated SRAM for any other reason is strongly discouraged.
+/// The returned pointer may be invalidated if the emulator is reset,
+/// or when a new game is loaded.
+/// Consequently, don't store the returned pointer for any longer than necessary.
+/// @returns Pointer to this cart's SRAM if a cart is loaded and supports SRAM, otherwise \c nullptr.
+u8* GetSaveMemory();
+
+/// @returns The length of the buffer returned by ::GetSaveMemory()
+/// if a cart is loaded and supports SRAM, otherwise zero.
+u32 GetSaveMemoryLength();
 
 }
 

--- a/src/NDSCart.cpp
+++ b/src/NDSCart.cpp
@@ -383,6 +383,16 @@ void CartCommon::SetIRQ()
     NDS::SetIRQ(1, NDS::IRQ_CartIREQMC);
 }
 
+u8 *CartCommon::GetSaveMemory() const
+{
+    return nullptr;
+}
+
+u32 CartCommon::GetSaveMemoryLength() const
+{
+    return 0;
+}
+
 void CartCommon::ReadROM(u32 addr, u32 len, u8* data, u32 offset)
 {
     if (addr >= ROMLength) return;
@@ -551,6 +561,16 @@ u8 CartRetail::SPIWrite(u8 val, u32 pos, bool last)
     case 3: return SRAMWrite_FLASH(val, pos, last);
     default: return 0xFF;
     }
+}
+
+u8 *CartRetail::GetSaveMemory() const
+{
+    return SRAM;
+}
+
+u32 CartRetail::GetSaveMemoryLength() const
+{
+    return SRAMLength;
 }
 
 void CartRetail::ReadROM_B7(u32 addr, u32 len, u8* data, u32 offset)
@@ -1730,6 +1750,16 @@ void SetupDirectBoot(std::string romname)
 {
     if (Cart)
         Cart->SetupDirectBoot(romname);
+}
+
+u8* GetSaveMemory()
+{
+    return Cart ? Cart->GetSaveMemory() : nullptr;
+}
+
+u32 GetSaveMemoryLength()
+{
+    return Cart ? Cart->GetSaveMemoryLength() : 0;
 }
 
 void EjectCart()

--- a/src/NDSCart.h
+++ b/src/NDSCart.h
@@ -52,6 +52,9 @@ public:
 
     virtual u8 SPIWrite(u8 val, u32 pos, bool last);
 
+    virtual u8* GetSaveMemory() const;
+    virtual u32 GetSaveMemoryLength() const;
+
 protected:
     void ReadROM(u32 addr, u32 len, u8* data, u32 offset);
 
@@ -87,6 +90,9 @@ public:
     virtual int ROMCommandStart(u8* cmd, u8* data, u32 len) override;
 
     virtual u8 SPIWrite(u8 val, u32 pos, bool last) override;
+
+    virtual u8* GetSaveMemory() const override;
+    virtual u32 GetSaveMemoryLength() const override;
 
 protected:
     void ReadROM_B7(u32 addr, u32 len, u8* data, u32 offset);
@@ -222,6 +228,19 @@ void DecryptSecureArea(u8* out);
 bool LoadROM(const u8* romdata, u32 romlen);
 void LoadSave(const u8* savedata, u32 savelen);
 void SetupDirectBoot(std::string romname);
+
+/// This function is intended to allow frontends to save and load SRAM
+/// without using melonDS APIs.
+/// Modifying the emulated SRAM for any other reason is strongly discouraged.
+/// The returned pointer may be invalidated if the emulator is reset,
+/// or when a new game is loaded.
+/// Consequently, don't store the returned pointer for any longer than necessary.
+/// @returns Pointer to this cart's SRAM if a cart is loaded and supports SRAM, otherwise \c nullptr.
+u8* GetSaveMemory();
+
+/// @returns The length of the buffer returned by ::GetSaveMemory()
+/// if a cart is loaded and supports SRAM, otherwise zero.
+u32 GetSaveMemoryLength();
 
 void EjectCart();
 

--- a/src/RTC.cpp
+++ b/src/RTC.cpp
@@ -30,6 +30,9 @@ using Platform::LogLevel;
 namespace RTC
 {
 
+/// This value represents the Nintendo DS IO register,
+/// \em not the value of the system's clock.
+/// The actual system time is taken directly from the host.
 u16 IO;
 
 u8 Input;


### PR DESCRIPTION
I wanted to use libretro's APIs for the [new libretro core I'm writing](https://github.com/JesseTG/melonds-ds) for melonDS, so that it can take advantage of whatever benefits the frontend provides (the details of which are beyond the scope of this post).

In order to do that, I need to return a pointer to the emulated SRAM from [`retro_get_memory_data`](https://github.com/libretro/RetroArch/blob/master/libretro-common/include/libretro.h#L3956-L3958), so that the frontend knows where to load and save the game data. However, the existing APIs in [NDSCart.h](https://github.com/melonDS-emu/melonDS/blob/master/src/NDSCart.h) and [GBACart.h](https://github.com/melonDS-emu/melonDS/blob/master/src/GBACart.h) are insufficient for this purpose.

This pull request exposes a pointer to the SRAM for supported NDS and GBA carts, i.e. subclasses of `NDSCart::CartRetail` and `GBACart::CartRetail` respectively. For other types of cartridges, the returned pointer is `nullptr` and the returned SRAM size is `0`.

I was warned that arbitrary modifications to SRAM (which this PR allows) can cause problems. I've added doc comments to this effect.

I have tested the NDS portion of this PR on my libretro core, and it works like a charm. I have not tested the GBA portion yet.