### PR TITLE
Fix 1 Pixel Tall Vertical Slopes Being Assigned the Wrong Increment

### DIFF
--- a/src/GPU3D_Soft.h
+++ b/src/GPU3D_Soft.h
@@ -294,7 +294,7 @@ private:
             // TODO: this is still not perfect (see for example x=169 y=33)
             if (ylen == 0)
                 Increment = 0;
-            else if (ylen == xlen)
+            else if (ylen == xlen && xlen != 1)
                 Increment = 0x40000;
             else
             {


### PR DESCRIPTION
Fixes anti-aliasing being calculated incorrectly on certain polygon edges, resulting in transparent holes in several objects.
There's a few different ways to fix this properly, so feel free to request a different fix, if desired.
Some examples of objects fixed by this include:
This table:
![image](https://github.com/melonDS-emu/melonDS/assets/102590697/826f1537-9c2d-4c23-9164-515733e6e166) ![image](https://github.com/melonDS-emu/melonDS/assets/102590697/f90f9507-d0fa-421f-9602-42c97f1066bf)
This mailbox:
![image](https://github.com/melonDS-emu/melonDS/assets/102590697/25f858ca-a199-4341-b69c-13e1f4827843) ![image](https://github.com/melonDS-emu/melonDS/assets/102590697/fac49422-72e5-4668-8756-e0f2e65f2489)
This shadow:
![image](https://github.com/melonDS-emu/melonDS/assets/102590697/db30c4f0-10f0-43f1-8cce-bc616b23ff73) ![image](https://github.com/melonDS-emu/melonDS/assets/102590697/286894ae-4737-4abd-be49-8d86739705cd)