### PR TITLE
Refactor DSi_NAND to manage the mount's lifetime with RAII

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -25,6 +25,7 @@ add_library(core STATIC
     DSi_NWifi.cpp
     DSi_SD.cpp
     DSi_SPI_TSC.cpp
+    FATIO.cpp
     FATStorage.cpp
     FIFO.h
     GBACart.cpp
@@ -51,7 +52,6 @@ add_library(core STATIC
     Wifi.cpp
     WifiAP.cpp
 
-    fatfs/diskio.c
     fatfs/ff.c
     fatfs/ffsystem.c
     fatfs/ffunicode.c

--- a/src/DSi_AES.h
+++ b/src/DSi_AES.h
@@ -26,12 +26,12 @@
 #pragma GCC diagnostic ignored "-Wattributes"
 #if defined(__GNUC__) && (__GNUC__ >= 11) // gcc 11.*
 // NOTE: Yes, the compiler does *not* recognize this code pattern, so it is indeed an optimization.
-__attribute((always_inline)) static void Bswap128(void* Dst, void* Src)
+__attribute((always_inline)) static void Bswap128(void* Dst, const void* Src)
 {
     *(__int128*)Dst = __builtin_bswap128(*(__int128*)Src);
 }
 #else
-__attribute((always_inline)) static void Bswap128(void* Dst, void* Src)
+__attribute((always_inline)) static void Bswap128(void* Dst, const void* Src)
 {
     for (int i = 0; i < 16; ++i) 
     { 

--- a/src/DSi_NAND.cpp
+++ b/src/DSi_NAND.cpp
@@ -22,6 +22,7 @@
 #include "DSi.h"
 #include "DSi_AES.h"
 #include "DSi_NAND.h"
+#include "FATIO.h"
 #include "Platform.h"
 
 #include "sha1/sha1.hpp"

--- a/src/FATIO.cpp
+++ b/src/FATIO.cpp
@@ -1,15 +1,24 @@
-/*-----------------------------------------------------------------------*/
-/* Low level disk I/O module SKELETON for FatFs     (C)ChaN, 2019        */
-/*-----------------------------------------------------------------------*/
-/* If a working storage control module is available, it should be        */
-/* attached to the FatFs via a glue function rather than modifying it.   */
-/* This is an example of glue functions to attach various exsisting      */
-/* storage control modules to the FatFs module with a defined API.       */
-/*-----------------------------------------------------------------------*/
+/*
+    Copyright 2016-2023 melonDS team
 
-#include "ff.h"			/* Obtains integer types */
-#include "diskio.h"		/* Declarations of disk functions */
+    This file is part of melonDS.
 
+    melonDS is free software: you can redistribute it and/or modify it under
+    the terms of the GNU General Public License as published by the Free
+    Software Foundation, either version 3 of the License, or (at your option)
+    any later version.
+
+    melonDS is distributed in the hope that it will be useful, but WITHOUT ANY
+    WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+    FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with melonDS. If not, see http://www.gnu.org/licenses/.
+*/
+
+#include "FATIO.h"
+#include "fatfs/ff.h"
+#include "fatfs/diskio.h"
 
 static ff_disk_read_cb ReadCb;
 static ff_disk_write_cb WriteCb;
@@ -17,7 +26,7 @@ static LBA_t SectorCount;
 static DSTATUS Status = STA_NOINIT | STA_NODISK;
 
 
-void ff_disk_open(ff_disk_read_cb readcb, ff_disk_write_cb writecb, LBA_t seccnt)
+void ff_disk_open(const ff_disk_read_cb& readcb, const ff_disk_write_cb& writecb, LBA_t seccnt)
 {
     if (!readcb) return;
 
@@ -30,10 +39,10 @@ void ff_disk_open(ff_disk_read_cb readcb, ff_disk_write_cb writecb, LBA_t seccnt
     else          Status &= ~STA_PROTECT;
 }
 
-void ff_disk_close(void)
+void ff_disk_close()
 {
-    ReadCb = (void*)0;
-    WriteCb = (void*)0;
+    ReadCb = nullptr;
+    WriteCb = nullptr;
     SectorCount = 0;
 
     Status &= ~STA_PROTECT;

--- a/src/FATIO.h
+++ b/src/FATIO.h
@@ -1,0 +1,34 @@
+/*
+    Copyright 2016-2023 melonDS team
+
+    This file is part of melonDS.
+
+    melonDS is free software: you can redistribute it and/or modify it under
+    the terms of the GNU General Public License as published by the Free
+    Software Foundation, either version 3 of the License, or (at your option)
+    any later version.
+
+    melonDS is distributed in the hope that it will be useful, but WITHOUT ANY
+    WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+    FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with melonDS. If not, see http://www.gnu.org/licenses/.
+*/
+
+
+#ifndef FATIO_H
+#define FATIO_H
+
+#include <functional>
+#include "fatfs/ff.h"
+
+// extra additions for interfacing with melonDS
+
+using ff_disk_read_cb = std::function<UINT(BYTE*, LBA_t, UINT)>;
+using ff_disk_write_cb = std::function<UINT(const BYTE*, LBA_t, UINT)>;
+
+void ff_disk_open(const ff_disk_read_cb& readcb, const ff_disk_write_cb& writecb, LBA_t seccnt);
+void ff_disk_close();
+
+#endif // FATIO_H

--- a/src/FATStorage.cpp
+++ b/src/FATStorage.cpp
@@ -21,6 +21,7 @@
 #include <inttypes.h>
 #include <vector>
 
+#include "FATIO.h"
 #include "FATStorage.h"
 #include "Platform.h"
 
@@ -122,7 +123,7 @@ UINT FATStorage::FF_ReadStorage(BYTE* buf, LBA_t sector, UINT num)
     return ReadSectorsInternal(FF_File, FF_FileSize, sector, num, buf);
 }
 
-UINT FATStorage::FF_WriteStorage(BYTE* buf, LBA_t sector, UINT num)
+UINT FATStorage::FF_WriteStorage(const BYTE* buf, LBA_t sector, UINT num)
 {
     return WriteSectorsInternal(FF_File, FF_FileSize, sector, num, buf);
 }
@@ -157,7 +158,7 @@ u32 FATStorage::ReadSectorsInternal(FileHandle* file, u64 filelen, u32 start, u3
     return res;
 }
 
-u32 FATStorage::WriteSectorsInternal(FileHandle* file, u64 filelen, u32 start, u32 num, u8* data)
+u32 FATStorage::WriteSectorsInternal(FileHandle* file, u64 filelen, u32 start, u32 num, const u8* data)
 {
     if (!file) return 0;
 

--- a/src/FATStorage.h
+++ b/src/FATStorage.h
@@ -55,10 +55,10 @@ private:
     static Platform::FileHandle* FF_File;
     static u64 FF_FileSize;
     static UINT FF_ReadStorage(BYTE* buf, LBA_t sector, UINT num);
-    static UINT FF_WriteStorage(BYTE* buf, LBA_t sector, UINT num);
+    static UINT FF_WriteStorage(const BYTE* buf, LBA_t sector, UINT num);
 
     static u32 ReadSectorsInternal(Platform::FileHandle* file, u64 filelen, u32 start, u32 num, u8* data);
-    static u32 WriteSectorsInternal(Platform::FileHandle* file, u64 filelen, u32 start, u32 num, u8* data);
+    static u32 WriteSectorsInternal(Platform::FileHandle* file, u64 filelen, u32 start, u32 num, const u8* data);
 
     void LoadIndex();
     void SaveIndex();

--- a/src/fatfs/ff.h
+++ b/src/fatfs/ff.h
@@ -414,16 +414,6 @@ int ff_del_syncobj (FF_SYNC_t sobj);	/* Delete a sync object */
 #define AM_DIR	0x10	/* Directory */
 #define AM_ARC	0x20	/* Archive */
 
-
-// extra additions for interfacing with melonDS
-
-typedef UINT (*ff_disk_read_cb)(BYTE* buff, LBA_t sector, UINT count);
-typedef UINT (*ff_disk_write_cb)(BYTE* buff, LBA_t sector, UINT count);
-
-void ff_disk_open(ff_disk_read_cb readcb, ff_disk_write_cb writecb, LBA_t seccnt);
-void ff_disk_close(void);
-
-
 #ifdef __cplusplus
 }
 #endif

--- a/src/frontend/qt_sdl/TitleManagerDialog.cpp
+++ b/src/frontend/qt_sdl/TitleManagerDialog.cpp
@@ -32,7 +32,7 @@
 
 using namespace Platform;
 
-bool TitleManagerDialog::NANDInited = false;
+std::unique_ptr<DSi_NAND::NANDMount> TitleManagerDialog::nand = nullptr;
 TitleManagerDialog* TitleManagerDialog::currentDlg = nullptr;
 
 extern std::string EmuDirectory;
@@ -47,7 +47,7 @@ TitleManagerDialog::TitleManagerDialog(QWidget* parent) : QDialog(parent), ui(ne
 
     const u32 category = 0x00030004;
     std::vector<u32> titlelist;
-    DSi_NAND::ListTitles(category, titlelist);
+    nand->ListTitles(category, titlelist);
 
     for (std::vector<u32>::iterator it = titlelist.begin(); it != titlelist.end(); it++)
     {
@@ -109,7 +109,7 @@ void TitleManagerDialog::createTitleItem(u32 category, u32 titleid)
     NDSHeader header;
     NDSBanner banner;
 
-    DSi_NAND::GetTitleInfo(category, titleid, version, &header, &banner);
+    nand->GetTitleInfo(category, titleid, version, &header, &banner);
 
     u32 icondata[32*32];
     ROMManager::ROMIcon(banner.Icon, banner.Palette, icondata);
@@ -137,7 +137,7 @@ void TitleManagerDialog::createTitleItem(u32 category, u32 titleid)
 
 bool TitleManagerDialog::openNAND()
 {
-    NANDInited = false;
+    nand = nullptr;
 
     FileHandle* bios7i = Platform::OpenLocalFile(Config::DSiBIOS7Path, FileMode::Read);
     if (!bios7i)
@@ -148,22 +148,19 @@ bool TitleManagerDialog::openNAND()
     FileRead(es_keyY, 16, 1, bios7i);
     CloseFile(bios7i);
 
-    if (!DSi_NAND::Init(es_keyY))
-    {
+    nand = std::make_unique<DSi_NAND::NANDMount>(es_keyY);
+    if (!*nand)
+    { // If loading and mounting the NAND image failed...
+        nand = nullptr;
         return false;
     }
 
-    NANDInited = true;
     return true;
 }
 
 void TitleManagerDialog::closeNAND()
 {
-    if (NANDInited)
-    {
-        DSi_NAND::DeInit();
-        NANDInited = false;
-    }
+    nand = nullptr;
 }
 
 void TitleManagerDialog::done(int r)
@@ -175,7 +172,7 @@ void TitleManagerDialog::done(int r)
 
 void TitleManagerDialog::on_btnImportTitle_clicked()
 {
-    TitleImportDialog* importdlg = new TitleImportDialog(this, importAppPath, &importTmdData, importReadOnly);
+    TitleImportDialog* importdlg = new TitleImportDialog(this, importAppPath, &importTmdData, importReadOnly, nand);
     importdlg->open();
     connect(importdlg, &TitleImportDialog::finished, this, &TitleManagerDialog::onImportTitleFinished);
 
@@ -190,14 +187,16 @@ void TitleManagerDialog::onImportTitleFinished(int res)
     titleid[0] = importTmdData.GetCategory();
     titleid[1] = importTmdData.GetID();
 
+    assert(nand != nullptr);
+    assert(*nand);
     // remove anything that might hinder the install
-    DSi_NAND::DeleteTitle(titleid[0], titleid[1]);
+    nand->DeleteTitle(titleid[0], titleid[1]);
 
-    bool importres = DSi_NAND::ImportTitle(importAppPath.toStdString().c_str(), importTmdData, importReadOnly);
+    bool importres = nand->ImportTitle(importAppPath.toStdString().c_str(), importTmdData, importReadOnly);
     if (!importres)
     {
         // remove a potential half-completed install
-        DSi_NAND::DeleteTitle(titleid[0], titleid[1]);
+        nand->DeleteTitle(titleid[0], titleid[1]);
 
         QMessageBox::critical(this,
                               "Import title - melonDS",
@@ -224,7 +223,7 @@ void TitleManagerDialog::on_btnDeleteTitle_clicked()
         return;
 
     u64 titleid = cur->data(Qt::UserRole).toULongLong();
-    DSi_NAND::DeleteTitle((u32)(titleid >> 32), (u32)titleid);
+    nand->DeleteTitle((u32)(titleid >> 32), (u32)titleid);
 
     delete cur;
 }
@@ -317,7 +316,7 @@ void TitleManagerDialog::onImportTitleData()
     }
 
     u64 titleid = cur->data(Qt::UserRole).toULongLong();
-    bool res = DSi_NAND::ImportTitleData((u32)(titleid >> 32), (u32)titleid, type, file.toStdString().c_str());
+    bool res = nand->ImportTitleData((u32)(titleid >> 32), (u32)titleid, type, file.toStdString().c_str());
     if (!res)
     {
         QMessageBox::critical(this,
@@ -370,7 +369,7 @@ void TitleManagerDialog::onExportTitleData()
     if (file.isEmpty()) return;
 
     u64 titleid = cur->data(Qt::UserRole).toULongLong();
-    bool res = DSi_NAND::ExportTitleData((u32)(titleid >> 32), (u32)titleid, type, file.toStdString().c_str());
+    bool res = nand->ExportTitleData((u32)(titleid >> 32), (u32)titleid, type, file.toStdString().c_str());
     if (!res)
     {
         QMessageBox::critical(this,
@@ -380,8 +379,8 @@ void TitleManagerDialog::onExportTitleData()
 }
 
 
-TitleImportDialog::TitleImportDialog(QWidget* parent, QString& apppath, const DSi_TMD::TitleMetadata* tmd, bool& readonly)
-: QDialog(parent), ui(new Ui::TitleImportDialog), appPath(apppath), tmdData(tmd), readOnly(readonly)
+TitleImportDialog::TitleImportDialog(QWidget* parent, QString& apppath, const DSi_TMD::TitleMetadata* tmd, bool& readonly, std::unique_ptr<DSi_NAND::NANDMount>& nand)
+: QDialog(parent), ui(new Ui::TitleImportDialog), appPath(apppath), tmdData(tmd), readOnly(readonly), nand(nand)
 {
     ui->setupUi(this);
     setAttribute(Qt::WA_DeleteOnClose);
@@ -455,7 +454,7 @@ void TitleImportDialog::accept()
         }
     }
 
-    if (DSi_NAND::TitleExists(titleid[1], titleid[0]))
+    if (nand->TitleExists(titleid[1], titleid[0]))
     {
         if (QMessageBox::question(this,
                                   "Import title - melonDS",

--- a/src/frontend/qt_sdl/TitleManagerDialog.h
+++ b/src/frontend/qt_sdl/TitleManagerDialog.h
@@ -19,6 +19,7 @@
 #ifndef TITLEMANAGERDIALOG_H
 #define TITLEMANAGERDIALOG_H
 
+#include <memory>
 #include <QDialog>
 #include <QMessageBox>
 #include <QListWidget>
@@ -30,6 +31,11 @@
 #include <QNetworkAccessManager>
 
 #include "DSi_TMD.h"
+
+namespace DSi_NAND
+{
+    class NANDMount;
+}
 
 namespace Ui
 {
@@ -47,7 +53,7 @@ public:
     explicit TitleManagerDialog(QWidget* parent);
     ~TitleManagerDialog();
 
-    static bool NANDInited;
+    static std::unique_ptr<DSi_NAND::NANDMount> nand;
     static bool openNAND();
     static void closeNAND();
 
@@ -106,7 +112,7 @@ class TitleImportDialog : public QDialog
     Q_OBJECT
 
 public:
-    explicit TitleImportDialog(QWidget* parent, QString& apppath, const DSi_TMD::TitleMetadata* tmd, bool& readonly);
+    explicit TitleImportDialog(QWidget* parent, QString& apppath, const DSi_TMD::TitleMetadata* tmd, bool& readonly, std::unique_ptr<DSi_NAND::NANDMount>& nand);
     ~TitleImportDialog();
 
 private slots:
@@ -119,6 +125,7 @@ private slots:
 
 private:
     Ui::TitleImportDialog* ui;
+    std::unique_ptr<DSi_NAND::NANDMount>& nand;
 
     QButtonGroup* grpTmdSource;
 


### PR DESCRIPTION
This is another small prerequisite PR in my storage refactoring series.

This PR introduces the following small refactorings:

- `DSi_NAND::NANDMount` is introduced, which mounts/unmounts a file system image with fatfs. The image is mounted upon creation and unmounted upon destruction.
- The contents of `diskio.c` are moved out of fatfs and into the main `src` directory, since it consists of application-specific logic and declarations.
- The callbacks registered by `ff_disk_open` now accept `std::function`s instead of plain function pointers, so that they don't need to rely on a particular global `NANDMount`.

Once this PR is merged, next on my list will be to move the NAND's disk image loading logic from the core to the frontend.