### PR TITLE
Generalize a path in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,7 @@ obj
 melon_grc.c
 melon_grc.h
 melon.rc
-cmake-build
+cmake-build*
 cmake-build-debug
 compile_commands.json
 .idea


### PR DESCRIPTION
- Covers all of CLion's default CMake build paths