### PR TITLE
Fix #1832

### DIFF
--- a/src/DSi.cpp
+++ b/src/DSi.cpp
@@ -296,7 +296,7 @@ void SetCartInserted(bool inserted)
         SCFG_MC |= 1;
 }
 
-void DecryptModcryptArea(u32 offset, u32 size, u8* iv)
+void DecryptModcryptArea(u32 offset, u32 size, const u8* iv)
 {
     AES_ctx ctx;
     u8 key[16];
@@ -398,7 +398,7 @@ void DecryptModcryptArea(u32 offset, u32 size, u8* iv)
 void SetupDirectBoot()
 {
     bool dsmode = false;
-    NDSHeader& header = NDSCart::Cart->GetHeader();
+    const NDSHeader& header = NDSCart::Cart->GetHeader();
     const u8* cartrom = NDSCart::Cart->GetROM();
     u32 cartid = NDSCart::Cart->ID();
 

--- a/src/DSi.cpp
+++ b/src/DSi.cpp
@@ -583,10 +583,10 @@ void SetupDirectBoot()
     u32 arm9start = 0;
 
     // load the ARM9 secure area
-    if (header.ARM9ROMOffset >= 0x4000 && header.ARM9ROMOffset < 0x8000)
+    if (NDSCart::Cart->HasSecureArea())
     {
-        u8 securearea[0x800];
-        NDSCart::DecryptSecureArea(securearea);
+        NDSCart::Cart->EnsureSecureAreaDecrypted();
+        const std::array<u8, 0x800>& securearea = NDSCart::Cart->SecureArea();
 
         for (u32 i = 0; i < 0x800; i+=4)
         {

--- a/src/DSi_AES.h
+++ b/src/DSi_AES.h
@@ -26,12 +26,12 @@
 #pragma GCC diagnostic ignored "-Wattributes"
 #if defined(__GNUC__) && (__GNUC__ >= 11) // gcc 11.*
 // NOTE: Yes, the compiler does *not* recognize this code pattern, so it is indeed an optimization.
-__attribute((always_inline)) static void Bswap128(void* Dst, void* Src)
+__attribute((always_inline)) static void Bswap128(void* Dst, const void* Src)
 {
     *(__int128*)Dst = __builtin_bswap128(*(__int128*)Src);
 }
 #else
-__attribute((always_inline)) static void Bswap128(void* Dst, void* Src)
+__attribute((always_inline)) static void Bswap128(void* Dst, const void* Src)
 {
     for (int i = 0; i < 16; ++i) 
     { 

--- a/src/NDS.cpp
+++ b/src/NDS.cpp
@@ -423,10 +423,10 @@ void SetupDirectBoot(const std::string& romname)
         u32 arm9start = 0;
 
         // load the ARM9 secure area
-        if (header.ARM9ROMOffset >= 0x4000 && header.ARM9ROMOffset < 0x8000)
+        if (NDSCart::Cart->HasSecureArea())
         {
-            u8 securearea[0x800];
-            NDSCart::DecryptSecureArea(securearea);
+            NDSCart::Cart->EnsureSecureAreaDecrypted();
+            const std::array<u8, 0x800>& securearea = NDSCart::Cart->SecureArea();
 
             for (u32 i = 0; i < 0x800; i+=4)
             {

--- a/src/NDSCart.cpp
+++ b/src/NDSCart.cpp
@@ -1644,8 +1644,7 @@ std::unique_ptr<CartCommon> ParseROM(const u8* romdata, u32 romlen)
     memcpy(cartrom, romdata, romlen);
     memset(cartrom + romlen, 0, cartromsize - romlen);
 
-    NDSHeader header {};
-    memcpy(&header, cartrom, sizeof(header));
+    const NDSHeader& header = *reinterpret_cast<const NDSHeader*>(cartrom);
 
     bool dsi = header.IsDSi();
     bool badDSiDump = false;

--- a/src/NDSCart.cpp
+++ b/src/NDSCart.cpp
@@ -197,9 +197,9 @@ CartCommon::CartCommon(u8* rom, u32 len, u32 chipid, bool badDSiDump, ROMListEnt
     ChipID = chipid;
     ROMParams = romparams;
 
-    memcpy(&Header, rom, sizeof(Header));
-    IsDSi = Header.IsDSi() && !badDSiDump;
-    DSiBase = Header.DSiRegionStart << 19;
+    const NDSHeader& header = GetHeader();
+    IsDSi = header.IsDSi() && !badDSiDump;
+    DSiBase = header.DSiRegionStart << 19;
 }
 
 CartCommon::~CartCommon()

--- a/src/NDSCart.h
+++ b/src/NDSCart.h
@@ -67,8 +67,7 @@ public:
     virtual u8* GetSaveMemory() const;
     virtual u32 GetSaveMemoryLength() const;
 
-    [[nodiscard]] const NDSHeader& GetHeader() const { return Header; }
-    [[nodiscard]] NDSHeader& GetHeader() { return Header; }
+    [[nodiscard]] const NDSHeader& GetHeader() const { return *reinterpret_cast<const NDSHeader*>(ROM); }
 
     /// @return The cartridge's banner if available, or \c nullptr if not.
     [[nodiscard]] const NDSBanner* Banner() const;
@@ -90,9 +89,6 @@ protected:
 
     u32 CmdEncMode;
     u32 DataEncMode;
-    // Kept separate from the ROM data so we can decrypt the modcrypt area
-    // without touching the overall ROM data
-    NDSHeader Header;
     ROMListEntry ROMParams;
 };
 

--- a/src/frontend/qt_sdl/ROMManager.cpp
+++ b/src/frontend/qt_sdl/ROMManager.cpp
@@ -32,6 +32,7 @@
 #include "Platform.h"
 
 #include "NDS.h"
+#include "NDSCart.h"
 #include "DSi.h"
 #include "SPI.h"
 #include "DSi_I2C.h"
@@ -519,6 +520,10 @@ void Reset()
         {
             NDS::SetupDirectBoot(BaseROMName);
         }
+        else
+        {
+            NDSCart::Cart->EnsureSecureAreaEncrypted();
+        }
     }
 }
 
@@ -766,6 +771,10 @@ bool LoadROM(QStringList filepath, bool reset)
         if (Config::DirectBoot || NDS::NeedsDirectBoot())
         {
             NDS::SetupDirectBoot(romname);
+        }
+        else
+        { // The DS itself will want to decrypt the ROM
+            NDSCart::Cart->EnsureSecureAreaEncrypted();
         }
     }
 


### PR DESCRIPTION
This PR ensures that the secure area for a ROM is encrypted before native boot, or that it's decrypted before direct boot. As a result, the ROM will now decrypt properly regardless of which boot-related settings are changed.

Improperly-decrypted ROMs can also be detected, although the frontend doesn't currently do anything with this besides logging an error.

There seems to be a case where the ROM is still improperly encrypted (or decrypted) after changing the config. I'm working on this.