### PR TITLE
Support loading Zstandard-compressed ROMs

### DIFF
--- a/.github/workflows/build-ubuntu-aarch64.yml
+++ b/.github/workflows/build-ubuntu-aarch64.yml
@@ -33,7 +33,7 @@ jobs:
         rm /etc/apt/sources.list
         mv /etc/apt/sources.list{.new,}
         apt update
-        DEBIAN_FRONTEND=noninteractive apt install -y {gcc-10,g++-10,pkg-config}-aarch64-linux-gnu {libsdl2,qtbase5,qtbase5-private,qtmultimedia5,libslirp,libarchive}-dev:arm64 cmake extra-cmake-modules dpkg-dev
+        DEBIAN_FRONTEND=noninteractive apt install -y {gcc-10,g++-10,pkg-config}-aarch64-linux-gnu {libsdl2,qtbase5,qtbase5-private,qtmultimedia5,libslirp,libarchive,libzstd}-dev:arm64 cmake extra-cmake-modules dpkg-dev
     - name: Configure
       shell: bash
       run: |

--- a/.github/workflows/build-ubuntu-aarch64.yml
+++ b/.github/workflows/build-ubuntu-aarch64.yml
@@ -33,7 +33,7 @@ jobs:
         rm /etc/apt/sources.list
         mv /etc/apt/sources.list{.new,}
         apt update
-        DEBIAN_FRONTEND=noninteractive apt install -y {gcc-10,g++-10,pkg-config}-aarch64-linux-gnu {libsdl2,qtbase5,qtbase5-private,qtmultimedia5,libslirp,libarchive,libzstd}-dev:arm64 cmake extra-cmake-modules dpkg-dev
+        DEBIAN_FRONTEND=noninteractive apt install -y {gcc-10,g++-10,pkg-config}-aarch64-linux-gnu {libsdl2,qtbase5,qtbase5-private,qtmultimedia5,libslirp,libarchive,libzstd}-dev:arm64 zstd:arm64 cmake extra-cmake-modules dpkg-dev
     - name: Configure
       shell: bash
       run: |

--- a/.github/workflows/build-ubuntu.yml
+++ b/.github/workflows/build-ubuntu.yml
@@ -19,7 +19,7 @@ jobs:
       run: |
         sudo rm -f /etc/apt/sources.list.d/dotnetdev.list /etc/apt/sources.list.d/microsoft-prod.list
         sudo apt update
-        sudo apt install cmake extra-cmake-modules libcurl4-gnutls-dev libpcap0.8-dev libsdl2-dev qt5-default qtbase5-private-dev qtmultimedia5-dev libslirp0 libslirp-dev libarchive-dev --allow-downgrades
+        sudo apt install cmake extra-cmake-modules libcurl4-gnutls-dev libpcap0.8-dev libsdl2-dev qt5-default qtbase5-private-dev qtmultimedia5-dev libslirp0 libslirp-dev libarchive-dev libzstd-dev --allow-downgrades
     - name: Create build environment
       run: mkdir ${{runner.workspace}}/build
     - name: Configure

--- a/.github/workflows/build-ubuntu.yml
+++ b/.github/workflows/build-ubuntu.yml
@@ -19,7 +19,7 @@ jobs:
       run: |
         sudo rm -f /etc/apt/sources.list.d/dotnetdev.list /etc/apt/sources.list.d/microsoft-prod.list
         sudo apt update
-        sudo apt install cmake extra-cmake-modules libcurl4-gnutls-dev libpcap0.8-dev libsdl2-dev qt5-default qtbase5-private-dev qtmultimedia5-dev libslirp0 libslirp-dev libarchive-dev libzstd-dev --allow-downgrades
+        sudo apt install cmake extra-cmake-modules libcurl4-gnutls-dev libpcap0.8-dev libsdl2-dev qt5-default qtbase5-private-dev qtmultimedia5-dev libslirp0 libslirp-dev libarchive-dev zstd libzstd-dev --allow-downgrades
     - name: Create build environment
       run: mkdir ${{runner.workspace}}/build
     - name: Configure

--- a/README.md
+++ b/README.md
@@ -35,9 +35,9 @@ As for the rest, the interface should be pretty straightforward. If you have a q
 
 ### Linux
 1. Install dependencies:
-   * Ubuntu 22.04: `sudo apt install cmake extra-cmake-modules libcurl4-gnutls-dev libpcap0.8-dev libsdl2-dev qtbase5-dev qtbase5-private-dev qtmultimedia5-dev libslirp-dev libarchive-dev`
-   * Older Ubuntu: `sudo apt install cmake extra-cmake-modules libcurl4-gnutls-dev libpcap0.8-dev libsdl2-dev qt5-default qtbase5-private-dev qtmultimedia5-dev libslirp-dev libarchive-dev`
-   * Arch Linux: `sudo pacman -S base-devel cmake extra-cmake-modules git libpcap sdl2 qt5-base qt5-multimedia libslirp libarchive`
+   * Ubuntu 22.04: `sudo apt install cmake extra-cmake-modules libcurl4-gnutls-dev libpcap0.8-dev libsdl2-dev qtbase5-dev qtbase5-private-dev qtmultimedia5-dev libslirp-dev libarchive-dev libzstd-dev`
+   * Older Ubuntu: `sudo apt install cmake extra-cmake-modules libcurl4-gnutls-dev libpcap0.8-dev libsdl2-dev qt5-default qtbase5-private-dev qtmultimedia5-dev libslirp-dev libarchive-dev libzstd-dev`
+   * Arch Linux: `sudo pacman -S base-devel cmake extra-cmake-modules git libpcap sdl2 qt5-base qt5-multimedia libslirp libarchive zstd`
 3. Download the melonDS repository and prepare:
    ```bash
    git clone https://github.com/melonDS-emu/melonDS
@@ -64,7 +64,7 @@ As for the rest, the interface should be pretty straightforward. If you have a q
    cd melonDS
    ```
 #### Dynamic builds (with DLLs)
-5. Install dependencies: `pacman -S mingw-w64-x86_64-{cmake,SDL2,toolchain,qt5-base,qt5-svg,qt5-multimedia,libslirp,libarchive}`
+5. Install dependencies: `pacman -S mingw-w64-x86_64-{cmake,SDL2,toolchain,qt5-base,qt5-svg,qt5-multimedia,libslirp,libarchive,zstd}`
 6. Compile:
    ```bash
    cmake -B build
@@ -75,7 +75,7 @@ As for the rest, the interface should be pretty straightforward. If you have a q
 If everything went well, melonDS and the libraries it needs should now be in the `dist` folder.
 
 #### Static builds (without DLLs, standalone executable)
-5. Install dependencies: `pacman -S mingw-w64-x86_64-{cmake,SDL2,toolchain,qt5-static,libslirp,libarchive}`
+5. Install dependencies: `pacman -S mingw-w64-x86_64-{cmake,SDL2,toolchain,qt5-static,libslirp,libarchive,zstd}`
 6. Compile:
    ```bash
    cmake -B build -DBUILD_STATIC=ON -DCMAKE_PREFIX_PATH=/mingw64/qt5-static
@@ -85,7 +85,7 @@ If everything went well, melonDS should now be in the `build` folder.
 
 ### macOS
 1. Install the [Homebrew Package Manager](https://brew.sh)
-2. Install dependencies: `brew install git pkg-config cmake sdl2 qt@6 libslirp libarchive`
+2. Install dependencies: `brew install git pkg-config cmake sdl2 qt@6 libslirp libarchive zstd`
 3. Download the melonDS repository and prepare:
    ```zsh
    git clone https://github.com/melonDS-emu/melonDS

--- a/res/melon.plist.in
+++ b/res/melon.plist.in
@@ -39,6 +39,10 @@
                 <string>srl</string>
                 <string>dsi</string>
                 <string>ids</string>
+                <string>nds.zst</string>
+                <string>srl.zst</string>
+                <string>dsi.zst</string>
+                <string>ids.zst</string>
             </array>
             <key>CFBundleTypeRole</key>
             <string>Viewer</string>
@@ -50,6 +54,8 @@
             <array>
                 <string>gba</string>
                 <string>agb</string>
+                <string>gba.zst</string>
+                <string>agb.zst</string>
             </array>
             <key>CFBundleTypeRole</key>
             <string>Viewer</string>

--- a/src/frontend/qt_sdl/CMakeLists.txt
+++ b/src/frontend/qt_sdl/CMakeLists.txt
@@ -83,6 +83,9 @@ pkg_check_modules(SDL2 REQUIRED IMPORTED_TARGET sdl2)
 pkg_check_modules(Slirp REQUIRED IMPORTED_TARGET slirp)
 pkg_check_modules(LibArchive REQUIRED IMPORTED_TARGET libarchive)
 
+find_package(zstd CONFIG)
+cmake_dependent_option(ENABLE_ZSTD "Enable support for Zstandard-compressed ROMs" ON "zstd_FOUND" OFF)
+
 fix_interface_includes(PkgConfig::SDL2 PkgConfig::Slirp PkgConfig::LibArchive)
 
 add_compile_definitions(ARCHIVE_SUPPORT_ENABLED)
@@ -156,6 +159,15 @@ endif()
 target_link_libraries(melonDS PRIVATE core)
 target_link_libraries(melonDS PRIVATE PkgConfig::SDL2 PkgConfig::Slirp PkgConfig::LibArchive)
 target_link_libraries(melonDS PRIVATE ${QT_LINK_LIBS} ${CMAKE_DL_LIBS})
+
+if (ENABLE_ZSTD)
+    target_compile_definitions(melonDS PRIVATE ZSTD_ENABLED)
+    if (BUILD_STATIC)
+        target_link_libraries(melonDS PRIVATE zstd::libzstd_static)
+    else()
+        target_link_libraries(melonDS PRIVATE zstd::libzstd_shared)
+    endif()
+endif()
 
 if (UNIX)
     option(PORTABLE "Make a portable build that looks for its configuration in the current directory" OFF)

--- a/src/frontend/qt_sdl/CMakeLists.txt
+++ b/src/frontend/qt_sdl/CMakeLists.txt
@@ -82,9 +82,9 @@ endif()
 pkg_check_modules(SDL2 REQUIRED IMPORTED_TARGET sdl2)
 pkg_check_modules(Slirp REQUIRED IMPORTED_TARGET slirp)
 pkg_check_modules(LibArchive REQUIRED IMPORTED_TARGET libarchive)
+pkg_check_modules(Zstd IMPORTED_TARGET libzstd)
 
-find_package(zstd CONFIG)
-cmake_dependent_option(ENABLE_ZSTD "Enable support for Zstandard-compressed ROMs" ON "zstd_FOUND" OFF)
+cmake_dependent_option(ENABLE_ZSTD "Enable support for Zstandard-compressed ROMs" ON "Zstd_FOUND" OFF)
 
 fix_interface_includes(PkgConfig::SDL2 PkgConfig::Slirp PkgConfig::LibArchive)
 
@@ -162,11 +162,7 @@ target_link_libraries(melonDS PRIVATE ${QT_LINK_LIBS} ${CMAKE_DL_LIBS})
 
 if (ENABLE_ZSTD)
     target_compile_definitions(melonDS PRIVATE ZSTD_ENABLED)
-    if (BUILD_STATIC)
-        target_link_libraries(melonDS PRIVATE zstd::libzstd_static)
-    else()
-        target_link_libraries(melonDS PRIVATE zstd::libzstd_shared)
-    endif()
+    target_link_libraries(melonDS PRIVATE PkgConfig::Zstd)
 endif()
 
 if (UNIX)

--- a/src/frontend/qt_sdl/CMakeLists.txt
+++ b/src/frontend/qt_sdl/CMakeLists.txt
@@ -82,9 +82,7 @@ endif()
 pkg_check_modules(SDL2 REQUIRED IMPORTED_TARGET sdl2)
 pkg_check_modules(Slirp REQUIRED IMPORTED_TARGET slirp)
 pkg_check_modules(LibArchive REQUIRED IMPORTED_TARGET libarchive)
-pkg_check_modules(Zstd IMPORTED_TARGET libzstd)
-
-cmake_dependent_option(ENABLE_ZSTD "Enable support for Zstandard-compressed ROMs" ON "Zstd_FOUND" OFF)
+pkg_check_modules(Zstd REQUIRED IMPORTED_TARGET libzstd)
 
 fix_interface_includes(PkgConfig::SDL2 PkgConfig::Slirp PkgConfig::LibArchive)
 
@@ -157,13 +155,8 @@ else()
     target_include_directories(melonDS PUBLIC ${Qt5Gui_PRIVATE_INCLUDE_DIRS})
 endif()
 target_link_libraries(melonDS PRIVATE core)
-target_link_libraries(melonDS PRIVATE PkgConfig::SDL2 PkgConfig::Slirp PkgConfig::LibArchive)
+target_link_libraries(melonDS PRIVATE PkgConfig::SDL2 PkgConfig::Slirp PkgConfig::LibArchive PkgConfig::Zstd)
 target_link_libraries(melonDS PRIVATE ${QT_LINK_LIBS} ${CMAKE_DL_LIBS})
-
-if (ENABLE_ZSTD)
-    target_compile_definitions(melonDS PRIVATE ZSTD_ENABLED)
-    target_link_libraries(melonDS PRIVATE PkgConfig::Zstd)
-endif()
 
 if (UNIX)
     option(PORTABLE "Make a portable build that looks for its configuration in the current directory" OFF)

--- a/src/frontend/qt_sdl/ROMManager.cpp
+++ b/src/frontend/qt_sdl/ROMManager.cpp
@@ -22,9 +22,7 @@
 #include <string>
 #include <utility>
 
-#ifdef ZSTD_ENABLED
 #include <zstd.h>
-#endif
 #ifdef ARCHIVE_SUPPORT_ENABLED
 #include "ArchiveUtil.h"
 #endif
@@ -481,7 +479,6 @@ bool LoadBIOS()
     return true;
 }
 
-#ifdef ZSTD_ENABLED
 u32 DecompressROM(const u8* inContent, const u32 inSize, u8** outContent)
 {
     u64 realSize = ZSTD_getFrameContentSize(inContent, inSize);
@@ -503,7 +500,6 @@ u32 DecompressROM(const u8* inContent, const u32 inSize, u8** outContent)
     *outContent = realContent;
     return realSize;
 }
-#endif
 
 bool LoadROM(QStringList filepath, bool reset)
 {
@@ -546,7 +542,6 @@ bool LoadROM(QStringList filepath, bool reset)
         fclose(f);
         filelen = (u32)len;
 
-#if ZSTD_ENABLED
         if (filename.length() > 4 && filename.substr(filename.length() - 4) == ".zst")
         {
             u8* outContent = nullptr;
@@ -565,7 +560,6 @@ bool LoadROM(QStringList filepath, bool reset)
                 return false;
             }
         }
-#endif
 
         int pos = LastSep(filename);
         if(pos != -1)
@@ -729,7 +723,6 @@ bool LoadGBAROM(QStringList filepath)
         fclose(f);
         filelen = (u32)len;
 
-#if ZSTD_ENABLED
         if (filename.length() > 4 && filename.substr(filename.length() - 4) == ".zst")
         {
             u8* outContent = nullptr;
@@ -748,7 +741,6 @@ bool LoadGBAROM(QStringList filepath)
                 return false;
             }
         }
-#endif
 
         int pos = LastSep(filename);
         basepath = filename.substr(0, pos);

--- a/src/frontend/qt_sdl/ROMManager.cpp
+++ b/src/frontend/qt_sdl/ROMManager.cpp
@@ -21,8 +21,10 @@
 
 #include <string>
 #include <utility>
-#include <zstd.h>
 
+#ifdef ZSTD_ENABLED
+#include <zstd.h>
+#endif
 #ifdef ARCHIVE_SUPPORT_ENABLED
 #include "ArchiveUtil.h"
 #endif
@@ -479,6 +481,7 @@ bool LoadBIOS()
     return true;
 }
 
+#ifdef ZSTD_ENABLED
 u32 DecompressROM(const u8* inContent, const u32 inSize, u8** outContent)
 {
     u64 realSize = ZSTD_getFrameContentSize(inContent, inSize);
@@ -500,6 +503,7 @@ u32 DecompressROM(const u8* inContent, const u32 inSize, u8** outContent)
     *outContent = realContent;
     return realSize;
 }
+#endif
 
 bool LoadROM(QStringList filepath, bool reset)
 {

--- a/src/frontend/qt_sdl/ROMManager.cpp
+++ b/src/frontend/qt_sdl/ROMManager.cpp
@@ -21,6 +21,7 @@
 
 #include <string>
 #include <utility>
+#include <zstd.h>
 
 #ifdef ARCHIVE_SUPPORT_ENABLED
 #include "ArchiveUtil.h"
@@ -478,6 +479,27 @@ bool LoadBIOS()
     return true;
 }
 
+u32 DecompressROM(const u8* inContent, const u32 inSize, u8** outContent)
+{
+    u64 realSize = ZSTD_getFrameContentSize(inContent, inSize);
+
+    if (realSize == ZSTD_CONTENTSIZE_UNKNOWN || realSize == ZSTD_CONTENTSIZE_ERROR || realSize > 0x40000000)
+    {
+        return 0;
+    }
+
+    u8* realContent = new u8[realSize];
+    u64 decompressed = ZSTD_decompress(realContent, realSize, inContent, inSize);
+
+    if (ZSTD_isError(decompressed))
+    {
+        delete[] realContent;
+        return 0;
+    }
+
+    *outContent = realContent;
+    return realSize;
+}
 
 bool LoadROM(QStringList filepath, bool reset)
 {
@@ -520,6 +542,27 @@ bool LoadROM(QStringList filepath, bool reset)
         fclose(f);
         filelen = (u32)len;
 
+#if ZSTD_ENABLED
+        if (filename.length() > 4 && filename.substr(filename.length() - 4) == ".zst")
+        {
+            u8* outContent = nullptr;
+            u32 decompressed = DecompressROM(filedata, len, &outContent);
+
+            if (decompressed > 0)
+            {
+                delete[] filedata;
+                filedata = outContent;
+                filelen = decompressed;
+                filename = filename.substr(0, filename.length() - 4);
+            }
+            else
+            {
+                delete[] filedata;
+                return false;
+            }
+        }
+#endif
+
         int pos = LastSep(filename);
         if(pos != -1)
             basepath = filename.substr(0, pos);
@@ -530,14 +573,14 @@ bool LoadROM(QStringList filepath, bool reset)
     {
         // file inside archive
 
-            s32 lenread = Archive::ExtractFileFromArchive(filepath.at(0), filepath.at(1), &filedata, &filelen);
-            if (lenread < 0) return false;
-            if (!filedata) return false;
-            if (lenread != filelen)
-            {
-                delete[] filedata;
-                return false;
-            }
+        s32 lenread = Archive::ExtractFileFromArchive(filepath.at(0), filepath.at(1), &filedata, &filelen);
+        if (lenread < 0) return false;
+        if (!filedata) return false;
+        if (lenread != filelen)
+        {
+            delete[] filedata;
+            return false;
+        }
 
         std::string std_archivepath = filepath.at(0).toStdString();
         basepath = std_archivepath.substr(0, LastSep(std_archivepath));
@@ -681,6 +724,27 @@ bool LoadGBAROM(QStringList filepath)
 
         fclose(f);
         filelen = (u32)len;
+
+#if ZSTD_ENABLED
+        if (filename.length() > 4 && filename.substr(filename.length() - 4) == ".zst")
+        {
+            u8* outContent = nullptr;
+            u32 decompressed = DecompressROM(filedata, len, &outContent);
+
+            if (decompressed > 0)
+            {
+                delete[] filedata;
+                filedata = outContent;
+                filelen = decompressed;
+                filename = filename.substr(0, filename.length() - 4);
+            }
+            else
+            {
+                delete[] filedata;
+                return false;
+            }
+        }
+#endif
 
         int pos = LastSep(filename);
         basepath = filename.substr(0, pos);

--- a/src/frontend/qt_sdl/main.cpp
+++ b/src/frontend/qt_sdl/main.cpp
@@ -146,7 +146,7 @@ const QStringList ArchiveExtensions
     ".tar.lz",
     ".tar.lzma", ".tlz",
     ".tar.lrz", ".tlrz",
-    ".tar.lzo", ".tzo",
+    ".tar.lzo", ".tzo"
 #endif
 };
 
@@ -1568,9 +1568,26 @@ static bool SupportedArchiveByMimetype(const QMimeType& mimetype)
     return MimeTypeInList(mimetype, ArchiveMimeTypes);
 }
 
+#ifdef ZSTD_ENABLED
+static bool ZstdNdsRomByExtension(const QString& filename)
+{
+    if (filename.endsWith(".zst", Qt::CaseInsensitive))
+        return NdsRomByExtension(filename.left(filename.size() - 4));
+}
+
+static bool ZstdGbaRomByExtension(const QString& filename)
+{
+    if (filename.endsWith(".zst", Qt::CaseInsensitive))
+        return GbaRomByExtension(filename.left(filename.size() - 4));
+}
+#endif
 
 static bool FileIsSupportedFiletype(const QString& filename, bool insideArchive = false)
 {
+#ifdef ZSTD_ENABLED
+    if (ZstdNdsRomByExtension(filename) || ZstdGbaRomByExtension(filename))
+        return true;
+#endif
     if (NdsRomByExtension(filename) || GbaRomByExtension(filename) || SupportedArchiveByExtension(filename))
         return true;
 
@@ -2207,7 +2224,14 @@ void MainWindow::dropEvent(QDropEvent* event)
     const auto matchMode = romInsideArchive ? QMimeDatabase::MatchExtension : QMimeDatabase::MatchDefault;
     const QMimeType mimetype = QMimeDatabase().mimeTypeForFile(filename, matchMode);
 
-    if (NdsRomByExtension(filename) || NdsRomByMimetype(mimetype))
+    bool isNdsRom = NdsRomByExtension(filename) || NdsRomByMimetype(mimetype);
+    bool isGbaRom = GbaRomByExtension(filename) || GbaRomByMimetype(mimetype);
+#ifdef ZSTD_ENABLED
+    isNdsRom |= ZstdNdsRomByExtension(filename);
+    isGbaRom |= ZstdGbaRomByExtension(filename);
+#endif
+
+    if (isNdsRom)
     {
         if (!ROMManager::LoadROM(file, true))
         {
@@ -2227,7 +2251,7 @@ void MainWindow::dropEvent(QDropEvent* event)
 
         updateCartInserted(false);
     }
-    else if (GbaRomByExtension(filename) || GbaRomByMimetype(mimetype))
+    else if (isGbaRom)
     {
         if (!ROMManager::LoadGBAROM(file))
         {
@@ -2452,14 +2476,26 @@ QStringList MainWindow::pickROM(bool gba)
     const QString console = gba ? "GBA" : "DS";
     const QStringList& romexts = gba ? GbaRomExtensions : NdsRomExtensions;
 
-    static const QString filterSuffix = ArchiveExtensions.empty()
-        ? ");;Any file (*.*)"
-        : " *" + ArchiveExtensions.join(" *") + ");;Any file (*.*)";
+    QString rawROMs = romexts.join(" *");
+    QString extraFilters = ";;" + console + " ROMs (*" + rawROMs;
+    QString allROMs = rawROMs;
+
+#ifdef ZSTD_ENABLED
+    QString zstdROMs = "*" + romexts.join(".zst *") + ".zst";
+    extraFilters += ");;Zstandard-compressed " + console + " ROMs (" + zstdROMs + ")";
+    allROMs += " " + zstdROMs;
+#endif
+#ifdef ARCHIVE_SUPPORT_ENABLED
+    QString archives = "*" + ArchiveExtensions.join(" *");
+    extraFilters += ";;Archives (" + archives + ")";
+    allROMs += " " + archives;
+#endif
+    extraFilters += ";;All files (*.*)";
 
     const QString filename = QFileDialog::getOpenFileName(
         this, "Open " + console + " ROM",
         QString::fromStdString(Config::LastROMFolder),
-        console + " ROMs (*" + romexts.join(" *") + filterSuffix
+        "All supported files (*" + allROMs + ")" + extraFilters
     );
 
     if (filename.isEmpty()) return {};

--- a/src/frontend/qt_sdl/main.cpp
+++ b/src/frontend/qt_sdl/main.cpp
@@ -1568,7 +1568,6 @@ static bool SupportedArchiveByMimetype(const QMimeType& mimetype)
     return MimeTypeInList(mimetype, ArchiveMimeTypes);
 }
 
-#ifdef ZSTD_ENABLED
 static bool ZstdNdsRomByExtension(const QString& filename)
 {
     if (filename.endsWith(".zst", Qt::CaseInsensitive))
@@ -1580,14 +1579,12 @@ static bool ZstdGbaRomByExtension(const QString& filename)
     if (filename.endsWith(".zst", Qt::CaseInsensitive))
         return GbaRomByExtension(filename.left(filename.size() - 4));
 }
-#endif
 
 static bool FileIsSupportedFiletype(const QString& filename, bool insideArchive = false)
 {
-#ifdef ZSTD_ENABLED
     if (ZstdNdsRomByExtension(filename) || ZstdGbaRomByExtension(filename))
         return true;
-#endif
+
     if (NdsRomByExtension(filename) || GbaRomByExtension(filename) || SupportedArchiveByExtension(filename))
         return true;
 
@@ -2226,10 +2223,8 @@ void MainWindow::dropEvent(QDropEvent* event)
 
     bool isNdsRom = NdsRomByExtension(filename) || NdsRomByMimetype(mimetype);
     bool isGbaRom = GbaRomByExtension(filename) || GbaRomByMimetype(mimetype);
-#ifdef ZSTD_ENABLED
     isNdsRom |= ZstdNdsRomByExtension(filename);
     isGbaRom |= ZstdGbaRomByExtension(filename);
-#endif
 
     if (isNdsRom)
     {
@@ -2480,11 +2475,10 @@ QStringList MainWindow::pickROM(bool gba)
     QString extraFilters = ";;" + console + " ROMs (*" + rawROMs;
     QString allROMs = rawROMs;
 
-#ifdef ZSTD_ENABLED
     QString zstdROMs = "*" + romexts.join(".zst *") + ".zst";
     extraFilters += ");;Zstandard-compressed " + console + " ROMs (" + zstdROMs + ")";
     allROMs += " " + zstdROMs;
-#endif
+
 #ifdef ARCHIVE_SUPPORT_ENABLED
     QString archives = "*" + ArchiveExtensions.join(" *");
     extraFilters += ";;Archives (" + archives + ")";


### PR DESCRIPTION
This feature adds support for loading individual ROMs compressed using [Zstandard](https://github.com/facebook/zstd).

Zstandard is able to achieve a good compression ratio while also having incredibly fast (de)compression speeds, so no noticeable delay is added when loading even very large compressed ROMs.

This is different from the archive support in that the compressed ROMs are standalone files, rather than archives, making it possible to use them exactly as if they were regular ROMs, while saving a bunch of space on disk. This is supported both for DS and GBA ROMs, though given GBA ROMs' generally small size it's mostly useful for the former.

I'm posting this as a PR rather than directly committing it to see what people think about this feature, it's relatively close to the existing archive feature, so it might be superfluous to have this too, but it's something I'd personally want to use.

To test this, install Zstandard (should be in all Linux package repositories and Homebrew for macOS), and then simply run `zstd YourROM.nds`, and you should be able to run the resulting `YourROM.nds.zst` in melonDS.