### PR TITLE
Add option to ask for confirmation when resetting or stopping emulation

### DIFF
--- a/src/frontend/qt_sdl/Config.cpp
+++ b/src/frontend/qt_sdl/Config.cpp
@@ -139,6 +139,7 @@ bool MouseHide;
 int MouseHideSeconds;
 
 bool PauseLostFocus;
+bool ConfirmReset;
 
 bool DSBatteryLevelOkay;
 int DSiBatteryLevel;
@@ -330,6 +331,7 @@ ConfigEntry ConfigFile[] =
     {"MouseHide",        1, &MouseHide,        false, false},
     {"MouseHideSeconds", 0, &MouseHideSeconds, 5, false},
     {"PauseLostFocus",   1, &PauseLostFocus,   false, false},
+    {"ConfirmReset",   1, &ConfirmReset,   false, false},
 
     {"DSBatteryLevelOkay",   1, &DSBatteryLevelOkay, true, true},
     {"DSiBatteryLevel",    0, &DSiBatteryLevel, 0xF, true},

--- a/src/frontend/qt_sdl/Config.h
+++ b/src/frontend/qt_sdl/Config.h
@@ -184,6 +184,7 @@ extern bool EnableCheats;
 extern bool MouseHide;
 extern int MouseHideSeconds;
 extern bool PauseLostFocus;
+extern bool ConfirmReset;
 
 extern bool DSBatteryLevelOkay;
 extern int DSiBatteryLevel;

--- a/src/frontend/qt_sdl/InterfaceSettingsDialog.cpp
+++ b/src/frontend/qt_sdl/InterfaceSettingsDialog.cpp
@@ -34,6 +34,7 @@ InterfaceSettingsDialog::InterfaceSettingsDialog(QWidget* parent) : QDialog(pare
     ui->spinMouseHideSeconds->setEnabled(Config::MouseHide != 0);
     ui->spinMouseHideSeconds->setValue(Config::MouseHideSeconds);
     ui->cbPauseLostFocus->setChecked(Config::PauseLostFocus != 0);
+    ui->cbConfirmReset->setChecked(Config::ConfirmReset != 0);
 }
 
 InterfaceSettingsDialog::~InterfaceSettingsDialog()
@@ -60,6 +61,7 @@ void InterfaceSettingsDialog::done(int r)
         Config::MouseHide = ui->cbMouseHide->isChecked() ? 1:0;
         Config::MouseHideSeconds = ui->spinMouseHideSeconds->value();
         Config::PauseLostFocus = ui->cbPauseLostFocus->isChecked() ? 1:0;
+        Config::ConfirmReset = ui->cbConfirmReset->isChecked() ? 1:0;
 
         Config::Save();
 

--- a/src/frontend/qt_sdl/InterfaceSettingsDialog.ui
+++ b/src/frontend/qt_sdl/InterfaceSettingsDialog.ui
@@ -34,6 +34,13 @@
      </property>
     </widget>
    </item>
+   <item row="3" column="0" colspan="4">
+    <widget class="QCheckBox" name="cbConfirmReset">
+     <property name="text">
+      <string>Ask to confirm when stopping or resetting</string>
+     </property>
+    </widget>
+   </item>
    <item row="0" column="0" colspan="5">
     <widget class="QCheckBox" name="cbMouseHide">
      <property name="text">
@@ -44,7 +51,7 @@
    <item row="1" column="1" alignment="Qt::AlignLeft">
     <widget class="QSpinBox" name="spinMouseHideSeconds"/>
    </item>
-   <item row="3" column="0" colspan="5">
+   <item row="4" column="0" colspan="5">
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
@@ -67,6 +74,7 @@
   <tabstop>cbMouseHide</tabstop>
   <tabstop>spinMouseHideSeconds</tabstop>
   <tabstop>cbPauseLostFocus</tabstop>
+  <tabstop>cbConfirmReset</tabstop>
  </tabstops>
  <resources/>
  <connections>

--- a/src/frontend/qt_sdl/main.h
+++ b/src/frontend/qt_sdl/main.h
@@ -296,7 +296,7 @@ private slots:
     void onQuit();
 
     void onPause(bool checked);
-    void onReset();
+    void onReset(bool confirmed);
     void onStop();
     void onFrameStep();
     void onEnableCheats(bool checked);


### PR DESCRIPTION
As the Pause and Reset buttons are really close together, I usually find myself accidentally clicking the Reset button instead. This happens to other people I know too, and I imagine impacts many other people.

This PR adds an option for a confirmation dialog when pressing the Reset or Stop buttons.
