### PR TITLE
Hopefully fix fastmem on macOS

### DIFF
--- a/src/ARMJIT_Memory.cpp
+++ b/src/ARMJIT_Memory.cpp
@@ -687,7 +687,11 @@ bool FaultHandler(FaultDescription& faultDesc)
             rewriteToSlowPath = !MapAtAddress(faultDesc.EmulatedFaultAddr);
 
         if (rewriteToSlowPath)
+        {
+            ARMJIT::JitEnableWrite();
             faultDesc.FaultPC = ARMJIT::JITCompiler->RewriteMemAccess(faultDesc.FaultPC);
+            ARMJIT::JitEnableExecute();
+        }
 
         return true;
     }
@@ -747,7 +751,9 @@ void Init()
     // but something was bad about this so instead we take this vmem eating monster
     // which seems to work better.
     MemoryBase = (u8*)mmap(NULL, AddrSpaceSize*4, PROT_NONE, MAP_ANON | MAP_PRIVATE, -1, 0);
+#if !defined(__APPLE__) && !defined(__FreeBSD__)
     munmap(MemoryBase, AddrSpaceSize*4);
+#endif
     FastMem9Start = MemoryBase;
     FastMem7Start = MemoryBase + AddrSpaceSize;
     MemoryBase = MemoryBase + AddrSpaceSize*2;

--- a/src/frontend/qt_sdl/EmuSettingsDialog.cpp
+++ b/src/frontend/qt_sdl/EmuSettingsDialog.cpp
@@ -76,9 +76,6 @@ EmuSettingsDialog::EmuSettingsDialog(QWidget* parent) : QDialog(parent), ui(new 
     ui->chkJITBranchOptimisations->setChecked(Config::JIT_BranchOptimisations);
     ui->chkJITLiteralOptimisations->setChecked(Config::JIT_LiteralOptimisations);
     ui->chkJITFastMemory->setChecked(Config::JIT_FastMemory);
-    #ifdef __APPLE__
-        ui->chkJITFastMemory->setDisabled(true);
-    #endif
     ui->spnJITMaximumBlockSize->setValue(Config::JIT_MaxBlockSize);
 #else
     ui->chkEnableJIT->setDisabled(true);


### PR DESCRIPTION
This makes two very small changes:

* Add forgotten calls to `JitEnableWrite`/`JitEnableExecute` in `FaultHandler`
* Disable the immediate `munmap` of `MemoryBase` which, while it works on Linux, seems to cause problems on macOS. Additionally this should fix FreeBSD as it seems to behave the same as macOS here.