### PR TITLE
Make librt a dependency only on Linux (not just `NOT APPLE`)

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -130,6 +130,8 @@ endif()
 
 if (WIN32)
     target_link_libraries(core PRIVATE ole32 comctl32 ws2_32)
+elseif(LINUX AND NOT ANDROID)
+    target_link_libraries(core PRIVATE rt)
 endif()
 
 if (ENABLE_JIT_PROFILING)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -130,8 +130,6 @@ endif()
 
 if (WIN32)
     target_link_libraries(core PRIVATE ole32 comctl32 ws2_32)
-elseif(NOT APPLE)
-    target_link_libraries(core PRIVATE rt)
 endif()
 
 if (ENABLE_JIT_PROFILING)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -130,8 +130,11 @@ endif()
 
 if (WIN32)
     target_link_libraries(core PRIVATE ole32 comctl32 ws2_32)
-elseif(LINUX AND NOT ANDROID)
-    target_link_libraries(core PRIVATE rt)
+elseif(NOT APPLE)
+    check_library_exists(rt shm_open "" NEED_LIBRT)
+    if (NEED_LIBRT)
+        target_link_libraries(core PRIVATE rt)
+    endif()
 endif()
 
 if (ENABLE_JIT_PROFILING)


### PR DESCRIPTION
librt was interfering with my ability to compile an Android build of [melonDS DS](https://github.com/JesseTG/melonds-ds). However, I discovered that it doesn't appear to actually be necessary for upstream melonDS. This patch makes life a little simpler for all of us.