### PR TITLE
Move GBACart-related global state into objects

### DIFF
--- a/src/NDS.h
+++ b/src/NDS.h
@@ -20,11 +20,13 @@
 #define NDS_H
 
 #include <string>
+#include <memory>
 #include <functional>
 
 #include "Platform.h"
 #include "Savestate.h"
 #include "types.h"
+#include "GBACart.h"
 
 // when touching the main loop/timing code, pls test a lot of shit
 // with this enabled, to make sure it doesn't desync
@@ -257,7 +259,7 @@ extern class SPU* SPU;
 extern class SPIHost* SPI;
 extern class RTC* RTC;
 extern class Wifi* Wifi;
-
+extern std::unique_ptr<GBACart::GBACartSlot> GBACartSlot;
 extern class AREngine* AREngine;
 
 const u32 ARM7WRAMSize = 0x10000;

--- a/src/frontend/qt_sdl/main.cpp
+++ b/src/frontend/qt_sdl/main.cpp
@@ -384,7 +384,8 @@ void EmuThread::run()
 
         if (Input::HotkeyPressed(HK_SolarSensorDecrease))
         {
-            int level = GBACart::SetInput(GBACart::Input_SolarSensorDown, true);
+            assert(NDS::GBACartSlot != nullptr);
+            int level = NDS::GBACartSlot->SetInput(GBACart::Input_SolarSensorDown, true);
             if (level != -1)
             {
                 char msg[64];
@@ -394,7 +395,8 @@ void EmuThread::run()
         }
         if (Input::HotkeyPressed(HK_SolarSensorIncrease))
         {
-            int level = GBACart::SetInput(GBACart::Input_SolarSensorUp, true);
+            assert(NDS::GBACartSlot != nullptr);
+            int level = NDS::GBACartSlot->SetInput(GBACart::Input_SolarSensorUp, true);
             if (level != -1)
             {
                 char msg[64];


### PR DESCRIPTION
- RAII will now do the heavy lifting
- Mark some methods as const or noexcept
- Once the `NDS` object is finalized, most of these `assert`s can go away

Consistent with the overall goal of removing global state.