### PR TITLE
Allow glad to be excluded in favor of a custom frontend's own OpenGL function loader

### DIFF
--- a/src/PlatformOGL.h
+++ b/src/PlatformOGL.h
@@ -1,9 +1,19 @@
 #ifndef PLATFORMOGL_H
 #define PLATFORMOGL_H
 
-// if you don't wanna use glad for your platform
-// add your header here!
+//! You can do the following if you want to use a different OpenGL function loader:
+///
+/// 1. Define \c MELONDS_NO_GLAD and \c MELONDS_PLATFORMOGL_PRIVATE in your project's build.
+/// 2. Create a header named \c PlatformOGLPrivate.h in your project.
+/// 3. Add its location to your project's \c #include search path.
+/// 4. Declare whatever symbols you need in PlatformOGLPrivate.h.
 
+#ifndef MELONDS_NO_GLAD
 #include "frontend/glad/glad.h"
+#endif
+
+#ifdef MELONDS_PLATFORMOGL_PRIVATE
+#include "PlatformOGLPrivate.h"
+#endif
 
 #endif


### PR DESCRIPTION
Since [melonDS DS](https://github.com/JesseTG/melonds-ds) is backed by libretro, the libretro frontend will have its own method of loading OpenGL functions. Using glad would conflict with that method, so I made it optional and added some instructions on using a private header.

This makes no difference to regular melonDS builds.