### PR TITLE
Fix Certain Slopes Having Bugged Anti-Aliasing + Rewrite Of AA Code

### DIFF
--- a/src/GPU3D_Soft.cpp
+++ b/src/GPU3D_Soft.cpp
@@ -741,8 +741,8 @@ void SoftRenderer::RenderShadowMaskScanline(RendererPolygon* rp, s32 y)
         interp_start = &rp->SlopeR.Interp;
         interp_end = &rp->SlopeL.Interp;
 
-        rp->SlopeR.EdgeParams<true>(&l_edgelen, &l_edgecov);
-        rp->SlopeL.EdgeParams<true>(&r_edgelen, &r_edgecov);
+        rp->SlopeR.EdgeParams(&l_edgelen, &l_edgecov, true);
+        rp->SlopeL.EdgeParams(&r_edgelen, &r_edgecov, true);
 
         std::swap(xstart, xend);
         std::swap(wl, wr);
@@ -773,9 +773,9 @@ void SoftRenderer::RenderShadowMaskScanline(RendererPolygon* rp, s32 y)
         interp_start = &rp->SlopeL.Interp;
         interp_end = &rp->SlopeR.Interp;
 
-        rp->SlopeL.EdgeParams<false>(&l_edgelen, &l_edgecov);
-        rp->SlopeR.EdgeParams<false>(&r_edgelen, &r_edgecov);
-
+        rp->SlopeL.EdgeParams(&l_edgelen, &l_edgecov, false);
+        rp->SlopeR.EdgeParams(&r_edgelen, &r_edgecov, false);
+        
         // CHECKME: edge fill rules for unswapped opaque shadow mask polygons
         if ((GPU.GPU3D.RenderDispCnt & ((1<<4)|(1<<5))) || ((polyalpha < 31) && (GPU.GPU3D.RenderDispCnt & (1<<3))) || wireframe)
         {
@@ -970,8 +970,8 @@ void SoftRenderer::RenderPolygonScanline(RendererPolygon* rp, s32 y)
         interp_start = &rp->SlopeR.Interp;
         interp_end = &rp->SlopeL.Interp;
 
-        rp->SlopeR.EdgeParams<true>(&l_edgelen, &l_edgecov);
-        rp->SlopeL.EdgeParams<true>(&r_edgelen, &r_edgecov);
+        rp->SlopeR.EdgeParams(&l_edgelen, &l_edgecov, true);
+        rp->SlopeL.EdgeParams(&r_edgelen, &r_edgecov, true);
 
         std::swap(xstart, xend);
         std::swap(wl, wr);
@@ -1008,8 +1008,8 @@ void SoftRenderer::RenderPolygonScanline(RendererPolygon* rp, s32 y)
         interp_start = &rp->SlopeL.Interp;
         interp_end = &rp->SlopeR.Interp;
 
-        rp->SlopeL.EdgeParams<false>(&l_edgelen, &l_edgecov);
-        rp->SlopeR.EdgeParams<false>(&r_edgelen, &r_edgecov);
+        rp->SlopeL.EdgeParams(&l_edgelen, &l_edgecov, false);
+        rp->SlopeR.EdgeParams(&r_edgelen, &r_edgecov, false);
 
         // edge fill rules for unswapped opaque edges:
         // * right edge is filled if slope > 1

--- a/src/GPU3D_Soft.cpp
+++ b/src/GPU3D_Soft.cpp
@@ -1070,11 +1070,7 @@ void SoftRenderer::RenderPolygonScanline(RendererPolygon* rp, s32 y)
     xlimit = xstart+l_edgelen;
     if (xlimit > xend+1) xlimit = xend+1;
     if (xlimit > 256) xlimit = 256;
-    if (l_edgecov & (1<<31))
-    {
-        xcov = (l_edgecov >> 12) & 0x3FF;
-        if (xcov == 0x3FF) xcov = 0;
-    }
+    if (l_edgecov & (1<<31)) xcov = (l_edgecov >> 12) & 0x3FF;
 
     if (!l_filledge) x = xlimit;
     else
@@ -1259,11 +1255,7 @@ void SoftRenderer::RenderPolygonScanline(RendererPolygon* rp, s32 y)
     edge = yedge | 0x2;
     xlimit = xend+1;
     if (xlimit > 256) xlimit = 256;
-    if (r_edgecov & (1<<31))
-    {
-        xcov = (r_edgecov >> 12) & 0x3FF;
-        if (xcov == 0x3FF) xcov = 0;
-    }
+    if (r_edgecov & (1<<31)) xcov = (r_edgecov >> 12) & 0x3FF;
 
     if (r_filledge)
     for (; x < xlimit; x++)

--- a/src/GPU3D_Soft.h
+++ b/src/GPU3D_Soft.h
@@ -352,13 +352,10 @@ private:
         {
             // only do length calc for right side when swapped as it's
             // only needed for aa calcs, as actual line spans are broken
-            if (!swapped || side)
-            {
-                if (side ^ Negative)
-                    *length = (dx >> 18) - ((dx-Increment) >> 18);
-                else
-                    *length = ((dx+Increment) >> 18) - (dx >> 18);
-            }
+            if (side ^ Negative)
+                *length = (dx >> 18) - ((dx-Increment) >> 18);
+            else
+                *length = ((dx+Increment) >> 18) - (dx >> 18);
 
             // for X-major edges, we return the coverage
             // for the first pixel, and the increment for

--- a/src/GPU3D_Soft.h
+++ b/src/GPU3D_Soft.h
@@ -236,6 +236,7 @@ private:
             dx = 0;
 
             this->x0 = x0;
+            this->y0 = y0;
             this->xmin = x0;
             this->xmax = x0;
 
@@ -253,6 +254,7 @@ private:
         constexpr s32 Setup(s32 x0, s32 x1, s32 y0, s32 y1, s32 w0, s32 w1, s32 y)
         {
             this->x0 = x0;
+            this->y0 = y0;
             this->y = y;
 
             if (x1 > x0)
@@ -367,7 +369,13 @@ private:
             if (side)     startx = startx - *length + 1;
 
             s32 startcov = (((startx << 10) + 0x1FF) * ylen) / xlen;
-            *coverage = (1<<31) | ((startcov & 0x3FF) << 12) | (xcov_incr & 0x3FF);
+
+            // fix the y value for negative slopes
+            s32 ycoord = Negative ? (ylen << 10) - startcov >> 10 : startcov >> 10;
+            // if yvalue is not equal to actual y value, invert coverage value
+            if (ycoord != y - y0) startcov = 0x3FF - (startcov & 0x3FF);
+
+            *coverage = (1<<31) | (startcov << 12) | (xcov_incr & 0x3FF);
 
             if constexpr (swapped) *length = 1;
         }
@@ -419,7 +427,7 @@ private:
         Interpolator<1> Interp;
 
     private:
-        s32 x0, xmin, xmax;
+        s32 x0, y0, xmin, xmax;
         s32 xlen, ylen;
         s32 dx;
         s32 y;

--- a/src/GPU3D_Soft.h
+++ b/src/GPU3D_Soft.h
@@ -347,13 +347,12 @@ private:
             else if (ret > xmax) ret = xmax;
             return ret;
         }
-
-        template<bool swapped>
-        constexpr void EdgeParams_XMajor(s32* length, s32* coverage) const
+        
+        constexpr void EdgeParams_XMajor(s32* length, s32* coverage, bool swapped) const
         {
             // only do length calc for right side when swapped as it's
             // only needed for aa calcs, as actual line spans are broken
-            if constexpr (!swapped || side)
+            if (!swapped || side)
             {
                 if (side ^ Negative)
                     *length = (dx >> 18) - ((dx-Increment) >> 18);
@@ -379,11 +378,10 @@ private:
 
             *coverage = startcov;
 
-            if constexpr (swapped) *length = 1;
+            if (swapped) *length = 1;
         }
 
-        template<bool swapped>
-        constexpr void EdgeParams_YMajor(s32* length, s32* coverage) const
+        constexpr void EdgeParams_YMajor(s32* length, s32* coverage, bool swapped) const
         {
             *length = 1;
 
@@ -404,14 +402,13 @@ private:
                 *coverage = cov << 5;
             }
         }
-
-        template<bool swapped>
-        constexpr void EdgeParams(s32* length, s32* coverage) const
+        
+        constexpr void EdgeParams(s32* length, s32* coverage, bool swapped) const
         {
             if (XMajor)
-                return EdgeParams_XMajor<swapped>(length, coverage);
+                return EdgeParams_XMajor(length, coverage, swapped);
             else
-                return EdgeParams_YMajor<swapped>(length, coverage);
+                return EdgeParams_YMajor(length, coverage, swapped);
         }
 
         s32 Increment;


### PR DESCRIPTION
This PR contains two commits:

Commit 1: Fixes a bug with certain positive x-major slopes having bugged aa.
This was caused by lack of proper handling for x coordinates which had a different y coordinate calculated than they actually had when following the DS' slope algorithm, resulting in improper coverage being calculated.
The fix was simply to invert the final coverage value when these two values differ.
This seems to match hardware behavior.
Also seems to allow for removing extra handling elsewhere as it should no longer be possible for abnormally high starting coverage values to be calculated.

Commit 2: Attempts to rewrite some of the anti-aliasing code to be simpler. Hope I succeeded, if not then it's easy to revert. (Though I'm keeping most of the changes to y-major aa, because in hindsight I wrote some needlessly gross code when I fixed aa for swapped slopes.)
I did some testing to ensure this new handling doesn't break anything, but it's possible I missed some weird edge case (there's a lot of them.)

For the most part anti-aliasing should be unchanged, aside from some small fixes on certain slopes.

Example bugged slope:
![image](https://github.com/melonDS-emu/melonDS/assets/102590697/8aaaacfd-ce9b-4cf7-b95a-2b24eecab38e)
Fixed:
![image](https://github.com/melonDS-emu/melonDS/assets/102590697/af090b02-4cd9-4166-8fa4-4a5758695ead)
