### PR TITLE
Fix aa being upside down on swapped y-major slopes

### DIFF
--- a/src/GPU3D_Soft.cpp
+++ b/src/GPU3D_Soft.cpp
@@ -753,8 +753,8 @@ void SoftRenderer::RenderShadowMaskScanline(RendererPolygon* rp, s32 y)
         interp_start = &rp->SlopeR.Interp;
         interp_end = &rp->SlopeL.Interp;
 
-        rp->SlopeR.EdgeParams_YMajor(&l_edgelen, &l_edgecov);
-        rp->SlopeL.EdgeParams_YMajor(&r_edgelen, &r_edgecov);
+        rp->SlopeR.EdgeParams_YMajor(&l_edgelen, &l_edgecov, 1);
+        rp->SlopeL.EdgeParams_YMajor(&r_edgelen, &r_edgecov, 1);
 
         std::swap(xstart, xend);
         std::swap(wl, wr);
@@ -973,8 +973,8 @@ void SoftRenderer::RenderPolygonScanline(RendererPolygon* rp, s32 y)
         interp_start = &rp->SlopeR.Interp;
         interp_end = &rp->SlopeL.Interp;
 
-        rp->SlopeR.EdgeParams_YMajor(&l_edgelen, &l_edgecov);
-        rp->SlopeL.EdgeParams_YMajor(&r_edgelen, &r_edgecov);
+        rp->SlopeR.EdgeParams_YMajor(&l_edgelen, &l_edgecov, 1);
+        rp->SlopeL.EdgeParams_YMajor(&r_edgelen, &r_edgecov, 1);
 
         std::swap(xstart, xend);
         std::swap(wl, wr);

--- a/src/GPU3D_Soft.cpp
+++ b/src/GPU3D_Soft.cpp
@@ -753,8 +753,8 @@ void SoftRenderer::RenderShadowMaskScanline(RendererPolygon* rp, s32 y)
         interp_start = &rp->SlopeR.Interp;
         interp_end = &rp->SlopeL.Interp;
 
-        rp->SlopeR.EdgeParams_YMajor(&l_edgelen, &l_edgecov, 1);
-        rp->SlopeL.EdgeParams_YMajor(&r_edgelen, &r_edgecov, 1);
+        rp->SlopeR.EdgeParams(&l_edgelen, &l_edgecov, 1);
+        rp->SlopeL.EdgeParams(&r_edgelen, &r_edgecov, 1);
 
         std::swap(xstart, xend);
         std::swap(wl, wr);
@@ -771,8 +771,8 @@ void SoftRenderer::RenderShadowMaskScanline(RendererPolygon* rp, s32 y)
         interp_start = &rp->SlopeL.Interp;
         interp_end = &rp->SlopeR.Interp;
 
-        rp->SlopeL.EdgeParams(&l_edgelen, &l_edgecov);
-        rp->SlopeR.EdgeParams(&r_edgelen, &r_edgecov);
+        rp->SlopeL.EdgeParams(&l_edgelen, &l_edgecov, 0);
+        rp->SlopeR.EdgeParams(&r_edgelen, &r_edgecov, 0);
     }
 
     // color/texcoord attributes aren't needed for shadow masks
@@ -958,10 +958,8 @@ void SoftRenderer::RenderPolygonScanline(RendererPolygon* rp, s32 y)
 
     // if the left and right edges are swapped, render backwards.
     // on hardware, swapped edges seem to break edge length calculation,
-    // causing X-major edges to be rendered wrong when
-    // wireframe/edgemarking/antialiasing are used
-    // it also causes bad antialiasing, but not sure what's going on (TODO)
-    // most probable explanation is that such slopes are considered to be Y-major
+    // causing X-major edges to be rendered wrong when filled
+    // it also causes buggy looking anti-aliasing on X-major edges
 
     if (xstart > xend)
     {
@@ -973,8 +971,8 @@ void SoftRenderer::RenderPolygonScanline(RendererPolygon* rp, s32 y)
         interp_start = &rp->SlopeR.Interp;
         interp_end = &rp->SlopeL.Interp;
 
-        rp->SlopeR.EdgeParams_YMajor(&l_edgelen, &l_edgecov, 1);
-        rp->SlopeL.EdgeParams_YMajor(&r_edgelen, &r_edgecov, 1);
+        rp->SlopeR.EdgeParams(&l_edgelen, &l_edgecov, 1);
+        rp->SlopeL.EdgeParams(&r_edgelen, &r_edgecov, 1);
 
         std::swap(xstart, xend);
         std::swap(wl, wr);
@@ -991,8 +989,8 @@ void SoftRenderer::RenderPolygonScanline(RendererPolygon* rp, s32 y)
         interp_start = &rp->SlopeL.Interp;
         interp_end = &rp->SlopeR.Interp;
 
-        rp->SlopeL.EdgeParams(&l_edgelen, &l_edgecov);
-        rp->SlopeR.EdgeParams(&r_edgelen, &r_edgecov);
+        rp->SlopeL.EdgeParams(&l_edgelen, &l_edgecov, 0);
+        rp->SlopeR.EdgeParams(&r_edgelen, &r_edgecov, 0);
     }
 
     // interpolate attributes along Y

--- a/src/GPU3D_Soft.cpp
+++ b/src/GPU3D_Soft.cpp
@@ -753,8 +753,8 @@ void SoftRenderer::RenderShadowMaskScanline(RendererPolygon* rp, s32 y)
         interp_start = &rp->SlopeR.Interp;
         interp_end = &rp->SlopeL.Interp;
 
-        rp->SlopeR.EdgeParams(&l_edgelen, &l_edgecov, 1);
-        rp->SlopeL.EdgeParams(&r_edgelen, &r_edgecov, 1);
+        rp->SlopeR.EdgeParams<true>(&l_edgelen, &l_edgecov);
+        rp->SlopeL.EdgeParams<true>(&r_edgelen, &r_edgecov);
 
         std::swap(xstart, xend);
         std::swap(wl, wr);
@@ -771,8 +771,8 @@ void SoftRenderer::RenderShadowMaskScanline(RendererPolygon* rp, s32 y)
         interp_start = &rp->SlopeL.Interp;
         interp_end = &rp->SlopeR.Interp;
 
-        rp->SlopeL.EdgeParams(&l_edgelen, &l_edgecov, 0);
-        rp->SlopeR.EdgeParams(&r_edgelen, &r_edgecov, 0);
+        rp->SlopeL.EdgeParams<false>(&l_edgelen, &l_edgecov);
+        rp->SlopeR.EdgeParams<false>(&r_edgelen, &r_edgecov);
     }
 
     // color/texcoord attributes aren't needed for shadow masks
@@ -958,8 +958,8 @@ void SoftRenderer::RenderPolygonScanline(RendererPolygon* rp, s32 y)
 
     // if the left and right edges are swapped, render backwards.
     // on hardware, swapped edges seem to break edge length calculation,
-    // causing X-major edges to be rendered wrong when filled
-    // it also causes buggy looking anti-aliasing on X-major edges
+    // causing X-major edges to be rendered wrong when filled,
+    // and resulting in buggy looking anti-aliasing on X-major edges
 
     if (xstart > xend)
     {
@@ -971,8 +971,8 @@ void SoftRenderer::RenderPolygonScanline(RendererPolygon* rp, s32 y)
         interp_start = &rp->SlopeR.Interp;
         interp_end = &rp->SlopeL.Interp;
 
-        rp->SlopeR.EdgeParams(&l_edgelen, &l_edgecov, 1);
-        rp->SlopeL.EdgeParams(&r_edgelen, &r_edgecov, 1);
+        rp->SlopeR.EdgeParams<true>(&l_edgelen, &l_edgecov);
+        rp->SlopeL.EdgeParams<true>(&r_edgelen, &r_edgecov);
 
         std::swap(xstart, xend);
         std::swap(wl, wr);
@@ -989,8 +989,8 @@ void SoftRenderer::RenderPolygonScanline(RendererPolygon* rp, s32 y)
         interp_start = &rp->SlopeL.Interp;
         interp_end = &rp->SlopeR.Interp;
 
-        rp->SlopeL.EdgeParams(&l_edgelen, &l_edgecov, 0);
-        rp->SlopeR.EdgeParams(&r_edgelen, &r_edgecov, 0);
+        rp->SlopeL.EdgeParams<false>(&l_edgelen, &l_edgecov);
+        rp->SlopeR.EdgeParams<false>(&r_edgelen, &r_edgecov);
     }
 
     // interpolate attributes along Y

--- a/src/GPU3D_Soft.h
+++ b/src/GPU3D_Soft.h
@@ -390,7 +390,7 @@ private:
             *coverage = (1<<31) | ((startcov & 0x3FF) << 12) | (xcov_incr & 0x3FF);
         }
 
-        void EdgeParams_YMajor(s32* length, s32* coverage)
+        void EdgeParams_YMajor(s32* length, s32* coverage, bool flipped)
         {
             *length = 1;
 
@@ -403,7 +403,7 @@ private:
                 s32 cov = ((dx >> 9) + (Increment >> 10)) >> 4;
                 if ((cov >> 5) != (dx >> 18)) cov = 31;
                 cov &= 0x1F;
-                if (!(side ^ Negative)) cov = 0x1F - cov;
+                if ((!(side ^ Negative)) ^ flipped) cov = 0x1F - cov;
 
                 *coverage = cov;
             }
@@ -414,7 +414,7 @@ private:
             if (XMajor)
                 return EdgeParams_XMajor(length, coverage);
             else
-                return EdgeParams_YMajor(length, coverage);
+                return EdgeParams_YMajor(length, coverage, 0);
         }
 
         s32 Increment;


### PR DESCRIPTION
fixes kyurem's face on the title screen, also fixes crossed quads.
![image](https://github.com/melonDS-emu/melonDS/assets/102590697/4d912181-d65a-409f-b1f8-0d1bb4e54a39)
fixed
![image](https://github.com/melonDS-emu/melonDS/assets/102590697/aa18b3c0-bf4a-4714-8906-d0d19f268247)
console screenshot
![image](https://github.com/melonDS-emu/melonDS/assets/102590697/9f1b1acb-cbea-454c-a261-e531dd29c1bb)
