### PR TITLE
Ensure that the new firmware is installed when resetting

### DIFF
--- a/src/frontend/qt_sdl/ROMManager.cpp
+++ b/src/frontend/qt_sdl/ROMManager.cpp
@@ -593,6 +593,8 @@ void Reset()
     NDS::SetConsoleType(Config::ConsoleType);
     if (Config::ConsoleType == 1) EjectGBACart();
     LoadBIOSFiles();
+
+    InstallFirmware();
     NDS::Reset();
     SetBatteryLevels();
 


### PR DESCRIPTION
This should fix firmware being overwritten when resetting after changing the console mode.