### PR TITLE
Fixed unhandled error status for LastSep(std::string)

### DIFF
--- a/src/frontend/qt_sdl/ROMManager.cpp
+++ b/src/frontend/qt_sdl/ROMManager.cpp
@@ -521,7 +521,8 @@ bool LoadROM(QStringList filepath, bool reset)
         filelen = (u32)len;
 
         int pos = LastSep(filename);
-        basepath = filename.substr(0, pos);
+        if(pos != -1)
+            basepath = filename.substr(0, pos);
         romname = filename.substr(pos+1);
     }
 #ifdef ARCHIVE_SUPPORT_ENABLED


### PR DESCRIPTION
fixes #1644

when `int LastSep(std::string)` gets a string, it will scan it from the back until a `/` or `\\` character/s are found.
If the string has none of these characters, -1 is returned.
https://github.com/melonDS-emu/melonDS/blob/79dfb8dc8f356834f0b6cf7baf73f77552b08923/src/frontend/qt_sdl/ROMManager.cpp#L524 did not account for this return value, generating an invalid result.

A simple check for the result of -1 has been added.
This works as `basepath` is initialized to empty, and `std::string GetAssetPath(bool, std::string, std::string, std::string)` correctly manages a situation where `basepath` is empty by only returning the file name with an edited extension. 

Refering to the examples in the issue, the output is now:
`/home/user/romName.nds`: `/home/user/romName.sav`
`./romName.nds`: `./romName.sav`
`romName.nds`: `romName.sav`