### PR TITLE
Edge fill rules for swapped polygons + a few minor fixes to edge cases

### DIFF
--- a/src/GPU3D_Soft.cpp
+++ b/src/GPU3D_Soft.cpp
@@ -746,7 +746,6 @@ void SoftRenderer::RenderShadowMaskScanline(RendererPolygon* rp, s32 y)
         std::swap(xstart, xend);
         std::swap(wl, wr);
         std::swap(zl, zr);
-        std::swap(l_filledge, r_filledge);
         
         // CHECKME: edge fill rules for swapped opaque shadow mask polygons
         if ((polyalpha < 31) || (RenderDispCnt & (3<<4)))

--- a/src/GPU3D_Soft.cpp
+++ b/src/GPU3D_Soft.cpp
@@ -976,7 +976,7 @@ void SoftRenderer::RenderPolygonScanline(RendererPolygon* rp, s32 y)
         // not accurate in all situations: needs more research
         // * right edge is filled if slope < -1
         // * left edge is filled if slope >= -1
-        // * right edges with slope = 0 are *not* filled, unless the below rule is true
+        // * right edges with slope = 0 are filled if the left edge slope = 0 ...because reasons.
         // edges are always filled if antialiasing/edgemarking are enabled or if the pixels are translucent
         if ((polyalpha < 31) || wireframe || (RenderDispCnt & ((1<<4)|(1<<5))))
         {
@@ -986,7 +986,7 @@ void SoftRenderer::RenderPolygonScanline(RendererPolygon* rp, s32 y)
         else
         {
             l_filledge = (rp->SlopeR.Negative || !rp->SlopeR.XMajor);
-            r_filledge = (!rp->SlopeL.Negative && rp->SlopeL.XMajor);
+            r_filledge = (!rp->SlopeL.Negative && rp->SlopeL.XMajor || (rp->SlopeR.Increment==0));
         }
     }
     else

--- a/src/GPU3D_Soft.cpp
+++ b/src/GPU3D_Soft.cpp
@@ -756,8 +756,11 @@ void SoftRenderer::RenderShadowMaskScanline(RendererPolygon* rp, s32 y)
         }
         else
         {
-            l_filledge = (rp->SlopeR.Negative || !rp->SlopeR.XMajor);
-            r_filledge = (!rp->SlopeL.Negative && rp->SlopeL.XMajor) || (!(rp->SlopeL.Negative && rp->SlopeL.XMajor) && rp->SlopeR.Increment==0);
+            l_filledge = (rp->SlopeR.Negative || !rp->SlopeR.XMajor)
+            || (y == polygon->YBottom-1) && rp->SlopeR.XMajor && (rp->NextVL != rp->NextVR);
+            r_filledge = (!rp->SlopeL.Negative && rp->SlopeL.XMajor)
+            || (!(rp->SlopeL.Negative && rp->SlopeL.XMajor) && rp->SlopeR.Increment==0)
+            || (y == polygon->YBottom-1) && rp->SlopeL.XMajor && (rp->NextVL != rp->NextVR);
         }
     }
     else
@@ -781,8 +784,10 @@ void SoftRenderer::RenderShadowMaskScanline(RendererPolygon* rp, s32 y)
         }
         else
         {
-            l_filledge = (rp->SlopeL.Negative || !rp->SlopeL.XMajor);
-            r_filledge = (!rp->SlopeR.Negative && rp->SlopeR.XMajor) || (rp->SlopeR.Increment==0);
+            l_filledge = (rp->SlopeL.Negative || !rp->SlopeL.XMajor)
+            || (y == polygon->YBottom-1) && rp->SlopeL.XMajor && (rp->NextVL != rp->NextVR);
+            r_filledge = (!rp->SlopeR.Negative && rp->SlopeR.XMajor) || (rp->SlopeR.Increment==0)
+            || (y == polygon->YBottom-1) && rp->SlopeR.XMajor && (rp->NextVL != rp->NextVR);
         }
     }
 
@@ -976,6 +981,7 @@ void SoftRenderer::RenderPolygonScanline(RendererPolygon* rp, s32 y)
         // edge fill rules for swapped opaque edges:
         // * right edge is filled if slope > 1, or if the left edge = 0, but is never filled if it is < -1
         // * left edge is filled if slope <= 1
+        // * the bottom-most pixel of negative x-major slopes are filled if they are next to a flat bottom edge
         // edges are always filled if antialiasing/edgemarking are enabled or if the pixels are translucent
         if ((polyalpha < 31) || wireframe || (RenderDispCnt & ((1<<4)|(1<<5))))
         {
@@ -984,8 +990,11 @@ void SoftRenderer::RenderPolygonScanline(RendererPolygon* rp, s32 y)
         }
         else
         {
-            l_filledge = (rp->SlopeR.Negative || !rp->SlopeR.XMajor);
-            r_filledge = (!rp->SlopeL.Negative && rp->SlopeL.XMajor) || (!(rp->SlopeL.Negative && rp->SlopeL.XMajor) && rp->SlopeR.Increment==0);
+            l_filledge = (rp->SlopeR.Negative || !rp->SlopeR.XMajor)
+            || (y == polygon->YBottom-1) && rp->SlopeR.XMajor && (rp->NextVL != rp->NextVR);
+            r_filledge = (!rp->SlopeL.Negative && rp->SlopeL.XMajor)
+            || (!(rp->SlopeL.Negative && rp->SlopeL.XMajor) && rp->SlopeR.Increment==0)
+            || (y == polygon->YBottom-1) && rp->SlopeL.XMajor && (rp->NextVL != rp->NextVR);
         }
     }
     else
@@ -1005,6 +1014,7 @@ void SoftRenderer::RenderPolygonScanline(RendererPolygon* rp, s32 y)
         // * right edge is filled if slope > 1
         // * left edge is filled if slope <= 1
         // * edges with slope = 0 are always filled
+        // * the bottom-most pixel of negative x-major slopes are filled if they are next to a flat bottom edge
         // edges are always filled if antialiasing/edgemarking are enabled or if the pixels are translucent
         if ((polyalpha < 31) || wireframe || (RenderDispCnt & ((1<<4)|(1<<5))))
         {
@@ -1013,8 +1023,10 @@ void SoftRenderer::RenderPolygonScanline(RendererPolygon* rp, s32 y)
         }
         else
         {
-            l_filledge = (rp->SlopeL.Negative || !rp->SlopeL.XMajor);
-            r_filledge = (!rp->SlopeR.Negative && rp->SlopeR.XMajor) || (rp->SlopeR.Increment==0);
+            l_filledge = (rp->SlopeL.Negative || !rp->SlopeL.XMajor)
+            || (y == polygon->YBottom-1) && rp->SlopeL.XMajor && (rp->NextVL != rp->NextVR);
+            r_filledge = (!rp->SlopeR.Negative && rp->SlopeR.XMajor) || (rp->SlopeR.Increment==0)
+            || (y == polygon->YBottom-1) && rp->SlopeR.XMajor && (rp->NextVL != rp->NextVR);
         }
     }
 

--- a/src/GPU3D_Soft.cpp
+++ b/src/GPU3D_Soft.cpp
@@ -1060,7 +1060,7 @@ void SoftRenderer::RenderPolygonScanline(RendererPolygon* rp, s32 y)
         if (xcov == 0x3FF) xcov = 0;
     }
 
-    if (!l_filledge) x = std::min(xlimit, xend-r_edgelen+1);
+    if (!l_filledge) x = xlimit;
     else
     for (; x < xlimit; x++)
     {
@@ -1156,7 +1156,7 @@ void SoftRenderer::RenderPolygonScanline(RendererPolygon* rp, s32 y)
     if (xlimit > xend+1) xlimit = xend+1;
     if (xlimit > 256) xlimit = 256;
 
-    if (wireframe && !edge) x = xlimit;
+    if (wireframe && !edge) x = std::max(x, xlimit);
     else
     for (; x < xlimit; x++)
     {

--- a/src/GPU3D_Soft.cpp
+++ b/src/GPU3D_Soft.cpp
@@ -757,10 +757,10 @@ void SoftRenderer::RenderShadowMaskScanline(RendererPolygon* rp, s32 y)
         else
         {
             l_filledge = (rp->SlopeR.Negative || !rp->SlopeR.XMajor)
-            || (y == polygon->YBottom-1) && rp->SlopeR.XMajor && (rp->NextVL != rp->NextVR);
+            || (y == polygon->YBottom-1) && rp->SlopeR.XMajor && (vlnext->FinalPosition[0] != vrnext->FinalPosition[0]);
             r_filledge = (!rp->SlopeL.Negative && rp->SlopeL.XMajor)
             || (!(rp->SlopeL.Negative && rp->SlopeL.XMajor) && rp->SlopeR.Increment==0)
-            || (y == polygon->YBottom-1) && rp->SlopeL.XMajor && (rp->NextVL != rp->NextVR);
+            || (y == polygon->YBottom-1) && rp->SlopeL.XMajor && (vlnext->FinalPosition[0] != vrnext->FinalPosition[0]);
         }
     }
     else
@@ -785,9 +785,9 @@ void SoftRenderer::RenderShadowMaskScanline(RendererPolygon* rp, s32 y)
         else
         {
             l_filledge = (rp->SlopeL.Negative || !rp->SlopeL.XMajor)
-            || (y == polygon->YBottom-1) && rp->SlopeL.XMajor && (rp->NextVL != rp->NextVR);
+            || (y == polygon->YBottom-1) && rp->SlopeL.XMajor && (vlnext->FinalPosition[0] != vrnext->FinalPosition[0]);
             r_filledge = (!rp->SlopeR.Negative && rp->SlopeR.XMajor) || (rp->SlopeR.Increment==0)
-            || (y == polygon->YBottom-1) && rp->SlopeR.XMajor && (rp->NextVL != rp->NextVR);
+            || (y == polygon->YBottom-1) && rp->SlopeR.XMajor && (vlnext->FinalPosition[0] != vrnext->FinalPosition[0]);
         }
     }
 
@@ -991,10 +991,10 @@ void SoftRenderer::RenderPolygonScanline(RendererPolygon* rp, s32 y)
         else
         {
             l_filledge = (rp->SlopeR.Negative || !rp->SlopeR.XMajor)
-            || (y == polygon->YBottom-1) && rp->SlopeR.XMajor && (rp->NextVL != rp->NextVR);
+            || (y == polygon->YBottom-1) && rp->SlopeR.XMajor && (vlnext->FinalPosition[0] != vrnext->FinalPosition[0]);
             r_filledge = (!rp->SlopeL.Negative && rp->SlopeL.XMajor)
             || (!(rp->SlopeL.Negative && rp->SlopeL.XMajor) && rp->SlopeR.Increment==0)
-            || (y == polygon->YBottom-1) && rp->SlopeL.XMajor && (rp->NextVL != rp->NextVR);
+            || (y == polygon->YBottom-1) && rp->SlopeL.XMajor && (vlnext->FinalPosition[0] != vrnext->FinalPosition[0]);
         }
     }
     else
@@ -1024,9 +1024,9 @@ void SoftRenderer::RenderPolygonScanline(RendererPolygon* rp, s32 y)
         else
         {
             l_filledge = (rp->SlopeL.Negative || !rp->SlopeL.XMajor)
-            || (y == polygon->YBottom-1) && rp->SlopeL.XMajor && (rp->NextVL != rp->NextVR);
+            || (y == polygon->YBottom-1) && rp->SlopeL.XMajor && (vlnext->FinalPosition[0] != vrnext->FinalPosition[0]);
             r_filledge = (!rp->SlopeR.Negative && rp->SlopeR.XMajor) || (rp->SlopeR.Increment==0)
-            || (y == polygon->YBottom-1) && rp->SlopeR.XMajor && (rp->NextVL != rp->NextVR);
+            || (y == polygon->YBottom-1) && rp->SlopeR.XMajor && (vlnext->FinalPosition[0] != vrnext->FinalPosition[0]);
         }
     }
 


### PR DESCRIPTION
Implements special edge fill rules for swapped polygons, and a few other small fixes.

Left edges follow the same rules as unswapped.
Right edges, however, are very interesting.
![image](https://github.com/melonDS-emu/melonDS/assets/102590697/e9ca1fa3-1c31-4021-ba3d-45da8695257b)
The left half of the diagram isn't super interesting, the only thing different than normal is that the right vertical edge isn't filled due to seemingly a bug, where instead of checking if the right slope is vertical, it checks the left slope to determine if it should fill, this leads us to the right half of the diagram.
This depicts whether the right vertical slope will fill if the left edge is vertical.
Note that the negative x-major slope is excluded from this behavior (for w/e reason).

The consequences of this results in some wonky edge fill behavior such as:
This quad: (218, 15), (183, 98), (192, 101), (192, 44)
![image](https://github.com/melonDS-emu/melonDS/assets/102590697/92146dd7-56da-4b88-8c24-a9a0ce5420c3)
This culled quad: (64, 70) (64, 160) (100, 160) (-50, 107)
![image](https://github.com/melonDS-emu/melonDS/assets/102590697/0f1a384b-c0c2-401b-94e0-9f09fb3e3ce2)

PR also includes a few minor tweaks to line drawing to fix glitched quads like this one: (-67, 40) (64, 160) (192, 160) (28, 156)
(Wireframe enabled to make the quirky rendering that these fixes recreate more apparent.)
![image](https://github.com/melonDS-emu/melonDS/assets/102590697/905cb482-5308-4c73-908d-b3b62d4d8293)

Also fixed: The bottom most pixel of negative x-major slopes is filled if it is next to a flat polygon bottom.
See: This trapezoidal quad:
![image](https://github.com/melonDS-emu/melonDS/assets/102590697/a7f3ef3f-fb8b-4fa6-9649-c34ea487bc58)