### PR TITLE
Add optional support for Tracy

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,7 @@ include(CheckSymbolExists)
 include(CheckLibraryExists)
 include(CMakeDependentOption)
 include(CheckIPOSupported)
+include(cmake/FetchDependencies.cmake)
 
 set(CMAKE_OSX_DEPLOYMENT_TARGET "10.15" CACHE STRING "Minimum OS X deployment version")
 

--- a/cmake/FetchDependencies.cmake
+++ b/cmake/FetchDependencies.cmake
@@ -1,0 +1,50 @@
+include(FetchContent)
+
+macro(define_git_dependency_vars name default_url default_tag)
+    string(TOUPPER ${name} VAR_NAME)
+    string(MAKE_C_IDENTIFIER ${VAR_NAME} VAR_NAME)
+
+    if (NOT ${VAR_NAME}_REPOSITORY_URL)
+        set(
+                "${VAR_NAME}_REPOSITORY_URL"
+                "${default_url}"
+                CACHE STRING
+                "${name} repository URL. Set this to use a fork."
+                FORCE
+        )
+    endif ()
+
+    if (NOT ${VAR_NAME}_REPOSITORY_TAG)
+        set(
+                "${VAR_NAME}_REPOSITORY_TAG"
+                "${default_tag}"
+                CACHE STRING
+                "${name} repository commit hash or tag. Set this when using a new version or a custom branch."
+                FORCE
+        )
+    endif ()
+endmacro()
+
+function(fetch_dependency name default_url default_tag)
+    define_git_dependency_vars(${name} ${default_url} ${default_tag})
+
+    message(STATUS "Using ${name}: ${${VAR_NAME}_REPOSITORY_URL} (ref ${${VAR_NAME}_REPOSITORY_TAG})")
+
+    FetchContent_Declare(
+            ${name}
+            GIT_REPOSITORY "${${VAR_NAME}_REPOSITORY_URL}"
+            GIT_TAG "${${VAR_NAME}_REPOSITORY_TAG}"
+    )
+
+    FetchContent_GetProperties(${name})
+endfunction()
+
+option(TRACY_ENABLE "Build with Tracy support." OFF)
+
+if (TRACY_ENABLE)
+    fetch_dependency(tracy "https://github.com/wolfpld/tracy.git" "v0.10")
+    FetchContent_MakeAvailable(tracy)
+    set(BUILD_SHARED_LIBS OFF)
+    set(TRACY_STATIC ON)
+    set(TRACY_ON_DEMAND ON)
+endif()

--- a/src/ARM.cpp
+++ b/src/ARM.cpp
@@ -26,6 +26,7 @@
 #include "ARMJIT.h"
 #include "Platform.h"
 #include "GPU.h"
+#include "Tracy.h"
 
 #ifdef JIT_ENABLED
 #include "ARMJIT.h"
@@ -114,6 +115,7 @@ ARM::ARM(u32 num)
     : GdbStub(this, Platform::GetConfigInt(num ? Platform::GdbPortARM7 : Platform::GdbPortARM9))
 #endif
 {
+    ZoneScopedN(TracyFunction);
     // well uh
     Num = num;
 
@@ -135,6 +137,7 @@ ARM::~ARM()
 
 ARMv5::ARMv5() : ARM(0)
 {
+    ZoneScopedN(TracyFunction);
 #ifndef JIT_ENABLED
     DTCM = new u8[DTCMPhysicalSize];
 #endif
@@ -258,6 +261,7 @@ void ARMv4::Reset()
 
 void ARM::DoSavestate(Savestate* file)
 {
+    ZoneScopedN(TracyFunction);
     file->Section((char*)(Num ? "ARM7" : "ARM9"));
 
     file->Var32((u32*)&Cycles);
@@ -318,6 +322,7 @@ void ARM::DoSavestate(Savestate* file)
 
 void ARMv5::DoSavestate(Savestate* file)
 {
+    ZoneScopedN(TracyFunction);
     ARM::DoSavestate(file);
     CP15DoSavestate(file);
 }

--- a/src/ARMJIT.cpp
+++ b/src/ARMJIT.cpp
@@ -43,6 +43,7 @@
 #include "Wifi.h"
 #include "NDSCart.h"
 #include "Platform.h"
+#include "Tracy.h"
 
 using Platform::Log;
 using Platform::LogLevel;
@@ -1179,6 +1180,7 @@ template void CheckAndInvalidate<1, ARMJIT_Memory::memregion_NewSharedWRAM_C>(u3
 
 void ResetBlockCache()
 {
+    ZoneScopedN(TracyFunction);
     Log(LogLevel::Debug, "Resetting JIT block cache...\n");
 
     // could be replace through a function which only resets

--- a/src/ARMJIT_Memory.cpp
+++ b/src/ARMJIT_Memory.cpp
@@ -45,6 +45,7 @@
 #include "Wifi.h"
 #include "NDSCart.h"
 #include "SPU.h"
+#include "Tracy.h"
 
 #include <stdlib.h>
 
@@ -877,6 +878,7 @@ void DeInit()
 
 void Reset()
 {
+    ZoneScopedN(TracyFunction);
     for (int region = 0; region < memregions_Count; region++)
     {
         for (int i = 0; i < Mappings[region].Length; i++)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -140,6 +140,12 @@ if (ENABLE_JIT)
     endif()
 endif()
 
+if (TRACY_ENABLE)
+    target_link_libraries(core PUBLIC TracyClient)
+    target_include_directories(core SYSTEM PUBLIC TracyClient)
+    target_compile_definitions(core PUBLIC HAVE_TRACY TRACY_ENABLE TRACY_ENABLED)
+endif()
+
 if (WIN32)
     target_link_libraries(core PRIVATE ole32 comctl32 wsock32 ws2_32)
 elseif(NOT APPLE)

--- a/src/CP15.cpp
+++ b/src/CP15.cpp
@@ -22,6 +22,7 @@
 #include "DSi.h"
 #include "ARM.h"
 #include "Platform.h"
+#include "Tracy.h"
 
 #ifdef JIT_ENABLED
 #include "ARMJIT.h"
@@ -75,6 +76,7 @@ void ARMv5::CP15Reset()
 
 void ARMv5::CP15DoSavestate(Savestate* file)
 {
+    ZoneScopedN(TracyFunction);
     file->Section("CP15");
 
     file->Var32(&CP15Control);
@@ -105,6 +107,7 @@ void ARMv5::CP15DoSavestate(Savestate* file)
 
 void ARMv5::UpdateDTCMSetting()
 {
+    ZoneScopedN(TracyFunction);
     u32 newDTCMBase;
     u32 newDTCMMask;
     u32 newDTCMSize;
@@ -135,6 +138,7 @@ void ARMv5::UpdateDTCMSetting()
 
 void ARMv5::UpdateITCMSetting()
 {
+    ZoneScopedN(TracyFunction);
     if (CP15Control & (1<<18))
     {
         ITCMSize = 0x200 << ((ITCMSetting >> 1) & 0x1F);
@@ -260,6 +264,7 @@ void ARMv5::UpdatePURegion(u32 n)
 
 void ARMv5::UpdatePURegions(bool update_all)
 {
+    ZoneScopedN(TracyFunction);
     if (!(CP15Control & (1<<0)))
     {
         // PU disabled
@@ -295,6 +300,7 @@ void ARMv5::UpdatePURegions(bool update_all)
 
 void ARMv5::UpdateRegionTimings(u32 addrstart, u32 addrend)
 {
+    ZoneScopedN(TracyFunction);
     for (u32 i = addrstart; i < addrend; i++)
     {
         u8 pu = PU_Map[i];

--- a/src/DMA.cpp
+++ b/src/DMA.cpp
@@ -23,6 +23,7 @@
 #include "GPU.h"
 #include "DMA_Timings.h"
 #include "Platform.h"
+#include "Tracy.h"
 
 using Platform::Log;
 using Platform::LogLevel;
@@ -82,6 +83,7 @@ void DMA::Reset()
 
 void DMA::DoSavestate(Savestate* file)
 {
+    ZoneScopedN(TracyFunction);
     char magic[5] = "DMAx";
     magic[3] = '0' + Num + (CPU*4);
     file->Section(magic);

--- a/src/GPU.cpp
+++ b/src/GPU.cpp
@@ -25,6 +25,7 @@
 #endif
 
 #include "GPU2D_Soft.h"
+#include "Tracy.h"
 
 using Platform::Log;
 using Platform::LogLevel;
@@ -184,6 +185,7 @@ void DeInit()
 
 void ResetVRAMCache()
 {
+    ZoneScopedN(TracyFunction);
     for (int i = 0; i < 9; i++)
         VRAMDirty[i] = NonStupidBitField<128*1024/VRAMDirtyGranularity>();
 
@@ -315,6 +317,7 @@ void Stop()
 
 void DoSavestate(Savestate* file)
 {
+    ZoneScopedN(TracyFunction);
     file->Section("GPUG");
 
     file->Var16(&VCount);

--- a/src/GPU2D.cpp
+++ b/src/GPU2D.cpp
@@ -20,6 +20,7 @@
 #include <string.h>
 #include "NDS.h"
 #include "GPU.h"
+#include "Tracy.h"
 
 using Platform::Log;
 using Platform::LogLevel;
@@ -142,6 +143,7 @@ void Unit::Reset()
 
 void Unit::DoSavestate(Savestate* file)
 {
+    ZoneScopedN(TracyFunction);
     file->Section((char*)(Num ? "GP2B" : "GP2A"));
 
     file->Var32(&DispCnt);

--- a/src/GPU3D.cpp
+++ b/src/GPU3D.cpp
@@ -23,6 +23,7 @@
 #include "GPU.h"
 #include "FIFO.h"
 #include "Platform.h"
+#include "Tracy.h"
 
 using Platform::Log;
 using Platform::LogLevel;
@@ -310,6 +311,7 @@ void ResetRenderingState()
 
 void Reset()
 {
+    ZoneScopedN(TracyFunction);
     CmdFIFO.Clear();
     CmdPIPE.Clear();
 
@@ -391,6 +393,7 @@ void Reset()
 
 void DoSavestate(Savestate* file)
 {
+    ZoneScopedN(TracyFunction);
     file->Section("GP3D");
 
     CmdFIFO.DoSavestate(file);
@@ -769,6 +772,7 @@ void MatrixTranslate(s32* m, s32* s)
 
 void UpdateClipMatrix()
 {
+    ZoneScopedN(TracyFunction);
     if (!ClipMatrixDirty) return;
     ClipMatrixDirty = false;
 
@@ -811,6 +815,7 @@ void AddCycles(s32 num)
 
 void NextVertexSlot()
 {
+    ZoneScopedN(TracyFunction);
     s32 num = (9 - VertexSlotCounter) + 1;
 
     for (;;)
@@ -854,6 +859,7 @@ void NextVertexSlot()
 
 void StallPolygonPipeline(s32 delay, s32 nonstalldelay)
 {
+    ZoneScopedN(TracyFunction);
     if (PolygonPipeline > 0)
     {
         CycleCount += PolygonPipeline + delay;
@@ -880,6 +886,7 @@ void StallPolygonPipeline(s32 delay, s32 nonstalldelay)
 template<int comp, s32 plane, bool attribs>
 void ClipSegment(Vertex* outbuf, Vertex* vin, Vertex* vout)
 {
+    ZoneScopedN(TracyFunction);
     s64 factor_num = vin->Position[3] - (plane*vin->Position[comp]);
     s32 factor_den = factor_num - (vout->Position[3] - (plane*vout->Position[comp]));
 
@@ -909,6 +916,7 @@ void ClipSegment(Vertex* outbuf, Vertex* vin, Vertex* vout)
 template<int comp, bool attribs>
 int ClipAgainstPlane(Vertex* vertices, int nverts, int clipstart)
 {
+    ZoneScopedN(TracyFunction);
     Vertex temp[10];
     int prev, next;
     int c = clipstart;
@@ -990,6 +998,7 @@ int ClipAgainstPlane(Vertex* vertices, int nverts, int clipstart)
 template<bool attribs>
 int ClipPolygon(Vertex* vertices, int nverts, int clipstart)
 {
+    ZoneScopedN(TracyFunction);
     // clip.
     // for each vertex:
     // if it's outside, check if the previous and next vertices are inside
@@ -1022,6 +1031,7 @@ bool ClipCoordsEqual(Vertex* a, Vertex* b)
 
 void SubmitPolygon()
 {
+    ZoneScopedN(TracyFunction);
     Vertex clippedvertices[10];
     Vertex* reusedvertices[2];
     int clipstart = 0;

--- a/src/GPU3D.cpp
+++ b/src/GPU3D.cpp
@@ -772,7 +772,6 @@ void MatrixTranslate(s32* m, s32* s)
 
 void UpdateClipMatrix()
 {
-    ZoneScopedN(TracyFunction);
     if (!ClipMatrixDirty) return;
     ClipMatrixDirty = false;
 

--- a/src/GPU3D_Soft.cpp
+++ b/src/GPU3D_Soft.cpp
@@ -23,6 +23,7 @@
 #include <string.h>
 #include "NDS.h"
 #include "GPU.h"
+#include "Tracy.h"
 
 
 namespace GPU3D
@@ -33,6 +34,7 @@ void RenderThreadFunc();
 
 void SoftRenderer::StopRenderThread()
 {
+    ZoneScopedN(TracyFunction);
     if (RenderThreadRunning.load(std::memory_order_relaxed))
     {
         RenderThreadRunning = false;
@@ -45,6 +47,7 @@ void SoftRenderer::StopRenderThread()
 
 void SoftRenderer::SetupRenderThread()
 {
+    ZoneScopedN(TracyFunction);
     if (Threaded)
     {
         if (!RenderThreadRunning.load(std::memory_order_relaxed))
@@ -96,6 +99,7 @@ SoftRenderer::~SoftRenderer()
 
 void SoftRenderer::Reset()
 {
+    ZoneScopedN(TracyFunction);
     memset(ColorBuffer, 0, BufferSize * 2 * 4);
     memset(DepthBuffer, 0, BufferSize * 2 * 4);
     memset(AttrBuffer, 0, BufferSize * 2 * 4);
@@ -107,6 +111,7 @@ void SoftRenderer::Reset()
 
 void SoftRenderer::SetRenderSettings(GPU::RenderSettings& settings)
 {
+    ZoneScopedN(TracyFunction);
     Threaded = settings.Soft_Threaded;
     SetupRenderThread();
 }
@@ -566,6 +571,7 @@ void SoftRenderer::PlotTranslucentPixel(u32 pixeladdr, u32 color, u32 z, u32 pol
 
 void SoftRenderer::SetupPolygonLeftEdge(SoftRenderer::RendererPolygon* rp, s32 y)
 {
+    ZoneScopedN(TracyFunction);
     Polygon* polygon = rp->PolyData;
 
     while (y >= polygon->Vertices[rp->NextVL]->FinalPosition[1] && rp->CurVL != polygon->VBottom)
@@ -593,6 +599,7 @@ void SoftRenderer::SetupPolygonLeftEdge(SoftRenderer::RendererPolygon* rp, s32 y
 
 void SoftRenderer::SetupPolygonRightEdge(SoftRenderer::RendererPolygon* rp, s32 y)
 {
+    ZoneScopedN(TracyFunction);
     Polygon* polygon = rp->PolyData;
 
     while (y >= polygon->Vertices[rp->NextVR]->FinalPosition[1] && rp->CurVR != polygon->VBottom)
@@ -620,6 +627,7 @@ void SoftRenderer::SetupPolygonRightEdge(SoftRenderer::RendererPolygon* rp, s32 
 
 void SoftRenderer::SetupPolygon(SoftRenderer::RendererPolygon* rp, Polygon* polygon)
 {
+    ZoneScopedN(TracyFunction);
     u32 nverts = polygon->NumVertices;
 
     u32 vtop = polygon->VTop, vbot = polygon->VBottom;
@@ -673,6 +681,7 @@ void SoftRenderer::SetupPolygon(SoftRenderer::RendererPolygon* rp, Polygon* poly
 
 void SoftRenderer::RenderShadowMaskScanline(RendererPolygon* rp, s32 y)
 {
+    ZoneScopedN(TracyFunction);
     Polygon* polygon = rp->PolyData;
 
     u32 polyattr = (polygon->Attr & 0x3F008000);
@@ -901,6 +910,7 @@ void SoftRenderer::RenderShadowMaskScanline(RendererPolygon* rp, s32 y)
 
 void SoftRenderer::RenderPolygonScanline(RendererPolygon* rp, s32 y)
 {
+    ZoneScopedN(TracyFunction);
     Polygon* polygon = rp->PolyData;
 
     u32 polyattr = (polygon->Attr & 0x3F008000);
@@ -1357,6 +1367,7 @@ void SoftRenderer::RenderPolygonScanline(RendererPolygon* rp, s32 y)
 
 void SoftRenderer::RenderScanline(s32 y, int npolys)
 {
+    ZoneScopedN(TracyFunction);
     for (int i = 0; i < npolys; i++)
     {
         RendererPolygon* rp = &PolygonList[i];
@@ -1413,6 +1424,7 @@ u32 SoftRenderer::CalculateFogDensity(u32 pixeladdr)
 
 void SoftRenderer::ScanlineFinalPass(s32 y)
 {
+    ZoneScopedN(TracyFunction);
     // to consider:
     // clearing all polygon fog flags if the master flag isn't set?
     // merging all final pass loops into one?
@@ -1583,6 +1595,7 @@ void SoftRenderer::ScanlineFinalPass(s32 y)
 
 void SoftRenderer::ClearBuffers()
 {
+    ZoneScopedN(TracyFunction);
     u32 clearz = ((RenderClearAttr2 & 0x7FFF) * 0x200) + 0x1FF;
     u32 polyid = RenderClearAttr1 & 0x3F000000; // this sets the opaque polygonID
 
@@ -1672,6 +1685,7 @@ void SoftRenderer::ClearBuffers()
 
 void SoftRenderer::RenderPolygons(bool threaded, Polygon** polygons, int npolys)
 {
+    ZoneScopedN(TracyFunction);
     int j = 0;
     for (int i = 0; i < npolys; i++)
     {
@@ -1732,6 +1746,7 @@ void SoftRenderer::RenderThreadFunc()
 {
     for (;;)
     {
+        ZoneScopedN(TracyFunction);
         Platform::Semaphore_Wait(Sema_RenderStart);
         if (!RenderThreadRunning) return;
 

--- a/src/NDS.cpp
+++ b/src/NDS.cpp
@@ -33,6 +33,7 @@
 #include "AREngine.h"
 #include "Platform.h"
 #include "FreeBIOS.h"
+#include "Tracy.h"
 
 #ifdef JIT_ENABLED
 #include "ARMJIT.h"
@@ -184,6 +185,7 @@ void SetGBASlotTimings();
 
 bool Init()
 {
+    ZoneScopedN(TracyFunction);
     ARM9 = new ARMv5();
     ARM7 = new ARMv4();
 
@@ -221,6 +223,7 @@ bool Init()
 
 void DeInit()
 {
+    ZoneScopedN(TracyFunction);
 #ifdef JIT_ENABLED
     ARMJIT::DeInit();
 #endif
@@ -253,6 +256,7 @@ void DeInit()
 
 void SetARM9RegionTimings(u32 addrstart, u32 addrend, u32 region, int buswidth, int nonseq, int seq)
 {
+    ZoneScopedN(TracyFunction);
     addrstart >>= 2;
     addrend   >>= 2;
 
@@ -295,6 +299,7 @@ void SetARM9RegionTimings(u32 addrstart, u32 addrend, u32 region, int buswidth, 
 
 void SetARM7RegionTimings(u32 addrstart, u32 addrend, u32 region, int buswidth, int nonseq, int seq)
 {
+    ZoneScopedN(TracyFunction);
     addrstart >>= 3;
     addrend   >>= 3;
 
@@ -326,6 +331,7 @@ void SetARM7RegionTimings(u32 addrstart, u32 addrend, u32 region, int buswidth, 
 
 void InitTimings()
 {
+    ZoneScopedN(TracyFunction);
     // TODO, eventually:
     // VRAM is initially unmapped. The timings should be those of void regions.
     // Similarly for any unmapped VRAM area.
@@ -384,6 +390,7 @@ bool NeedsDirectBoot()
 
 void SetupDirectBoot(const std::string& romname)
 {
+    ZoneScopedN(TracyFunction);
     const NDSHeader& header = NDSCart::Cart->GetHeader();
 
     if (ConsoleType == 1)
@@ -514,6 +521,7 @@ void SetupDirectBoot(const std::string& romname)
 
 void Reset()
 {
+    ZoneScopedN(TracyFunction);
     Platform::FileHandle* f;
     u32 i;
 
@@ -672,6 +680,7 @@ static const char* StopReasonName(Platform::StopReason reason)
 
 void Stop(Platform::StopReason reason)
 {
+    ZoneScopedN(TracyFunction);
     Platform::LogLevel level;
     switch (reason)
     {
@@ -700,6 +709,7 @@ void Stop(Platform::StopReason reason)
 
 bool DoSavestate_Scheduler(Savestate* file)
 {
+    ZoneScopedN(TracyFunction);
     // this is a bit of a hack
     // but uh, your local coder realized that the scheduler list contains function pointers
     // and that storing those as-is is not a very good idea
@@ -799,6 +809,7 @@ bool DoSavestate_Scheduler(Savestate* file)
 
 bool DoSavestate(Savestate* file)
 {
+    ZoneScopedN(TracyFunction);
     file->Section("NDSG");
 
     if (file->Saving)
@@ -952,6 +963,7 @@ void SetConsoleType(int type)
 
 bool LoadCart(const u8* romdata, u32 romlen, const u8* savedata, u32 savelen)
 {
+    ZoneScopedN(TracyFunction);
     if (!NDSCart::LoadROM(romdata, romlen))
         return false;
 
@@ -963,6 +975,7 @@ bool LoadCart(const u8* romdata, u32 romlen, const u8* savedata, u32 savelen)
 
 void LoadSave(const u8* savedata, u32 savelen)
 {
+    ZoneScopedN(TracyFunction);
     if (savedata && savelen)
         NDSCart::LoadSave(savedata, savelen);
 }
@@ -979,6 +992,7 @@ bool CartInserted()
 
 bool LoadGBACart(const u8* romdata, u32 romlen, const u8* savedata, u32 savelen)
 {
+    ZoneScopedN(TracyFunction);
     if (!GBACart::LoadROM(romdata, romlen))
         return false;
 
@@ -990,11 +1004,13 @@ bool LoadGBACart(const u8* romdata, u32 romlen, const u8* savedata, u32 savelen)
 
 void LoadGBAAddon(int type)
 {
+    ZoneScopedN(TracyFunction);
     GBACart::LoadAddon(type);
 }
 
 void EjectGBACart()
 {
+    ZoneScopedN(TracyFunction);
     GBACart::EjectCart();
 }
 
@@ -1062,6 +1078,7 @@ void RunSystem(u64 timestamp)
 template <bool EnableJIT, int ConsoleType>
 u32 RunFrame()
 {
+    ZoneScopedN(TracyFunction);
     FrameStartTimestamp = SysTimestamp;
 
     LagFrameFlag = true;
@@ -1170,6 +1187,7 @@ u32 RunFrame()
 
 u32 RunFrame()
 {
+    ZoneScopedN(TracyFunction);
 #ifdef JIT_ENABLED
     if (EnableJIT)
         return NDS::ConsoleType == 1
@@ -1226,6 +1244,7 @@ void ScheduleEvent(u32 id, bool periodic, s32 delay, void (*func)(u32), u32 para
 
 void ScheduleEvent(u32 id, u64 timestamp, void (*func)(u32), u32 param)
 {
+    ZoneScopedN(TracyFunction);
     if (SchedListMask & (1<<id))
     {
         Log(LogLevel::Debug, "!! EVENT %d ALREADY SCHEDULED\n", id);
@@ -1251,6 +1270,7 @@ void CancelEvent(u32 id)
 
 void TouchScreen(u16 x, u16 y)
 {
+    ZoneScopedN(TracyFunction);
     if (ConsoleType == 1)
     {
         DSi_SPI_TSC::SetTouchCoords(x, y);
@@ -1264,6 +1284,7 @@ void TouchScreen(u16 x, u16 y)
 
 void ReleaseScreen()
 {
+    ZoneScopedN(TracyFunction);
     if (ConsoleType == 1)
     {
         DSi_SPI_TSC::SetTouchCoords(0x000, 0xFFF);
@@ -1293,6 +1314,7 @@ bool IsLidClosed()
 
 void SetLidClosed(bool closed)
 {
+    ZoneScopedN(TracyFunction);
     if (closed)
     {
         KeyInput |= (1<<23);
@@ -1341,6 +1363,7 @@ void Halt()
 
 void MapSharedWRAM(u8 val)
 {
+    ZoneScopedN(TracyFunction);
     if (val == WRAMCnt)
         return;
 
@@ -1385,6 +1408,7 @@ void MapSharedWRAM(u8 val)
 
 void UpdateWifiTimings()
 {
+    ZoneScopedN(TracyFunction);
     if (PowerControl7 & 0x0002)
     {
         const int ntimings[4] = {10, 8, 6, 18};
@@ -1402,6 +1426,7 @@ void UpdateWifiTimings()
 
 void SetWifiWaitCnt(u16 val)
 {
+    ZoneScopedN(TracyFunction);
     if (WifiWaitCnt == val) return;
 
     WifiWaitCnt = val;
@@ -1410,6 +1435,7 @@ void SetWifiWaitCnt(u16 val)
 
 void SetGBASlotTimings()
 {
+    ZoneScopedN(TracyFunction);
     const int ntimings[4] = {10, 8, 6, 18};
     const u16 openbus[4] = {0xFE08, 0x0000, 0x0000, 0xFFFF};
 
@@ -1506,6 +1532,7 @@ bool HaltInterrupted(u32 cpu)
 
 void StopCPU(u32 cpu, u32 mask)
 {
+    ZoneScopedN(TracyFunction);
     if (cpu)
     {
         CPUStop |= (mask << 16);
@@ -1526,6 +1553,7 @@ void ResumeCPU(u32 cpu, u32 mask)
 
 void GXFIFOStall()
 {
+    ZoneScopedN(TracyFunction);
     if (CPUStop & 0x80000000) return;
 
     CPUStop |= 0x80000000;
@@ -1548,6 +1576,7 @@ void GXFIFOUnstall()
 
 void EnterSleepMode()
 {
+    ZoneScopedN(TracyFunction);
     if (CPUStop & 0x40000000) return;
 
     CPUStop |= 0x40000000;
@@ -1588,6 +1617,7 @@ u64 GetSysClockCycles(int num)
 
 void NocashPrint(u32 ncpu, u32 addr)
 {
+    ZoneScopedN(TracyFunction);
     // addr: debug string
 
     ARM* cpu = ncpu ? (ARM*)ARM7 : (ARM*)ARM9;
@@ -1689,6 +1719,7 @@ void MonitorARM9Jump(u32 addr)
 
 void HandleTimerOverflow(u32 tid)
 {
+    ZoneScopedN(TracyFunction);
     Timer* timer = &Timers[tid];
 
     timer->Counter += (timer->Reload << 10);
@@ -1762,6 +1793,7 @@ u16 TimerGetCounter(u32 timer)
 
 void TimerStart(u32 id, u16 cnt)
 {
+    ZoneScopedN(TracyFunction);
     Timer* timer = &Timers[id];
     u16 curstart = timer->Cnt & (1<<7);
     u16 newstart = cnt & (1<<7);

--- a/src/NDSCart.cpp
+++ b/src/NDSCart.cpp
@@ -27,6 +27,7 @@
 #include "ROMList.h"
 #include "melonDLDI.h"
 #include "xxhash/xxhash.h"
+#include "Tracy.h"
 
 using Platform::Log;
 using Platform::LogLevel;
@@ -1485,6 +1486,7 @@ void Reset()
 
 void DoSavestate(Savestate* file)
 {
+    ZoneScopedN(TracyFunction);
     file->Section("NDSC");
 
     file->Var16(&SPICnt);

--- a/src/Savestate.cpp
+++ b/src/Savestate.cpp
@@ -211,7 +211,6 @@ void Savestate::Bool32(bool* var)
 
 void Savestate::VarArray(void* data, u32 len)
 {
-    ZoneScopedN(TracyFunction);
     if (Error || finished) return;
 
     assert(buffer_offset <= buffer_length);

--- a/src/Savestate.cpp
+++ b/src/Savestate.cpp
@@ -21,6 +21,7 @@
 #include <cstring>
 #include "Savestate.h"
 #include "Platform.h"
+#include "Tracy.h"
 
 using Platform::Log;
 using Platform::LogLevel;
@@ -60,6 +61,7 @@ Savestate::Savestate(void *buffer, u32 size, bool save) :
     buffer_owned(false),
     finished(false)
 {
+    ZoneScopedN(TracyFunction);
     if (Saving)
     {
         WriteSavestateHeader();
@@ -124,6 +126,7 @@ Savestate::Savestate(u32 initial_size) :
     buffer_owned(true),
     finished(false)
 {
+    ZoneScopedN(TracyFunction);
     buffer = static_cast<u8 *>(malloc(buffer_length));
 
     if (buffer == nullptr)
@@ -153,6 +156,7 @@ Savestate::~Savestate()
 
 void Savestate::Section(const char* magic)
 {
+    ZoneScopedN(TracyFunction);
     if (Error || finished) return;
 
     if (Saving)
@@ -207,6 +211,7 @@ void Savestate::Bool32(bool* var)
 
 void Savestate::VarArray(void* data, u32 len)
 {
+    ZoneScopedN(TracyFunction);
     if (Error || finished) return;
 
     assert(buffer_offset <= buffer_length);
@@ -285,6 +290,7 @@ void Savestate::CloseCurrentSection()
 
 bool Savestate::Resize(u32 new_length)
 {
+    ZoneScopedN(TracyFunction);
     if (!buffer_owned)
     { // If we're not allowed to resize this buffer...
         Log(LogLevel::Error, "savestate: Buffer is externally-owned, cannot resize it\n");
@@ -311,6 +317,7 @@ bool Savestate::Resize(u32 new_length)
 
 void Savestate::WriteSavestateHeader()
 {
+    ZoneScopedN(TracyFunction);
     // The magic number
     VarArray((void *) SAVESTATE_MAGIC, 4);
 
@@ -342,6 +349,7 @@ void Savestate::WriteStateLength()
 
 u32 Savestate::FindSection(const char* magic) const
 {
+    ZoneScopedN(TracyFunction);
     if (!magic) return NO_SECTION;
 
     // Start looking at the savestate's beginning, right after its global header

--- a/src/Tracy.h
+++ b/src/Tracy.h
@@ -1,0 +1,143 @@
+/*
+    Copyright 2016-2023 melonDS team
+
+    This file is part of melonDS.
+
+    melonDS is free software: you can redistribute it and/or modify it under
+    the terms of the GNU General Public License as published by the Free
+    Software Foundation, either version 3 of the License, or (at your option)
+    any later version.
+
+    melonDS is distributed in the hope that it will be useful, but WITHOUT ANY
+    WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+    FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with melonDS. If not, see http://www.gnu.org/licenses/.
+*/
+
+#ifndef MELONDS_DS_TRACY_HPP
+#define MELONDS_DS_TRACY_HPP
+
+#ifdef HAVE_TRACY
+#if defined(__clang__) || defined(__GNUC__)
+# define TracyFunction __PRETTY_FUNCTION__
+#elif defined(_MSC_VER)
+# define TracyFunction __FUNCSIG__
+#endif
+
+#include <tracy/Tracy.hpp>
+#else
+#define ZoneNamed(x,y)
+#define ZoneNamedN(x,y,z)
+#define ZoneNamedC(x,y,z)
+#define ZoneNamedNC(x,y,z,w)
+
+#define ZoneTransient(x,y)
+#define ZoneTransientN(x,y,z)
+
+#define ZoneScoped
+#define ZoneScopedN(x)
+#define ZoneScopedC(x)
+#define ZoneScopedNC(x,y)
+
+#define ZoneText(x,y)
+#define ZoneTextV(x,y,z)
+#define ZoneName(x,y)
+#define ZoneNameV(x,y,z)
+#define ZoneColor(x)
+#define ZoneColorV(x,y)
+#define ZoneValue(x)
+#define ZoneValueV(x,y)
+#define ZoneIsActive false
+#define ZoneIsActiveV(x) false
+
+#define FrameMark
+#define FrameMarkNamed(x)
+#define FrameMarkStart(x)
+#define FrameMarkEnd(x)
+
+#define FrameImage(x,y,z,w,a)
+
+#define TracyLockable( type, varname ) type varname
+#define TracyLockableN( type, varname, desc ) type varname
+#define TracySharedLockable( type, varname ) type varname
+#define TracySharedLockableN( type, varname, desc ) type varname
+#define LockableBase( type ) type
+#define SharedLockableBase( type ) type
+#define LockMark(x) (void)x
+#define LockableName(x,y,z)
+
+#define TracyPlot(x,y)
+#define TracyPlotConfig(x,y,z,w,a)
+
+#define TracyMessage(x,y)
+#define TracyMessageL(x)
+#define TracyMessageC(x,y,z)
+#define TracyMessageLC(x,y)
+#define TracyAppInfo(x,y)
+
+#define TracyAlloc(x,y)
+#define TracyFree(x)
+#define TracySecureAlloc(x,y)
+#define TracySecureFree(x)
+
+#define TracyAllocN(x,y,z)
+#define TracyFreeN(x,y)
+#define TracySecureAllocN(x,y,z)
+#define TracySecureFreeN(x,y)
+
+#define ZoneNamedS(x,y,z)
+#define ZoneNamedNS(x,y,z,w)
+#define ZoneNamedCS(x,y,z,w)
+#define ZoneNamedNCS(x,y,z,w,a)
+
+#define ZoneTransientS(x,y,z)
+#define ZoneTransientNS(x,y,z,w)
+
+#define ZoneScopedS(x)
+#define ZoneScopedNS(x,y)
+#define ZoneScopedCS(x,y)
+#define ZoneScopedNCS(x,y,z)
+
+#define TracyAllocS(x,y,z)
+#define TracyFreeS(x,y)
+#define TracySecureAllocS(x,y,z)
+#define TracySecureFreeS(x,y)
+
+#define TracyAllocNS(x,y,z,w)
+#define TracyFreeNS(x,y,z)
+#define TracySecureAllocNS(x,y,z,w)
+#define TracySecureFreeNS(x,y,z)
+
+#define TracyMessageS(x,y,z)
+#define TracyMessageLS(x,y)
+#define TracyMessageCS(x,y,z,w)
+#define TracyMessageLCS(x,y,z)
+
+#define TracySourceCallbackRegister(x,y)
+#define TracyParameterRegister(x,y)
+#define TracyParameterSetup(x,y,z,w)
+#define TracyIsConnected false
+#define TracySetProgramName(x)
+
+#define TracyFiberEnter(x)
+#define TracyFiberLeave
+
+#define TracyGpuContext
+#define TracyGpuContextName(x,y)
+#define TracyGpuNamedZone(x,y,z)
+#define TracyGpuNamedZoneC(x,y,z,w)
+#define TracyGpuZone(x)
+#define TracyGpuZoneC(x,y)
+#define TracyGpuZoneTransient(x,y,z)
+#define TracyGpuCollect
+
+#define TracyGpuNamedZoneS(x,y,z,w)
+#define TracyGpuNamedZoneCS(x,y,z,w,a)
+#define TracyGpuZoneS(x,y)
+#define TracyGpuZoneCS(x,y,z)
+#define TracyGpuZoneTransientS(x,y,z,w)
+#endif
+
+#endif //MELONDS_DS_TRACY_HPP

--- a/src/frontend/qt_sdl/main.cpp
+++ b/src/frontend/qt_sdl/main.cpp
@@ -90,6 +90,7 @@
 #include "LocalMP.h"
 #include "Config.h"
 #include "DSi_I2C.h"
+#include "Tracy.h"
 
 #include "Savestate.h"
 
@@ -612,6 +613,7 @@ void EmuThread::run()
                     sprintf(melontitle, "[%d/%.0f] melonDS (%d)", fps, fpstarget, inst+1);
                 changeWindowTitle(melontitle);
             }
+            FrameMark;
         }
         else
         {


### PR DESCRIPTION
[Tracy](https://github.com/wolfpld/tracy) is a frame profiler that is intended to be integrated directly into a game (or emulator, or other application). It has minimal overhead, and can be conditionally compiled out.

I use it in melonDS DS, but I needed to be able to instrument parts of melonDS itself. So I added Tracy to the build process, optionally. No extra steps are required, it's fetched with [`FetchContent`](https://cmake.org/cmake/help/latest/module/FetchContent.html). To enable Tracy, set the `TRACY_ENABLE` option in CMake to `ON`.

Here are some examples of Tracy's output:

![Screenshot 2023-10-25 102908](https://github.com/melonDS-emu/melonDS/assets/1175189/2fb129d6-615e-443a-bca7-9d0b559fef78)
![Screenshot 2023-10-24 193152](https://github.com/melonDS-emu/melonDS/assets/1175189/80583db8-fcc9-4c49-ad9d-583ae9f4281b)

It's helping me diagnose a race conditions issue that's causing [this bug](https://github.com/JesseTG/melonds-ds/issues/81) as well.