### PR TITLE
Fix DS firmware not being bootable after shutting down DSi firmware

### DIFF
--- a/src/SPI.cpp
+++ b/src/SPI.cpp
@@ -91,6 +91,8 @@ bool Init()
 
 void DeInit()
 {
+    FirmwareLength = 0;
+    FirmwareMask = 0;
     if (Firmware) delete[] Firmware;
 }
 


### PR DESCRIPTION
## Problem
Attempting to run the DS firmware after running the DSi firmware (or a ROM in DSi mode) shows the "This firmware is not bootable." error.

**Steps to reproduce:**
1. Setup BIOS and firmware files for both DS and DSi
2. Set the console type to DSi
3. Boot the firmware (or any ROM)
4. Stop the emulation
5. Set the console type to DS
6. Boot the firmware

**Expected results:**  
The DS firmware is booted.

**Actual results:**  
The "This firmware is not bootable." popup error is shown even though the firmware can be booted

## Fix
This is caused because in `NDS::NeedsDirectBoot()`, the check `SPI_Firmware::GetFirmwareLength() == 0x20000` is made. However, the firmware is not loaded before performing this check, so it's actually checking against the firmware length of the previous run. By clearing the firmware length and firmware mask on `SPI_Firmware::DeInit()`, we discard the values of the last run and the check no longer fails.

This may not be the ideal solution. Maybe the firmware should be loaded before attempting to perform this check, but I would rather have your opinions on this.