### PR TITLE
Fix Incorrect Polygon Swapping Behavior and Implement Correct Rules for Shifting Right Edges Left

### DIFF
--- a/src/GPU3D.cpp
+++ b/src/GPU3D.cpp
@@ -1049,12 +1049,12 @@ void SubmitPolygon()
     v2 = &TempVertexBuffer[2];
     v3 = &TempVertexBuffer[3];
 
-    normalX = ((s64)(v1->Position[1]-v0->Position[1]) * (v2->Position[3]-v0->Position[3]))
-        - ((s64)(v1->Position[3]-v0->Position[3]) * (v2->Position[1]-v0->Position[1]));
-    normalY = ((s64)(v1->Position[3]-v0->Position[3]) * (v2->Position[0]-v0->Position[0]))
-        - ((s64)(v1->Position[0]-v0->Position[0]) * (v2->Position[3]-v0->Position[3]));
-    normalZ = ((s64)(v1->Position[0]-v0->Position[0]) * (v2->Position[1]-v0->Position[1]))
-        - ((s64)(v1->Position[1]-v0->Position[1]) * (v2->Position[0]-v0->Position[0]));
+    normalX = ((s64)(v0->Position[1]-v1->Position[1]) * (v2->Position[3]-v1->Position[3]))
+        - ((s64)(v0->Position[3]-v1->Position[3]) * (v2->Position[1]-v1->Position[1]));
+    normalY = ((s64)(v0->Position[3]-v1->Position[3]) * (v2->Position[0]-v1->Position[0]))
+        - ((s64)(v0->Position[0]-v1->Position[0]) * (v2->Position[3]-v1->Position[3]));
+    normalZ = ((s64)(v0->Position[0]-v1->Position[0]) * (v2->Position[1]-v1->Position[1]))
+        - ((s64)(v0->Position[1]-v1->Position[1]) * (v2->Position[0]-v1->Position[0]));
 
     while ((((normalX>>31) ^ (normalX>>63)) != 0) ||
            (((normalY>>31) ^ (normalY>>63)) != 0) ||
@@ -1065,9 +1065,9 @@ void SubmitPolygon()
         normalZ >>= 4;
     }
 
-    dot = ((s64)v0->Position[0] * normalX) + ((s64)v0->Position[1] * normalY) + ((s64)v0->Position[3] * normalZ);
+    dot = ((s64)v1->Position[0] * normalX) + ((s64)v1->Position[1] * normalY) + ((s64)v1->Position[3] * normalZ);
 
-    bool facingview = (dot >= 0);
+    bool facingview = (dot <= 0);
 
     if (facingview)
     {
@@ -1077,7 +1077,7 @@ void SubmitPolygon()
             return;
         }
     }
-    else if (dot <= 0)
+    else if (dot > 0)
     {
         if (!(CurPolygonAttr & (1<<6)))
         {

--- a/src/GPU3D.cpp
+++ b/src/GPU3D.cpp
@@ -1049,12 +1049,12 @@ void SubmitPolygon()
     v2 = &TempVertexBuffer[2];
     v3 = &TempVertexBuffer[3];
 
-    normalX = ((s64)(v0->Position[1]-v1->Position[1]) * (v2->Position[3]-v1->Position[3]))
-        - ((s64)(v0->Position[3]-v1->Position[3]) * (v2->Position[1]-v1->Position[1]));
-    normalY = ((s64)(v0->Position[3]-v1->Position[3]) * (v2->Position[0]-v1->Position[0]))
-        - ((s64)(v0->Position[0]-v1->Position[0]) * (v2->Position[3]-v1->Position[3]));
-    normalZ = ((s64)(v0->Position[0]-v1->Position[0]) * (v2->Position[1]-v1->Position[1]))
-        - ((s64)(v0->Position[1]-v1->Position[1]) * (v2->Position[0]-v1->Position[0]));
+    normalX = ((s64)(v1->Position[1]-v0->Position[1]) * (v2->Position[3]-v0->Position[3]))
+        - ((s64)(v1->Position[3]-v0->Position[3]) * (v2->Position[1]-v0->Position[1]));
+    normalY = ((s64)(v1->Position[3]-v0->Position[3]) * (v2->Position[0]-v0->Position[0]))
+        - ((s64)(v1->Position[0]-v0->Position[0]) * (v2->Position[3]-v0->Position[3]));
+    normalZ = ((s64)(v1->Position[0]-v0->Position[0]) * (v2->Position[1]-v0->Position[1]))
+        - ((s64)(v1->Position[1]-v0->Position[1]) * (v2->Position[0]-v0->Position[0]));
 
     while ((((normalX>>31) ^ (normalX>>63)) != 0) ||
            (((normalY>>31) ^ (normalY>>63)) != 0) ||
@@ -1065,9 +1065,9 @@ void SubmitPolygon()
         normalZ >>= 4;
     }
 
-    dot = ((s64)v1->Position[0] * normalX) + ((s64)v1->Position[1] * normalY) + ((s64)v1->Position[3] * normalZ);
+    dot = ((s64)v0->Position[0] * normalX) + ((s64)v0->Position[1] * normalY) + ((s64)v0->Position[3] * normalZ);
 
-    bool facingview = (dot < 0);
+    bool facingview = (dot >= 0);
 
     if (facingview)
     {
@@ -1077,7 +1077,7 @@ void SubmitPolygon()
             return;
         }
     }
-    else if (dot > 0)
+    else if (dot <= 0)
     {
         if (!(CurPolygonAttr & (1<<6)))
         {

--- a/src/GPU3D_Soft.cpp
+++ b/src/GPU3D_Soft.cpp
@@ -742,6 +742,11 @@ void SoftRenderer::RenderShadowMaskScanline(RendererPolygon* rp, s32 y)
     s32 zl = rp->SlopeL.Interp.InterpolateZ(polygon->FinalZ[rp->CurVL], polygon->FinalZ[rp->NextVL], polygon->WBuffer);
     s32 zr = rp->SlopeR.Interp.InterpolateZ(polygon->FinalZ[rp->CurVR], polygon->FinalZ[rp->NextVR], polygon->WBuffer);
 
+    // right vertical edges are pushed 1px to the left as long as either:
+    // the left edge slope is not 0, or the span is not 0 pixels wide, and it is not at the leftmost pixel of the screen
+    if (rp->SlopeR.Increment==0 && (rp->SlopeL.Increment!=0 || xstart != xend) && (xend != 0))
+        xend--;
+
     // if the left and right edges are swapped, render backwards.
     if (xstart > xend)
     {
@@ -955,6 +960,11 @@ void SoftRenderer::RenderPolygonScanline(RendererPolygon* rp, s32 y)
 
     s32 zl = rp->SlopeL.Interp.InterpolateZ(polygon->FinalZ[rp->CurVL], polygon->FinalZ[rp->NextVL], polygon->WBuffer);
     s32 zr = rp->SlopeR.Interp.InterpolateZ(polygon->FinalZ[rp->CurVR], polygon->FinalZ[rp->NextVR], polygon->WBuffer);
+    
+    // right vertical edges are pushed 1px to the left as long as either:
+    // the left edge slope is not 0, or the span is not 0 pixels wide, and it is not at the leftmost pixel of the screen
+    if (rp->SlopeR.Increment==0 && (rp->SlopeL.Increment!=0 || xstart != xend) && (xend != 0))
+        xend--;
 
     // if the left and right edges are swapped, render backwards.
     // on hardware, swapped edges seem to break edge length calculation,

--- a/src/GPU3D_Soft.h
+++ b/src/GPU3D_Soft.h
@@ -233,16 +233,8 @@ private:
 
         s32 SetupDummy(s32 x0)
         {
-            if (side)
-            {
-                dx = -0x40000;
-                x0--;
-            }
-            else
-            {
-                dx = 0;
-            }
-
+            dx = 0;
+            
             this->x0 = x0;
             this->xmin = x0;
             this->xmax = x0;
@@ -278,7 +270,6 @@ private:
             else
             {
                 this->xmin = x0;
-                if (side) this->xmin--;
                 this->xmax = this->xmin;
                 this->Negative = false;
             }
@@ -309,7 +300,7 @@ private:
 
                 if (XMajor)              dx = Negative ? (0x20000 + 0x40000) : (Increment - 0x20000);
                 else if (Increment != 0) dx = Negative ? 0x40000 : 0;
-                else                     dx = -0x40000;
+                else                     dx = 0;
             }
             else
             {


### PR DESCRIPTION
Decided to combine these two fixes into one PR, as the latter is dependent on the former to work properly.
Can be split into two if requested.

**Fix Incorrect Polygon Swapping Behavior:**

I'll be honest I basically just yoinked this from NooDS just to see what would happen and it worked.
In short melonDS was (I'm not familiar with this type of math so I'm not gonna try to explain in detail) but it was using the second vertex where it should've used the first.
Changing that essentially got things working flawlessly... once I inverted everything that was determined by the dot.
possible I messed up something when changing that, since I'm not super familiar with what that part of the code is trying to do.
(should it be > instead of >= ? etc.)
But it fixes odd behavior with the second vertex and polygons being swapped where they shouldn't be.
Or in other words it fixes Mario and Luigi: Partners in Time's time travel scene being broken.

**Implement Correct Rules for Shifting Right Edges Left:**

Based on some personal research into swapped polygon behavior done on a 3ds.
Currently melonDS always shifts right vertical edges left, but there are situations where it should not do so.
This PR implements the rules for this and should result in most affected polygons rendering properly.
Fixes a number of objects in the gen 4 Pokemon games.
Some relevant polygons do not render their textures perfectly for reasons I have yet to fully determine.
Such as this one, which should have the topmost pixel be green:
![image](https://github.com/melonDS-emu/melonDS/assets/102590697/50ba2f10-8238-42d4-a9f0-f6fc4115f2f3)
Seems like the textures are being applied slightly too high up?
