### PR TITLE
Implement in-memory savestates

### DIFF
--- a/src/GPU3D.cpp
+++ b/src/GPU3D.cpp
@@ -562,7 +562,7 @@ void DoSavestate(Savestate* file)
         file->Bool32(&poly->IsShadowMask);
         file->Bool32(&poly->IsShadow);
 
-        if (file->IsAtleastVersion(4, 1))
+        if (file->IsAtLeastVersion(4, 1))
             file->Var32((u32*)&poly->Type);
         else
             poly->Type = 0;

--- a/src/NDS.cpp
+++ b/src/NDS.cpp
@@ -937,6 +937,8 @@ bool DoSavestate(Savestate* file)
     }
 #endif
 
+    file->Finish();
+
     return true;
 }
 

--- a/src/NDS.cpp
+++ b/src/NDS.cpp
@@ -815,7 +815,10 @@ bool DoSavestate(Savestate* file)
         u32 console;
         file->Var32(&console);
         if (console != ConsoleType)
+        {
+            Log(LogLevel::Error, "savestate: Expected console type %d, got console type %d. cannot load.\n", ConsoleType, console);
             return false;
+        }
     }
 
     file->VarArray(MainRAM, MainRAMMaxSize);
@@ -870,7 +873,11 @@ bool DoSavestate(Savestate* file)
 
     file->VarArray(DMA9Fill, 4*sizeof(u32));
 
-    if (!DoSavestate_Scheduler(file)) return false;
+    if (!DoSavestate_Scheduler(file))
+    {
+        Platform::Log(Platform::LogLevel::Error, "savestate: failed to %s scheduler state\n", file->Saving ? "save" : "load");
+        return false;
+    }
     file->Var32(&SchedListMask);
     file->Var64(&ARM9Timestamp);
     file->Var64(&ARM9Target);

--- a/src/Savestate.cpp
+++ b/src/Savestate.cpp
@@ -319,6 +319,7 @@ bool Savestate::Resize(u32 new_length)
     buffer = static_cast<u8 *>(resized);
     buffer_length = new_length;
 
+    Log(LogLevel::Debug, "savestate: Expanded %uB savestate buffer to %uB\n", old_length, new_length);
     // Zero out the newly-allocated memory (to ensure we don't introduce a security hole)
     memset(buffer + old_length, 0, length_diff);
     return true;

--- a/src/Savestate.cpp
+++ b/src/Savestate.cpp
@@ -176,8 +176,8 @@ void Savestate::Section(const char* magic)
     else
     {
         // Start looking at the savestate's beginning, right after its header
-
-        for (u32 offset = 0x10;;)
+        u32 offset = 0x10;
+        for (offset = 0x10;;)
         { // Until we've found the desired section...
             // Get this section's magic number
             u32 read_magic = 0;
@@ -195,15 +195,20 @@ void Savestate::Section(const char* magic)
                 // ...otherwise, let's keep looking
                 u32 read_length = 0;
                 memcpy(&read_length, buffer + offset, sizeof(read_length));
+                offset += sizeof(read_length);
 
                 // Skip past the remainder of this section
-                offset += sizeof(read_length) + read_length - sizeof(read_length);
+                // (read_length includes the size of the header;
+                // we already processed the magic and the size, so we don't need to skip them)
+                offset += read_length - sizeof(read_magic) + sizeof(read_length);
                 continue;
             }
 
             offset += 12; // Skip the extra 12 bytes we don't need
             break;
         }
+
+        buffer_offset = offset;
     }
 }
 

--- a/src/Savestate.cpp
+++ b/src/Savestate.cpp
@@ -268,9 +268,15 @@ void Savestate::VarArray(void* data, u32 len)
     buffer_offset += len;
 }
 
+void Savestate::Finish()
+{
+    CloseCurrentSection();
+    finished = true;
+}
+
 void Savestate::CloseCurrentSection()
 {
-    if (CurSection != NO_SECTION)
+    if (CurSection != NO_SECTION && !finished)
     { // If we're in the middle of writing a section...
 
         // Go back to the section's header

--- a/src/Savestate.cpp
+++ b/src/Savestate.cpp
@@ -272,6 +272,16 @@ void Savestate::Finish()
     finished = true;
 }
 
+void Savestate::Rewind(bool save)
+{
+    Error = false;
+    Saving = save;
+    CurSection = NO_SECTION;
+
+    buffer_offset = 0;
+    finished = false;
+}
+
 void Savestate::CloseCurrentSection()
 {
     if (CurSection != NO_SECTION && !finished)

--- a/src/Savestate.cpp
+++ b/src/Savestate.cpp
@@ -17,11 +17,15 @@
 */
 
 #include <stdio.h>
+#include <cassert>
+#include <cstring>
 #include "Savestate.h"
 #include "Platform.h"
 
 using Platform::Log;
 using Platform::LogLevel;
+
+static const char* SAVESTATE_MAGIC = "MELN";
 
 /*
     Savestate format
@@ -46,64 +50,40 @@ using Platform::LogLevel;
     * different minor means adjustments may have to be made
 */
 
-// TODO: buffering system! or something of that sort
-// repeated fread/fwrite is slow on Switch
-
-Savestate::Savestate(std::string filename, bool save)
+Savestate::Savestate(void *buffer, u32 size, bool save) :
+    Error(false),
+    Saving(save),
+    VersionMajor(SAVESTATE_MAJOR),
+    VersionMinor(SAVESTATE_MINOR),
+    CurSection(NO_SECTION),
+    buffer(static_cast<u8 *>(buffer)),
+    buffer_offset(0),
+    buffer_length(size),
+    buffer_owned(false),
+    finished(false)
 {
-    const char* magic = "MELN";
-
-    Error = false;
-
-    if (save)
+    if (Saving)
     {
-        Saving = true;
-        file = Platform::OpenLocalFile(filename, "wb");
-        if (!file)
-        {
-            Log(LogLevel::Error, "savestate: file %s doesn't exist\n", filename.c_str());
-            Error = true;
-            return;
-        }
-
-        VersionMajor = SAVESTATE_MAJOR;
-        VersionMinor = SAVESTATE_MINOR;
-
-        fwrite(magic, 4, 1, file);
-        fwrite(&VersionMajor, 2, 1, file);
-        fwrite(&VersionMinor, 2, 1, file);
-        fseek(file, 8, SEEK_CUR); // length to be fixed later
+        WriteSavestateHeader();
     }
     else
     {
-        Saving = false;
-        file = Platform::OpenFile(filename, "rb");
-        if (!file)
+        // Ensure that the file starts with "MELN"
+        u32 read_magic = 0;
+        Var32(&read_magic);
+
+        if (read_magic != *((u32*)SAVESTATE_MAGIC))
         {
-            Log(LogLevel::Error, "savestate: file %s doesn't exist\n", filename.c_str());
+            Log(LogLevel::Error, "savestate: expected magic number %#08x (%s), got %#08x\n",
+                *((u32*)SAVESTATE_MAGIC),
+                SAVESTATE_MAGIC,
+                read_magic
+            );
             Error = true;
             return;
         }
 
-        u32 len;
-        fseek(file, 0, SEEK_END);
-        len = (u32)ftell(file);
-        fseek(file, 0, SEEK_SET);
-
-        u32 buf = 0;
-
-        fread(&buf, 4, 1, file);
-        if (buf != ((u32*)magic)[0])
-        {
-            Log(LogLevel::Error, "savestate: invalid magic %08X\n", buf);
-            Error = true;
-            return;
-        }
-
-        VersionMajor = 0;
-        VersionMinor = 0;
-
-        fread(&VersionMajor, 2, 1, file);
+        Var16(&VersionMajor);
         if (VersionMajor != SAVESTATE_MAJOR)
         {
             Log(LogLevel::Error, "savestate: bad version major %d, expecting %d\n", VersionMajor, SAVESTATE_MAJOR);
@@ -111,7 +91,7 @@ Savestate::Savestate(std::string filename, bool save)
             return;
         }
 
-        fread(&VersionMinor, 2, 1, file);
+        Var16(&VersionMinor);
         if (VersionMinor > SAVESTATE_MINOR)
         {
             Log(LogLevel::Error, "savestate: state from the future, %d > %d\n", VersionMinor, SAVESTATE_MINOR);
@@ -119,93 +99,111 @@ Savestate::Savestate(std::string filename, bool save)
             return;
         }
 
-        buf = 0;
-        fread(&buf, 4, 1, file);
-        if (buf != len)
+        u32 read_length = 0;
+        Var32(&read_length);
+        if (read_length != buffer_length)
         {
-            Log(LogLevel::Error, "savestate: bad length %d\n", buf);
+            Log(LogLevel::Error, "savestate: expected a length of %d, got %d\n", buffer_length, read_length);
             Error = true;
             return;
         }
 
-        fseek(file, 4, SEEK_CUR);
+        // The next 4 bytes are reserved
+        buffer_offset += 4;
+    }
+}
+
+
+Savestate::Savestate(u32 initial_size) :
+    Error(false),
+    Saving(true), // Can't load from an empty buffer
+    VersionMajor(SAVESTATE_MAJOR),
+    VersionMinor(SAVESTATE_MINOR),
+    CurSection(NO_SECTION),
+    buffer(nullptr),
+    buffer_offset(0),
+    buffer_length(initial_size),
+    buffer_owned(true),
+    finished(false)
+{
+    buffer = static_cast<u8 *>(malloc(buffer_length));
+
+    if (buffer == nullptr)
+    {
+        Log(LogLevel::Error, "savestate: failed to allocate %d bytes\n", buffer_length);
+        Error = true;
+        return;
     }
 
-    CurSection = -1;
+    WriteSavestateHeader();
 }
 
 Savestate::~Savestate()
 {
-    if (Error) return;
-
-    if (Saving)
-    {
-        if (CurSection != 0xFFFFFFFF)
-        {
-            u32 pos = (u32)ftell(file);
-            fseek(file, CurSection+4, SEEK_SET);
-
-            u32 len = pos - CurSection;
-            fwrite(&len, 4, 1, file);
-
-            fseek(file, pos, SEEK_SET);
-        }
-
-        fseek(file, 0, SEEK_END);
-        u32 len = (u32)ftell(file);
-        fseek(file, 8, SEEK_SET);
-        fwrite(&len, 4, 1, file);
+    if (Saving && !finished && !buffer_owned && !Error)
+    { // If we haven't finished saving, and there hasn't been an error...
+        CloseCurrentSection();
+        // No need to close the active section for an owned buffer,
+        // it's about to be thrown out.
     }
 
-    if (file) fclose(file);
+    if (buffer_owned)
+    {
+        free(buffer);
+    }
 }
 
 void Savestate::Section(const char* magic)
 {
-    if (Error) return;
+    if (Error || finished) return;
 
     if (Saving)
     {
-        if (CurSection != 0xFFFFFFFF)
-        {
-            u32 pos = (u32)ftell(file);
-            fseek(file, CurSection+4, SEEK_SET);
+        // Go back to the current section's header and write the length
+        CloseCurrentSection();
 
-            u32 len = pos - CurSection;
-            fwrite(&len, 4, 1, file);
+        CurSection = buffer_offset;
 
-            fseek(file, pos, SEEK_SET);
-        }
+        // Write the new section's magic number
+        VarArray((void*)magic, 4);
 
-        CurSection = (u32)ftell(file);
+        // The next 4 bytes are the length, which we'll come back to later.
+        u32 zero = 0;
+        Var32(&zero);
 
-        fwrite(magic, 4, 1, file);
-        fseek(file, 12, SEEK_CUR);
+        // The 8 bytes afterward are reserved, so we skip them.
+        Var32(&zero);
+        Var32(&zero);
     }
     else
     {
-        fseek(file, 0x10, SEEK_SET);
+        // Start looking at the savestate's beginning, right after its header
 
-        for (;;)
-        {
-            u32 buf = 0;
+        for (u32 offset = 0x10;;)
+        { // Until we've found the desired section...
+            // Get this section's magic number
+            u32 read_magic = 0;
+            memcpy(&read_magic, buffer + offset, sizeof(read_magic));
+            offset += sizeof(read_magic);
 
-            fread(&buf, 4, 1, file);
-            if (buf != ((u32*)magic)[0])
-            {
-                if (buf == 0)
-                {
+            if (read_magic != ((u32*)magic)[0])
+            { // If this isn't the right section...
+                if (offset >= buffer_length)
+                { // If we've reached the end of the file without finding this section...
                     Log(LogLevel::Error, "savestate: section %s not found. blarg\n", magic);
                     return;
                 }
 
-                buf = 0;
-                fread(&buf, 4, 1, file);
-                fseek(file, buf-8, SEEK_CUR);
+                // ...otherwise, let's keep looking
+                u32 read_length = 0;
+                memcpy(&read_length, buffer + offset, sizeof(read_length));
+
+                // Skip past the remainder of this section
+                offset += sizeof(read_length) + read_length - sizeof(read_length);
                 continue;
             }
 
-            fseek(file, 12, SEEK_CUR);
+            offset += 12; // Skip the extra 12 bytes we don't need
             break;
         }
     }
@@ -213,7 +211,7 @@ void Savestate::Section(const char* magic)
 
 void Savestate::Bool32(bool* var)
 {
-    // for compability
+    // for compatibility
     if (Saving)
     {
         u32 val = *var;
@@ -229,14 +227,101 @@ void Savestate::Bool32(bool* var)
 
 void Savestate::VarArray(void* data, u32 len)
 {
-    if (Error) return;
+    if (Error || finished) return;
+
+    assert(buffer_offset <= buffer_length);
 
     if (Saving)
     {
-        fwrite(data, len, 1, file);
+        if (buffer_offset + len > buffer_length)
+        { // If writing the given data would take us past the buffer's end...
+            Log(LogLevel::Warn, "savestate: %u-byte write would exceed %u-byte savestate buffer\n", len, buffer_length);
+
+            if (!(buffer_owned && Resize(buffer_length * 2 + len)))
+            { // If we're not allowed to resize this buffer, or if we are but failed...
+                Log(LogLevel::Error, "savestate: Failed to write %d bytes to savestate\n", len);
+                Error = true;
+                return;
+            }
+            // The buffer's length is doubled, plus however much memory is needed for this write.
+            // This way we can write the data and reduce the chance of needing to resize again.
+        }
+
+        memcpy(buffer + buffer_offset, data, len);
     }
     else
     {
-        fread(data, len, 1, file);
+        if (buffer_offset + len > buffer_length)
+        { // If reading the requested amount of data would take us past the buffer's edge...
+            Log(LogLevel::Error, "savestate: %u-byte read would exceed %u-byte savestate buffer\n", len, buffer_length);
+            Error = true;
+            return;
+
+            // Can't realloc here.
+            // Not only do we not own the buffer pointer (when loading a state),
+            // but we can't magically make the desired data appear.
+        }
+
+        memcpy(data, buffer + buffer_offset, len);
     }
+
+    buffer_offset += len;
+}
+
+void Savestate::CloseCurrentSection()
+{
+    if (CurSection != NO_SECTION)
+    { // If we're in the middle of writing a section...
+
+        // Go back to the section's header
+        // Get the length of the section we've written thus far
+        u32 section_length = buffer_offset - CurSection;
+
+        // Write the length in the section's header
+        // (specifically the first 4 bytes after the magic number)
+        memcpy(buffer + CurSection + 4, &section_length, sizeof(section_length));
+
+        CurSection = NO_SECTION;
+    }
+}
+
+bool Savestate::Resize(u32 new_length)
+{
+    if (!buffer_owned)
+    { // If we're not allowed to resize this buffer...
+        Log(LogLevel::Error, "savestate: Buffer is externally-owned, cannot resize it\n");
+        return false;
+    }
+
+    u32 old_length = buffer_length;
+    void* resized = realloc(buffer, new_length);
+    if (!resized)
+    { // If the buffer couldn't be expanded...
+        Log(LogLevel::Error, "savestate: Failed to resize owned savestate buffer from %dB to %dB\n", old_length, new_length);
+        return false;
+    }
+
+    u32 length_diff = new_length - old_length;
+    buffer = static_cast<u8 *>(resized);
+    buffer_length = new_length;
+
+    // Zero out the newly-allocated memory (to ensure we don't introduce a security hole)
+    memset(buffer + old_length, 0, length_diff);
+    return true;
+}
+
+void Savestate::WriteSavestateHeader()
+{// The magic number
+    VarArray((void *) SAVESTATE_MAGIC, 4);
+
+    // The major and minor versions
+    Var16(&VersionMajor);
+    Var16(&VersionMinor);
+
+    // The next 4 bytes are the file's length, which will be filled in at the end
+    u32 zero = 0;
+    Var32(&zero);
+
+    // The following 4 bytes are reserved
+    Var32(&zero);
 }

--- a/src/Savestate.cpp
+++ b/src/Savestate.cpp
@@ -315,7 +315,8 @@ bool Savestate::Resize(u32 new_length)
 }
 
 void Savestate::WriteSavestateHeader()
-{// The magic number
+{
+    // The magic number
     VarArray((void *) SAVESTATE_MAGIC, 4);
 
     // The major and minor versions

--- a/src/Savestate.cpp
+++ b/src/Savestate.cpp
@@ -211,62 +211,6 @@ void Savestate::Section(const char* magic)
     }
 }
 
-void Savestate::Var8(u8* var)
-{
-    if (Error) return;
-
-    if (Saving)
-    {
-        fwrite(var, 1, 1, file);
-    }
-    else
-    {
-        fread(var, 1, 1, file);
-    }
-}
-
-void Savestate::Var16(u16* var)
-{
-    if (Error) return;
-
-    if (Saving)
-    {
-        fwrite(var, 2, 1, file);
-    }
-    else
-    {
-        fread(var, 2, 1, file);
-    }
-}
-
-void Savestate::Var32(u32* var)
-{
-    if (Error) return;
-
-    if (Saving)
-    {
-        fwrite(var, 4, 1, file);
-    }
-    else
-    {
-        fread(var, 4, 1, file);
-    }
-}
-
-void Savestate::Var64(u64* var)
-{
-    if (Error) return;
-
-    if (Saving)
-    {
-        fwrite(var, 8, 1, file);
-    }
-    else
-    {
-        fread(var, 8, 1, file);
-    }
-}
-
 void Savestate::Bool32(bool* var)
 {
     // for compability

--- a/src/Savestate.cpp
+++ b/src/Savestate.cpp
@@ -140,7 +140,7 @@ Savestate::~Savestate()
 {
     if (Saving && !finished && !buffer_owned && !Error)
     { // If we haven't finished saving, and there hasn't been an error...
-        CloseCurrentSection();
+        Finish();
         // No need to close the active section for an owned buffer,
         // it's about to be thrown out.
     }
@@ -268,7 +268,9 @@ void Savestate::VarArray(void* data, u32 len)
 
 void Savestate::Finish()
 {
+    if (Error || finished) return;
     CloseCurrentSection();
+    WriteStateLength();
     finished = true;
 }
 
@@ -343,4 +345,15 @@ void Savestate::WriteSavestateHeader()
 
     // The following 4 bytes are reserved
     Var32(&zero);
+}
+
+void Savestate::WriteStateLength()
+{
+    // Not to be confused with the buffer length.
+    // The buffer might not be full,
+    // so we don't want to write out the extra stuff.
+    u32 state_length = buffer_offset;
+
+    // Write the length in the header
+    memcpy(buffer + 0x08, &state_length, sizeof(state_length));
 }

--- a/src/Savestate.cpp
+++ b/src/Savestate.cpp
@@ -53,8 +53,6 @@ static const char* SAVESTATE_MAGIC = "MELN";
 Savestate::Savestate(void *buffer, u32 size, bool save) :
     Error(false),
     Saving(save),
-    VersionMajor(SAVESTATE_MAJOR),
-    VersionMinor(SAVESTATE_MINOR),
     CurSection(NO_SECTION),
     buffer(static_cast<u8 *>(buffer)),
     buffer_offset(0),
@@ -83,18 +81,20 @@ Savestate::Savestate(void *buffer, u32 size, bool save) :
             return;
         }
 
-        Var16(&VersionMajor);
-        if (VersionMajor != SAVESTATE_MAJOR)
+        u16 major = 0;
+        Var16(&major);
+        if (major != SAVESTATE_MAJOR)
         {
-            Log(LogLevel::Error, "savestate: bad version major %d, expecting %d\n", VersionMajor, SAVESTATE_MAJOR);
+            Log(LogLevel::Error, "savestate: bad version major %d, expecting %d\n", major, SAVESTATE_MAJOR);
             Error = true;
             return;
         }
 
-        Var16(&VersionMinor);
-        if (VersionMinor > SAVESTATE_MINOR)
+        u16 minor = 0;
+        Var16(&minor);
+        if (minor > SAVESTATE_MINOR)
         {
-            Log(LogLevel::Error, "savestate: state from the future, %d > %d\n", VersionMinor, SAVESTATE_MINOR);
+            Log(LogLevel::Error, "savestate: state from the future, %d > %d\n", minor, SAVESTATE_MINOR);
             Error = true;
             return;
         }
@@ -117,8 +117,6 @@ Savestate::Savestate(void *buffer, u32 size, bool save) :
 Savestate::Savestate(u32 initial_size) :
     Error(false),
     Saving(true), // Can't load from an empty buffer
-    VersionMajor(SAVESTATE_MAJOR),
-    VersionMinor(SAVESTATE_MINOR),
     CurSection(NO_SECTION),
     buffer(nullptr),
     buffer_offset(0),
@@ -321,8 +319,11 @@ void Savestate::WriteSavestateHeader()
     VarArray((void *) SAVESTATE_MAGIC, 4);
 
     // The major and minor versions
-    Var16(&VersionMajor);
-    Var16(&VersionMinor);
+    u16 major = SAVESTATE_MAJOR;
+    Var16(&major);
+
+    u16 minor = SAVESTATE_MINOR;
+    Var16(&minor);
 
     // The next 4 bytes are the file's length, which will be filled in at the end
     u32 zero = 0;

--- a/src/Savestate.cpp
+++ b/src/Savestate.cpp
@@ -181,10 +181,13 @@ void Savestate::Section(const char* magic)
         { // Until we've found the desired section...
             // Get this section's magic number
             u32 read_magic = 0;
+            u32 magic_as_int = 0;
             memcpy(&read_magic, buffer + offset, sizeof(read_magic));
             offset += sizeof(read_magic);
 
-            if (read_magic != ((u32*)magic)[0])
+            memcpy(&magic_as_int, magic, sizeof(magic_as_int));
+
+            if (read_magic != magic_as_int)
             { // If this isn't the right section...
                 if (offset >= buffer_length)
                 { // If we've reached the end of the file without finding this section...

--- a/src/Savestate.h
+++ b/src/Savestate.h
@@ -42,10 +42,25 @@ public:
 
     void Section(const char* magic);
 
-    void Var8(u8* var);
-    void Var16(u16* var);
-    void Var32(u32* var);
-    void Var64(u64* var);
+    void Var8(u8* var)
+    {
+        VarArray(var, sizeof(*var));
+    }
+
+    void Var16(u16* var)
+    {
+        VarArray(var, sizeof(*var));
+    }
+
+    void Var32(u32* var)
+    {
+        VarArray(var, sizeof(*var));
+    }
+
+    void Var64(u64* var)
+    {
+        VarArray(var, sizeof(*var));
+    }
 
     void Bool32(bool* var);
 

--- a/src/Savestate.h
+++ b/src/Savestate.h
@@ -19,6 +19,7 @@
 #ifndef SAVESTATE_H
 #define SAVESTATE_H
 
+#include <cstring>
 #include <string>
 #include <stdio.h>
 #include "types.h"

--- a/src/Savestate.h
+++ b/src/Savestate.h
@@ -32,7 +32,7 @@ public:
     static constexpr u32 DEFAULT_SIZE = 16 * 1024 * 1024; // 16 MB
     [[deprecated]] Savestate(std::string filename, bool save);
     Savestate(void* buffer, u32 size, bool save);
-    Savestate(u32 initial_size = DEFAULT_SIZE);
+    explicit Savestate(u32 initial_size = DEFAULT_SIZE);
 
     ~Savestate();
 

--- a/src/Savestate.h
+++ b/src/Savestate.h
@@ -71,7 +71,7 @@ public:
     void Finish();
 
     // TODO rewinds the stream
-    void Reset(bool save);
+    void Rewind(bool save);
 
     bool IsAtleastVersion(u32 major, u32 minor)
     {

--- a/src/Savestate.h
+++ b/src/Savestate.h
@@ -73,7 +73,7 @@ public:
     // TODO rewinds the stream
     void Rewind(bool save);
 
-    bool IsAtleastVersion(u32 major, u32 minor)
+    bool IsAtLeastVersion(u32 major, u32 minor)
     {
         u16 major_version = MajorVersion();
         if (MajorVersion() > major) return true;

--- a/src/Savestate.h
+++ b/src/Savestate.h
@@ -29,7 +29,7 @@
 class Savestate
 {
 public:
-    static constexpr u32 DEFAULT_SIZE = 16 * 1024 * 1024; // 16 MB
+    static constexpr u32 DEFAULT_SIZE = 32 * 1024 * 1024; // 32 MB
     [[deprecated]] Savestate(std::string filename, bool save);
     Savestate(void* buffer, u32 size, bool save);
     explicit Savestate(u32 initial_size = DEFAULT_SIZE);

--- a/src/Savestate.h
+++ b/src/Savestate.h
@@ -109,6 +109,7 @@ private:
     void CloseCurrentSection();
     bool Resize(u32 new_length);
     void WriteSavestateHeader();
+    void WriteStateLength();
     u8* buffer;
     u32 buffer_offset;
     u32 buffer_length;

--- a/src/Savestate.h
+++ b/src/Savestate.h
@@ -39,8 +39,6 @@ public:
     bool Error;
 
     bool Saving;
-    u16 VersionMajor;
-    u16 VersionMinor;
 
     u32 CurSection;
 
@@ -77,8 +75,9 @@ public:
 
     bool IsAtleastVersion(u32 major, u32 minor)
     {
-        if (VersionMajor > major) return true;
-        if (VersionMajor == major && VersionMinor >= minor) return true;
+        u16 major_version = MajorVersion();
+        if (MajorVersion() > major) return true;
+        if (major_version == major && MinorVersion() >= minor) return true;
         return false;
     }
 
@@ -88,6 +87,22 @@ public:
     [[nodiscard]] u32 BufferLength() const { return buffer_length; }
 
     [[nodiscard]] u32 Length() const { return buffer_offset; }
+
+    [[nodiscard]] u16 MajorVersion() const
+    {
+        // major version is stored at offset 0x04
+        u16 major = 0;
+        memcpy(&major, buffer + 0x04, sizeof(major));
+        return major;
+    }
+
+    [[nodiscard]] u16 MinorVersion() const
+    {
+        // minor version is stored at offset 0x06
+        u16 minor = 0;
+        memcpy(&minor, buffer + 0x06, sizeof(minor));
+        return minor;
+    }
 
 private:
     static constexpr u32 NO_SECTION = 0xffffffff;

--- a/src/Savestate.h
+++ b/src/Savestate.h
@@ -30,7 +30,6 @@ class Savestate
 {
 public:
     static constexpr u32 DEFAULT_SIZE = 32 * 1024 * 1024; // 32 MB
-    [[deprecated]] Savestate(std::string filename, bool save);
     Savestate(void* buffer, u32 size, bool save);
     explicit Savestate(u32 initial_size = DEFAULT_SIZE);
 

--- a/src/Savestate.h
+++ b/src/Savestate.h
@@ -109,6 +109,7 @@ private:
     bool Resize(u32 new_length);
     void WriteSavestateHeader();
     void WriteStateLength();
+    u32 FindSection(const char* magic) const;
     u8* buffer;
     u32 buffer_offset;
     u32 buffer_length;

--- a/src/frontend/qt_sdl/ROMManager.cpp
+++ b/src/frontend/qt_sdl/ROMManager.cpp
@@ -478,6 +478,13 @@ bool LoadBIOS()
     return true;
 }
 
+void ClearBackupState()
+{
+    if (BackupState != nullptr)
+    {
+        BackupState = nullptr;
+    }
+}
 
 bool LoadROM(QStringList filepath, bool reset)
 {

--- a/src/frontend/qt_sdl/ROMManager.cpp
+++ b/src/frontend/qt_sdl/ROMManager.cpp
@@ -295,7 +295,7 @@ bool LoadState(std::string filename)
     FILE* file = fopen(filename.c_str(), "rb");
     if (file == nullptr)
     { // If we couldn't open the state file...
-        Platform::Log(Platform::LogLevel::Error, "Failed to open state file %s\n", filename.c_str());
+        Platform::Log(Platform::LogLevel::Error, "Failed to open state file \"%s\"\n", filename.c_str());
         return false;
     }
 
@@ -309,7 +309,7 @@ bool LoadState(std::string filename)
 
     if (!NDS::DoSavestate(backup.get()) || backup->Error)
     { // Back up the emulator's state. If that failed...
-        Platform::Log(Platform::LogLevel::Error, "Failed to back up state, aborting load (from %s)\n", filename.c_str());
+        Platform::Log(Platform::LogLevel::Error, "Failed to back up state, aborting load (from \"%s\")\n", filename.c_str());
         fclose(file);
         return false;
     }
@@ -319,7 +319,7 @@ bool LoadState(std::string filename)
     // Get the size of the file that we opened
     if (fseek(file, 0, SEEK_END) != 0)
     {
-        Platform::Log(Platform::LogLevel::Error, "Failed to seek to end of state file %s\n", filename.c_str());
+        Platform::Log(Platform::LogLevel::Error, "Failed to seek to end of state file \"%s\"\n", filename.c_str());
         fclose(file);
         return false;
     }
@@ -330,7 +330,7 @@ bool LoadState(std::string filename)
     std::vector<u8> buffer(size);
     if (fread(buffer.data(), size, 1, file) == 0)
     { // Read the state file into the buffer. If that failed...
-        Platform::Log(Platform::LogLevel::Error, "Failed to read %u-byte state file %s\n", size, filename.c_str());
+        Platform::Log(Platform::LogLevel::Error, "Failed to read %u-byte state file \"%s\"\n", size, filename.c_str());
         fclose(file);
         return false;
     }
@@ -341,7 +341,7 @@ bool LoadState(std::string filename)
 
     if (!NDS::DoSavestate(state.get()) || state->Error)
     { // If we couldn't load the savestate from the buffer...
-        Platform::Log(Platform::LogLevel::Error, "Failed to load state file %s into emulator\n", filename.c_str());
+        Platform::Log(Platform::LogLevel::Error, "Failed to load state file \"%s\" into emulator\n", filename.c_str());
         return false;
     }
 

--- a/src/frontend/qt_sdl/ROMManager.h
+++ b/src/frontend/qt_sdl/ROMManager.h
@@ -35,6 +35,7 @@ extern SaveManager* GBASave;
 QString VerifySetup();
 void Reset();
 bool LoadBIOS();
+void ClearBackupState();
 
 bool LoadROM(QStringList filepath, bool reset);
 void EjectCart();


### PR DESCRIPTION
I wanted [my new melonDS libretro core](https://github.com/JesseTG/melonds-ds) to support savestates and rewind. However, the current build of melonDS writes savestates directly to disk.

So I prepared this PR, which...

- Modifies the `Savestate` class to read/write savestates to a memory buffer, not to disk. The buffer can be managed internally or externally.
- Modifies `ROMManager` to actually read/write the savestates to disk.
- Stores backup states in memory, rather than in `timewarp.mln`.
- Preserves all existing frontend behavior, as far as saving/loading states goes.