### PR TITLE
Add microphone combobox using SDL

### DIFF
--- a/src/frontend/qt_sdl/AudioInOut.cpp
+++ b/src/frontend/qt_sdl/AudioInOut.cpp
@@ -133,7 +133,12 @@ void MicOpen()
     whatIwant.channels = 1;
     whatIwant.samples = 1024;
     whatIwant.callback = MicCallback;
-    micDevice = SDL_OpenAudioDevice(NULL, 1, &whatIwant, &whatIget, 0);
+    const char* mic = NULL;
+    if (Config::MicDevice != "")
+    {
+        mic = Config::MicDevice.c_str();
+    }
+    micDevice = SDL_OpenAudioDevice(mic, 1, &whatIwant, &whatIget, 0);
     if (!micDevice)
     {
         Platform::Log(Platform::LogLevel::Error, "Mic init failed: %s\n", SDL_GetError());

--- a/src/frontend/qt_sdl/AudioSettingsDialog.ui
+++ b/src/frontend/qt_sdl/AudioSettingsDialog.ui
@@ -136,7 +136,7 @@
         </property>
        </widget>
       </item>
-      <item row="1" column="0" colspan="3">
+      <item row="1" column="0">
        <widget class="QRadioButton" name="rbMicExternal">
         <property name="whatsThis">
          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Input from an external microphone, if available, will be forwarded to the emulated microphone.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
@@ -145,6 +145,13 @@
          <string>External microphone</string>
         </property>
        </widget>
+      </item>
+      <item row="1" column="1" colspan="2">
+        <widget class="QComboBox" name="cbMic">
+         <property name="whatsThis"> 
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The selected microphone to be used.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>       
+         </property>
+        </widget>
       </item>
       <item row="2" column="0" colspan="3">
        <widget class="QRadioButton" name="rbMicNoise">

--- a/src/frontend/qt_sdl/Config.cpp
+++ b/src/frontend/qt_sdl/Config.cpp
@@ -120,6 +120,7 @@ int AudioBitDepth;
 int AudioVolume;
 bool DSiVolumeSync;
 int MicInputType;
+std::string MicDevice;
 std::string MicWavPath;
 
 std::string LastROMFolder;
@@ -300,6 +301,7 @@ ConfigEntry ConfigFile[] =
     {"AudioVolume", 0, &AudioVolume, 256, true},
     {"DSiVolumeSync", 0, &DSiVolumeSync, 0, true},
     {"MicInputType", 0, &MicInputType, 1, false},
+    {"MicDevice", 2, &MicDevice, (std::string)"", false},
     {"MicWavPath", 2, &MicWavPath, (std::string)"", false},
 
     {"LastROMFolder", 2, &LastROMFolder, (std::string)"", true},

--- a/src/frontend/qt_sdl/Config.h
+++ b/src/frontend/qt_sdl/Config.h
@@ -177,6 +177,7 @@ extern int AudioBitDepth;
 extern int AudioVolume;
 extern bool DSiVolumeSync;
 extern int MicInputType;
+extern std::string MicDevice;
 extern std::string MicWavPath;
 
 extern std::string LastROMFolder;


### PR DESCRIPTION
Closes #1571 
Uses SDL to list devices instead to avoid compatibility issues and possible issue with names being different in Qt.