### PR TITLE
Conditionally enable JIT_DEBUGPRINT

### DIFF
--- a/src/ARMJIT.cpp
+++ b/src/ARMJIT.cpp
@@ -55,8 +55,11 @@ static_assert(offsetof(ARM, StopExecution) == ARM_StopExecution_offset, "");
 namespace ARMJIT
 {
 
+#ifdef ENABLE_JIT_DEBUGPRINT
+#define JIT_DEBUGPRINT(msg, ...) Platform::Log(Platform::LogLevel::Debug, msg, ## __VA_ARGS__)
+#else
 #define JIT_DEBUGPRINT(msg, ...)
-//#define JIT_DEBUGPRINT(msg, ...) Platform::Log(Platform::LogLevel::Debug, msg, ## __VA_ARGS__)
+#endif
 
 Compiler* JITCompiler;
 


### PR DESCRIPTION
This way, it can be toggled with a compiler flag instead of having to edit the source.