### PR TITLE
Move NDSCart-related global state into objects

### DIFF
--- a/src/AREngine.h
+++ b/src/AREngine.h
@@ -32,7 +32,7 @@ public:
     void SetCodeFile(ARCodeFile* file) { CodeFile = file; }
 
     void RunCheats();
-
+    void RunCheat(ARCode& arcode);
 private:
     ARCodeFile* CodeFile; // AR code file - frontend is responsible for managing this
 
@@ -43,8 +43,6 @@ private:
     void (*BusWrite8)(u32 addr, u8 val);
     void (*BusWrite16)(u32 addr, u16 val);
     void (*BusWrite32)(u32 addr, u32 val);
-
-    void RunCheat(ARCode& arcode);
 };
 
 #endif // ARENGINE_H

--- a/src/ARMJIT_Memory.cpp
+++ b/src/ARMJIT_Memory.cpp
@@ -1248,6 +1248,11 @@ T VRAMRead(u32 addr)
     }
 }
 
+u32 NDSCartSlot_ReadROMData()
+{ // TODO: Add a NDS* parameter, when NDS* is eventually implemented
+    return NDS::NDSCartSlot->ReadROMData();
+}
+
 void* GetFuncForAddr(ARM* cpu, u32 addr, bool store, int size)
 {
     if (cpu->Num == 0)
@@ -1256,7 +1261,7 @@ void* GetFuncForAddr(ARM* cpu, u32 addr, bool store, int size)
         {
         case 0x04000000:
             if (!store && size == 32 && addr == 0x04100010 && NDS::ExMemCnt[0] & (1<<11))
-                return (void*)NDSCart::ReadROMData;
+                return (void*)NDSCartSlot_ReadROMData;
 
             /*
                 unfortunately we can't map GPU2D this way

--- a/src/DSi.cpp
+++ b/src/DSi.cpp
@@ -193,7 +193,7 @@ void Reset()
     SCFG_Clock7 = 0x0187;
     SCFG_EXT[0] = 0x8307F100;
     SCFG_EXT[1] = 0x93FFFB06;
-    SCFG_MC = 0x0010 | (~((u32)(NDSCart::Cart != nullptr))&1);//0x0011;
+    SCFG_MC = 0x0010 | (~((u32)(NDS::NDSCartSlot->GetCart() != nullptr))&1);//0x0011;
     SCFG_RST = 0;
 
     DSP->SetRstLine(false);
@@ -310,13 +310,13 @@ void DecryptModcryptArea(u32 offset, u32 size, u8* iv)
     if ((offset == 0) || (size == 0))
         return;
 
-    const NDSHeader& header = NDSCart::Cart->GetHeader();
+    const NDSHeader& header = NDS::NDSCartSlot->GetCart()->GetHeader();
 
     if ((header.DSiCryptoFlags & (1<<4)) ||
         (header.AppFlags & (1<<7)))
     {
         // dev key
-        const u8* cartrom = NDSCart::Cart->GetROM();
+        const u8* cartrom = NDS::NDSCartSlot->GetCart()->GetROM();
         memcpy(key, &cartrom[0], 16);
     }
     else
@@ -403,9 +403,9 @@ void DecryptModcryptArea(u32 offset, u32 size, u8* iv)
 void SetupDirectBoot()
 {
     bool dsmode = false;
-    NDSHeader& header = NDSCart::Cart->GetHeader();
-    const u8* cartrom = NDSCart::Cart->GetROM();
-    u32 cartid = NDSCart::Cart->ID();
+    NDSHeader& header = NDS::NDSCartSlot->GetCart()->GetHeader();
+    const u8* cartrom = NDS::NDSCartSlot->GetCart()->GetROM();
+    u32 cartid = NDS::NDSCartSlot->GetCart()->ID();
     DSi_TSC* tsc = (DSi_TSC*)NDS::SPI->GetTSC();
 
     // TODO: add controls for forcing DS or DSi mode?
@@ -594,7 +594,7 @@ void SetupDirectBoot()
     if (header.ARM9ROMOffset >= 0x4000 && header.ARM9ROMOffset < 0x8000)
     {
         u8 securearea[0x800];
-        NDSCart::DecryptSecureArea(securearea);
+        NDS::NDSCartSlot->DecryptSecureArea(securearea);
 
         for (u32 i = 0; i < 0x800; i+=4)
         {
@@ -1289,7 +1289,7 @@ void Set_SCFG_MC(u32 val)
 
     if ((oldslotstatus == 0x0) && ((SCFG_MC & 0xC) == 0x4))
     {
-        NDSCart::ResetCart();
+        NDS::NDSCartSlot->ResetCart();
     }
 }
 

--- a/src/NDS.cpp
+++ b/src/NDS.cpp
@@ -183,6 +183,7 @@ class SPU* SPU;
 class SPIHost* SPI;
 class RTC* RTC;
 class Wifi* Wifi;
+std::unique_ptr<NDSCart::NDSCartSlot> NDSCartSlot;
 std::unique_ptr<GBACart::GBACartSlot> GBACartSlot;
 class AREngine* AREngine;
 
@@ -227,9 +228,8 @@ bool Init()
     SPI = new class SPIHost();
     RTC = new class RTC();
     Wifi = new class Wifi();
+    NDSCartSlot = std::make_unique<NDSCart::NDSCartSlot>();
     GBACartSlot = std::make_unique<GBACart::GBACartSlot>();
-
-    if (!NDSCart::Init()) return false;
     if (!GPU::Init()) return false;
 
     if (!DSi::Init()) return false;
@@ -259,7 +259,7 @@ void DeInit()
     delete RTC; RTC = nullptr;
     delete Wifi; Wifi = nullptr;
 
-    NDSCart::DeInit();
+    NDSCartSlot = nullptr;
     GBACartSlot = nullptr;
     GPU::DeInit();
 
@@ -405,7 +405,7 @@ bool NeedsDirectBoot()
 
 void SetupDirectBoot(const std::string& romname)
 {
-    const NDSHeader& header = NDSCart::Cart->GetHeader();
+    const NDSHeader& header = NDSCartSlot->GetCart()->GetHeader();
 
     if (ConsoleType == 1)
     {
@@ -413,8 +413,8 @@ void SetupDirectBoot(const std::string& romname)
     }
     else
     {
-        u32 cartid = NDSCart::Cart->ID();
-        const u8* cartrom = NDSCart::Cart->GetROM();
+        u32 cartid = NDSCartSlot->GetCart()->ID();
+        const u8* cartrom = NDSCartSlot->GetCart()->GetROM();
         MapSharedWRAM(3);
 
         // setup main RAM data
@@ -447,7 +447,7 @@ void SetupDirectBoot(const std::string& romname)
         if (header.ARM9ROMOffset >= 0x4000 && header.ARM9ROMOffset < 0x8000)
         {
             u8 securearea[0x800];
-            NDSCart::DecryptSecureArea(securearea);
+            NDSCartSlot->DecryptSecureArea(securearea);
 
             for (u32 i = 0; i < 0x800; i+=4)
             {
@@ -500,7 +500,7 @@ void SetupDirectBoot(const std::string& romname)
         ARM9->CP15Write(0x911, 0x00000020);
     }
 
-    NDSCart::SetupDirectBoot(romname);
+    NDSCartSlot->SetupDirectBoot(romname);
 
     ARM9->R[12] = header.ARM9EntryAddress;
     ARM9->R[13] = 0x03002F7C;
@@ -526,7 +526,7 @@ void SetupDirectBoot(const std::string& romname)
     // checkme
     RCnt = 0x8000;
 
-    NDSCart::SPICnt = 0x8000;
+    NDSCartSlot->SetSPICnt(0x8000);
 
     SPU->SetBias(0x200);
 
@@ -644,7 +644,7 @@ void Reset()
     KeyCnt[1] = 0;
     RCnt = 0;
 
-    NDSCart::Reset();
+    NDSCartSlot->Reset();
     GBACartSlot->Reset();
     GPU::Reset();
     SPU->Reset();
@@ -845,7 +845,7 @@ bool DoSavestate(Savestate* file)
     ARM9->DoSavestate(file);
     ARM7->DoSavestate(file);
 
-    NDSCart::DoSavestate(file);
+    NDSCartSlot->DoSavestate(file);
     if (ConsoleType == 0)
         GBACartSlot->DoSavestate(file);
     GPU::DoSavestate(file);
@@ -885,11 +885,11 @@ void SetConsoleType(int type)
 
 bool LoadCart(const u8* romdata, u32 romlen, const u8* savedata, u32 savelen)
 {
-    if (!NDSCart::LoadROM(romdata, romlen))
+    if (!NDSCartSlot->LoadROM(romdata, romlen))
         return false;
 
     if (savedata && savelen)
-        NDSCart::LoadSave(savedata, savelen);
+        NDSCartSlot->LoadSave(savedata, savelen);
 
     return true;
 }
@@ -897,17 +897,17 @@ bool LoadCart(const u8* romdata, u32 romlen, const u8* savedata, u32 savelen)
 void LoadSave(const u8* savedata, u32 savelen)
 {
     if (savedata && savelen)
-        NDSCart::LoadSave(savedata, savelen);
+        NDSCartSlot->LoadSave(savedata, savelen);
 }
 
 void EjectCart()
 {
-    NDSCart::EjectCart();
+    NDSCartSlot->EjectCart();
 }
 
 bool CartInserted()
 {
-    return NDSCart::Cart != nullptr;
+    return NDSCartSlot->GetCart() != nullptr;
 }
 
 bool LoadGBACart(const u8* romdata, u32 romlen, const u8* savedata, u32 savelen)
@@ -1741,9 +1741,9 @@ void MonitorARM9Jump(u32 addr)
     // checkme: can the entrypoint addr be THUMB?
     // also TODO: make it work in DSi mode
 
-    if ((!RunningGame) && NDSCart::Cart)
+    if ((!RunningGame) && NDSCartSlot->GetCart())
     {
-        const NDSHeader& header = NDSCart::Cart->GetHeader();
+        const NDSHeader& header = NDSCartSlot->GetCart()->GetHeader();
         if (addr == header.ARM9EntryAddress)
         {
             Log(LogLevel::Info, "Game is now booting\n");
@@ -3035,40 +3035,40 @@ u8 ARM9IORead8(u32 addr)
 
     case 0x040001A2:
         if (!(ExMemCnt[0] & (1<<11)))
-            return NDSCart::ReadSPIData();
+            return NDSCartSlot->ReadSPIData();
         return 0;
 
     case 0x040001A8:
         if (!(ExMemCnt[0] & (1<<11)))
-            return NDSCart::ROMCommand[0];
+            return NDSCartSlot->GetROMCommand(0);
         return 0;
     case 0x040001A9:
         if (!(ExMemCnt[0] & (1<<11)))
-            return NDSCart::ROMCommand[1];
+            return NDSCartSlot->GetROMCommand(1);
         return 0;
     case 0x040001AA:
         if (!(ExMemCnt[0] & (1<<11)))
-            return NDSCart::ROMCommand[2];
+            return NDSCartSlot->GetROMCommand(2);
         return 0;
     case 0x040001AB:
         if (!(ExMemCnt[0] & (1<<11)))
-            return NDSCart::ROMCommand[3];
+            return NDSCartSlot->GetROMCommand(3);
         return 0;
     case 0x040001AC:
         if (!(ExMemCnt[0] & (1<<11)))
-            return NDSCart::ROMCommand[4];
+            return NDSCartSlot->GetROMCommand(4);
         return 0;
     case 0x040001AD:
         if (!(ExMemCnt[0] & (1<<11)))
-            return NDSCart::ROMCommand[5];
+            return NDSCartSlot->GetROMCommand(5);
         return 0;
     case 0x040001AE:
         if (!(ExMemCnt[0] & (1<<11)))
-            return NDSCart::ROMCommand[6];
+            return NDSCartSlot->GetROMCommand(6);
         return 0;
     case 0x040001AF:
         if (!(ExMemCnt[0] & (1<<11)))
-            return NDSCart::ROMCommand[7];
+            return NDSCartSlot->GetROMCommand(7);
         return 0;
 
     case 0x04000208: return IME[0];
@@ -3182,32 +3182,32 @@ u16 ARM9IORead16(u32 addr)
 
     case 0x040001A0:
         if (!(ExMemCnt[0] & (1<<11)))
-            return NDSCart::SPICnt;
+            return NDSCartSlot->GetSPICnt();
         return 0;
     case 0x040001A2:
         if (!(ExMemCnt[0] & (1<<11)))
-            return NDSCart::ReadSPIData();
+            return NDSCartSlot->ReadSPIData();
         return 0;
 
     case 0x040001A8:
         if (!(ExMemCnt[0] & (1<<11)))
-            return NDSCart::ROMCommand[0] |
-                  (NDSCart::ROMCommand[1] << 8);
+            return NDSCartSlot->GetROMCommand(0) |
+                  (NDSCartSlot->GetROMCommand(1) << 8);
         return 0;
     case 0x040001AA:
         if (!(ExMemCnt[0] & (1<<11)))
-            return NDSCart::ROMCommand[2] |
-                  (NDSCart::ROMCommand[3] << 8);
+            return NDSCartSlot->GetROMCommand(2) |
+                  (NDSCartSlot->GetROMCommand(3) << 8);
         return 0;
     case 0x040001AC:
         if (!(ExMemCnt[0] & (1<<11)))
-            return NDSCart::ROMCommand[4] |
-                  (NDSCart::ROMCommand[5] << 8);
+            return NDSCartSlot->GetROMCommand(4) |
+                  (NDSCartSlot->GetROMCommand(5) << 8);
         return 0;
     case 0x040001AE:
         if (!(ExMemCnt[0] & (1<<11)))
-            return NDSCart::ROMCommand[6] |
-                  (NDSCart::ROMCommand[7] << 8);
+            return NDSCartSlot->GetROMCommand(6) |
+                  (NDSCartSlot->GetROMCommand(7) << 8);
         return 0;
 
     case 0x04000204: return ExMemCnt[0];
@@ -3316,26 +3316,26 @@ u32 ARM9IORead32(u32 addr)
 
     case 0x040001A0:
         if (!(ExMemCnt[0] & (1<<11)))
-            return NDSCart::SPICnt | (NDSCart::ReadSPIData() << 16);
+            return NDSCartSlot->GetSPICnt() | (NDSCartSlot->ReadSPIData() << 16);
         return 0;
     case 0x040001A4:
         if (!(ExMemCnt[0] & (1<<11)))
-            return NDSCart::ROMCnt;
+            return NDSCartSlot->GetROMCnt();
         return 0;
 
     case 0x040001A8:
         if (!(ExMemCnt[0] & (1<<11)))
-            return NDSCart::ROMCommand[0] |
-                  (NDSCart::ROMCommand[1] << 8) |
-                  (NDSCart::ROMCommand[2] << 16) |
-                  (NDSCart::ROMCommand[3] << 24);
+            return NDSCartSlot->GetROMCommand(0) |
+                  (NDSCartSlot->GetROMCommand(1) << 8) |
+                  (NDSCartSlot->GetROMCommand(2) << 16) |
+                  (NDSCartSlot->GetROMCommand(3) << 24);
         return 0;
     case 0x040001AC:
         if (!(ExMemCnt[0] & (1<<11)))
-            return NDSCart::ROMCommand[4] |
-                  (NDSCart::ROMCommand[5] << 8) |
-                  (NDSCart::ROMCommand[6] << 16) |
-                  (NDSCart::ROMCommand[7] << 24);
+            return NDSCartSlot->GetROMCommand(4) |
+                  (NDSCartSlot->GetROMCommand(5) << 8) |
+                  (NDSCartSlot->GetROMCommand(6) << 16) |
+                  (NDSCartSlot->GetROMCommand(7) << 24);
         return 0;
 
     case 0x04000208: return IME[0];
@@ -3386,7 +3386,7 @@ u32 ARM9IORead32(u32 addr)
             return IPCFIFO7.Peek();
 
     case 0x04100010:
-        if (!(ExMemCnt[0] & (1<<11))) return NDSCart::ReadROMData();
+        if (!(ExMemCnt[0] & (1<<11))) return NDSCartSlot->ReadROMData();
         return 0;
 
     case 0x04004000:
@@ -3441,25 +3441,25 @@ void ARM9IOWrite8(u32 addr, u8 val)
 
     case 0x040001A0:
         if (!(ExMemCnt[0] & (1<<11)))
-            NDSCart::WriteSPICnt((NDSCart::SPICnt & 0xFF00) | val);
+            NDSCartSlot->WriteSPICnt((NDSCartSlot->GetSPICnt() & 0xFF00) | val);
         return;
     case 0x040001A1:
         if (!(ExMemCnt[0] & (1<<11)))
-            NDSCart::WriteSPICnt((NDSCart::SPICnt & 0x00FF) | (val << 8));
+            NDSCartSlot->WriteSPICnt((NDSCartSlot->GetSPICnt() & 0x00FF) | (val << 8));
         return;
     case 0x040001A2:
         if (!(ExMemCnt[0] & (1<<11)))
-            NDSCart::WriteSPIData(val);
+            NDSCartSlot->WriteSPIData(val);
         return;
 
-    case 0x040001A8: if (!(ExMemCnt[0] & (1<<11))) NDSCart::ROMCommand[0] = val; return;
-    case 0x040001A9: if (!(ExMemCnt[0] & (1<<11))) NDSCart::ROMCommand[1] = val; return;
-    case 0x040001AA: if (!(ExMemCnt[0] & (1<<11))) NDSCart::ROMCommand[2] = val; return;
-    case 0x040001AB: if (!(ExMemCnt[0] & (1<<11))) NDSCart::ROMCommand[3] = val; return;
-    case 0x040001AC: if (!(ExMemCnt[0] & (1<<11))) NDSCart::ROMCommand[4] = val; return;
-    case 0x040001AD: if (!(ExMemCnt[0] & (1<<11))) NDSCart::ROMCommand[5] = val; return;
-    case 0x040001AE: if (!(ExMemCnt[0] & (1<<11))) NDSCart::ROMCommand[6] = val; return;
-    case 0x040001AF: if (!(ExMemCnt[0] & (1<<11))) NDSCart::ROMCommand[7] = val; return;
+    case 0x040001A8: if (!(ExMemCnt[0] & (1<<11))) NDSCartSlot->SetROMCommand(0, val); return;
+    case 0x040001A9: if (!(ExMemCnt[0] & (1<<11))) NDSCartSlot->SetROMCommand(1, val); return;
+    case 0x040001AA: if (!(ExMemCnt[0] & (1<<11))) NDSCartSlot->SetROMCommand(2, val); return;
+    case 0x040001AB: if (!(ExMemCnt[0] & (1<<11))) NDSCartSlot->SetROMCommand(3, val); return;
+    case 0x040001AC: if (!(ExMemCnt[0] & (1<<11))) NDSCartSlot->SetROMCommand(4, val); return;
+    case 0x040001AD: if (!(ExMemCnt[0] & (1<<11))) NDSCartSlot->SetROMCommand(5, val); return;
+    case 0x040001AE: if (!(ExMemCnt[0] & (1<<11))) NDSCartSlot->SetROMCommand(6, val); return;
+    case 0x040001AF: if (!(ExMemCnt[0] & (1<<11))) NDSCartSlot->SetROMCommand(7, val); return;
 
     case 0x04000208: IME[0] = val & 0x1; UpdateIRQ(0); return;
 
@@ -3574,39 +3574,39 @@ void ARM9IOWrite16(u32 addr, u16 val)
 
     case 0x040001A0:
         if (!(ExMemCnt[0] & (1<<11)))
-            NDSCart::WriteSPICnt(val);
+            NDSCartSlot->WriteSPICnt(val);
         return;
     case 0x040001A2:
         if (!(ExMemCnt[0] & (1<<11)))
-            NDSCart::WriteSPIData(val & 0xFF);
+            NDSCartSlot->WriteSPIData(val & 0xFF);
         return;
 
     case 0x040001A8:
         if (!(ExMemCnt[0] & (1<<11)))
         {
-            NDSCart::ROMCommand[0] = val & 0xFF;
-            NDSCart::ROMCommand[1] = val >> 8;
+            NDSCartSlot->SetROMCommand(0, val & 0xFF);
+            NDSCartSlot->SetROMCommand(1, val >> 8);
         }
         return;
     case 0x040001AA:
         if (!(ExMemCnt[0] & (1<<11)))
         {
-            NDSCart::ROMCommand[2] = val & 0xFF;
-            NDSCart::ROMCommand[3] = val >> 8;
+            NDSCartSlot->SetROMCommand(2, val & 0xFF);
+            NDSCartSlot->SetROMCommand(3, val >> 8);
         }
         return;
     case 0x040001AC:
         if (!(ExMemCnt[0] & (1<<11)))
         {
-            NDSCart::ROMCommand[4] = val & 0xFF;
-            NDSCart::ROMCommand[5] = val >> 8;
+            NDSCartSlot->SetROMCommand(4, val & 0xFF);
+            NDSCartSlot->SetROMCommand(5, val >> 8);
         }
         return;
     case 0x040001AE:
         if (!(ExMemCnt[0] & (1<<11)))
         {
-            NDSCart::ROMCommand[6] = val & 0xFF;
-            NDSCart::ROMCommand[7] = val >> 8;
+            NDSCartSlot->SetROMCommand(6, val & 0xFF);
+            NDSCartSlot->SetROMCommand(7, val >> 8);
         }
         return;
 
@@ -3760,31 +3760,31 @@ void ARM9IOWrite32(u32 addr, u32 val)
     case 0x040001A0:
         if (!(ExMemCnt[0] & (1<<11)))
         {
-            NDSCart::WriteSPICnt(val & 0xFFFF);
-            NDSCart::WriteSPIData((val >> 16) & 0xFF);
+            NDSCartSlot->WriteSPICnt(val & 0xFFFF);
+            NDSCartSlot->WriteSPIData((val >> 16) & 0xFF);
         }
         return;
     case 0x040001A4:
         if (!(ExMemCnt[0] & (1<<11)))
-            NDSCart::WriteROMCnt(val);
+            NDSCartSlot->WriteROMCnt(val);
         return;
 
     case 0x040001A8:
         if (!(ExMemCnt[0] & (1<<11)))
         {
-            NDSCart::ROMCommand[0] = val & 0xFF;
-            NDSCart::ROMCommand[1] = (val >> 8) & 0xFF;
-            NDSCart::ROMCommand[2] = (val >> 16) & 0xFF;
-            NDSCart::ROMCommand[3] = val >> 24;
+            NDSCartSlot->SetROMCommand(0, val & 0xFF);
+            NDSCartSlot->SetROMCommand(1, (val >> 8) & 0xFF);
+            NDSCartSlot->SetROMCommand(2, (val >> 16) & 0xFF);
+            NDSCartSlot->SetROMCommand(3, val >> 24);
         }
         return;
     case 0x040001AC:
         if (!(ExMemCnt[0] & (1<<11)))
         {
-            NDSCart::ROMCommand[4] = val & 0xFF;
-            NDSCart::ROMCommand[5] = (val >> 8) & 0xFF;
-            NDSCart::ROMCommand[6] = (val >> 16) & 0xFF;
-            NDSCart::ROMCommand[7] = val >> 24;
+            NDSCartSlot->SetROMCommand(4, val & 0xFF);
+            NDSCartSlot->SetROMCommand(5, (val >> 8) & 0xFF);
+            NDSCartSlot->SetROMCommand(6, (val >> 16) & 0xFF);
+            NDSCartSlot->SetROMCommand(7, val >> 24);
         }
         return;
 
@@ -3830,7 +3830,7 @@ void ARM9IOWrite32(u32 addr, u32 val)
         return;
 
     case 0x04100010:
-        if (!(ExMemCnt[0] & (1<<11)))  NDSCart::WriteROMData(val);
+        if (!(ExMemCnt[0] & (1<<11)))  NDSCartSlot->WriteROMData(val);
         return;
 
     // NO$GBA debug register "String Out (raw)"
@@ -3899,40 +3899,40 @@ u8 ARM7IORead8(u32 addr)
 
     case 0x040001A2:
         if (ExMemCnt[0] & (1<<11))
-            return NDSCart::ReadSPIData();
+            return NDSCartSlot->ReadSPIData();
         return 0;
 
     case 0x040001A8:
         if (ExMemCnt[0] & (1<<11))
-            return NDSCart::ROMCommand[0];
+            return NDSCartSlot->GetROMCommand(0);
         return 0;
     case 0x040001A9:
         if (ExMemCnt[0] & (1<<11))
-            return NDSCart::ROMCommand[1];
+            return NDSCartSlot->GetROMCommand(1);
         return 0;
     case 0x040001AA:
         if (ExMemCnt[0] & (1<<11))
-            return NDSCart::ROMCommand[2];
+            return NDSCartSlot->GetROMCommand(2);
         return 0;
     case 0x040001AB:
         if (ExMemCnt[0] & (1<<11))
-            return NDSCart::ROMCommand[3];
+            return NDSCartSlot->GetROMCommand(3);
         return 0;
     case 0x040001AC:
         if (ExMemCnt[0] & (1<<11))
-            return NDSCart::ROMCommand[4];
+            return NDSCartSlot->GetROMCommand(4);
         return 0;
     case 0x040001AD:
         if (ExMemCnt[0] & (1<<11))
-            return NDSCart::ROMCommand[5];
+            return NDSCartSlot->GetROMCommand(5);
         return 0;
     case 0x040001AE:
         if (ExMemCnt[0] & (1<<11))
-            return NDSCart::ROMCommand[6];
+            return NDSCartSlot->GetROMCommand(6);
         return 0;
     case 0x040001AF:
         if (ExMemCnt[0] & (1<<11))
-            return NDSCart::ROMCommand[7];
+            return NDSCartSlot->GetROMCommand(7);
         return 0;
 
     case 0x040001C2: return SPI->ReadData();
@@ -3999,28 +3999,28 @@ u16 ARM7IORead16(u32 addr)
             return val;
         }
 
-    case 0x040001A0: if (ExMemCnt[0] & (1<<11)) return NDSCart::SPICnt;        return 0;
-    case 0x040001A2: if (ExMemCnt[0] & (1<<11)) return NDSCart::ReadSPIData(); return 0;
+    case 0x040001A0: if (ExMemCnt[0] & (1<<11)) return NDSCartSlot->GetSPICnt();   return 0;
+    case 0x040001A2: if (ExMemCnt[0] & (1<<11)) return NDSCartSlot->ReadSPIData(); return 0;
 
     case 0x040001A8:
         if (ExMemCnt[0] & (1<<11))
-            return NDSCart::ROMCommand[0] |
-                  (NDSCart::ROMCommand[1] << 8);
+            return NDSCartSlot->GetROMCommand(0) |
+                  (NDSCartSlot->GetROMCommand(1) << 8);
         return 0;
     case 0x040001AA:
         if (ExMemCnt[0] & (1<<11))
-            return NDSCart::ROMCommand[2] |
-                  (NDSCart::ROMCommand[3] << 8);
+            return NDSCartSlot->GetROMCommand(2) |
+                  (NDSCartSlot->GetROMCommand(3) << 8);
         return 0;
     case 0x040001AC:
         if (ExMemCnt[0] & (1<<11))
-            return NDSCart::ROMCommand[4] |
-                  (NDSCart::ROMCommand[5] << 8);
+            return NDSCartSlot->GetROMCommand(4) |
+                  (NDSCartSlot->GetROMCommand(5) << 8);
         return 0;
     case 0x040001AE:
         if (ExMemCnt[0] & (1<<11))
-            return NDSCart::ROMCommand[6] |
-                  (NDSCart::ROMCommand[7] << 8);
+            return NDSCartSlot->GetROMCommand(6) |
+                  (NDSCartSlot->GetROMCommand(7) << 8);
         return 0;
 
     case 0x040001C0: return SPI->ReadCnt();
@@ -4083,26 +4083,26 @@ u32 ARM7IORead32(u32 addr)
 
     case 0x040001A0:
         if (ExMemCnt[0] & (1<<11))
-            return NDSCart::SPICnt | (NDSCart::ReadSPIData() << 16);
+            return NDSCartSlot->GetSPICnt() | (NDSCartSlot->ReadSPIData() << 16);
         return 0;
     case 0x040001A4:
         if (ExMemCnt[0] & (1<<11))
-            return NDSCart::ROMCnt;
+            return NDSCartSlot->GetROMCnt();
         return 0;
 
     case 0x040001A8:
         if (ExMemCnt[0] & (1<<11))
-            return NDSCart::ROMCommand[0] |
-                  (NDSCart::ROMCommand[1] << 8) |
-                  (NDSCart::ROMCommand[2] << 16) |
-                  (NDSCart::ROMCommand[3] << 24);
+            return NDSCartSlot->GetROMCommand(0) |
+                  (NDSCartSlot->GetROMCommand(1) << 8) |
+                  (NDSCartSlot->GetROMCommand(2) << 16) |
+                  (NDSCartSlot->GetROMCommand(3) << 24);
         return 0;
     case 0x040001AC:
         if (ExMemCnt[0] & (1<<11))
-            return NDSCart::ROMCommand[4] |
-                  (NDSCart::ROMCommand[5] << 8) |
-                  (NDSCart::ROMCommand[6] << 16) |
-                  (NDSCart::ROMCommand[7] << 24);
+            return NDSCartSlot->GetROMCommand(4) |
+                  (NDSCartSlot->GetROMCommand(5) << 8) |
+                  (NDSCartSlot->GetROMCommand(6) << 16) |
+                  (NDSCartSlot->GetROMCommand(7) << 24);
         return 0;
 
     case 0x040001C0:
@@ -4137,7 +4137,7 @@ u32 ARM7IORead32(u32 addr)
             return IPCFIFO9.Peek();
 
     case 0x04100010:
-        if (ExMemCnt[0] & (1<<11)) return NDSCart::ReadROMData();
+        if (ExMemCnt[0] & (1<<11)) return NDSCartSlot->ReadROMData();
         return 0;
     }
 
@@ -4177,26 +4177,26 @@ void ARM7IOWrite8(u32 addr, u8 val)
     case 0x040001A0:
         if (ExMemCnt[0] & (1<<11))
         {
-            NDSCart::WriteSPICnt((NDSCart::SPICnt & 0xFF00) | val);
+            NDSCartSlot->WriteSPICnt((NDSCartSlot->GetSPICnt() & 0xFF00) | val);
         }
         return;
     case 0x040001A1:
         if (ExMemCnt[0] & (1<<11))
-            NDSCart::WriteSPICnt((NDSCart::SPICnt & 0x00FF) | (val << 8));
+            NDSCartSlot->WriteSPICnt((NDSCartSlot->GetSPICnt() & 0x00FF) | (val << 8));
         return;
     case 0x040001A2:
         if (ExMemCnt[0] & (1<<11))
-            NDSCart::WriteSPIData(val);
+            NDSCartSlot->WriteSPIData(val);
         return;
 
-    case 0x040001A8: if (ExMemCnt[0] & (1<<11)) NDSCart::ROMCommand[0] = val; return;
-    case 0x040001A9: if (ExMemCnt[0] & (1<<11)) NDSCart::ROMCommand[1] = val; return;
-    case 0x040001AA: if (ExMemCnt[0] & (1<<11)) NDSCart::ROMCommand[2] = val; return;
-    case 0x040001AB: if (ExMemCnt[0] & (1<<11)) NDSCart::ROMCommand[3] = val; return;
-    case 0x040001AC: if (ExMemCnt[0] & (1<<11)) NDSCart::ROMCommand[4] = val; return;
-    case 0x040001AD: if (ExMemCnt[0] & (1<<11)) NDSCart::ROMCommand[5] = val; return;
-    case 0x040001AE: if (ExMemCnt[0] & (1<<11)) NDSCart::ROMCommand[6] = val; return;
-    case 0x040001AF: if (ExMemCnt[0] & (1<<11)) NDSCart::ROMCommand[7] = val; return;
+    case 0x040001A8: if (ExMemCnt[0] & (1<<11)) NDSCartSlot->SetROMCommand(0, val); return;
+    case 0x040001A9: if (ExMemCnt[0] & (1<<11)) NDSCartSlot->SetROMCommand(1, val); return;
+    case 0x040001AA: if (ExMemCnt[0] & (1<<11)) NDSCartSlot->SetROMCommand(2, val); return;
+    case 0x040001AB: if (ExMemCnt[0] & (1<<11)) NDSCartSlot->SetROMCommand(3, val); return;
+    case 0x040001AC: if (ExMemCnt[0] & (1<<11)) NDSCartSlot->SetROMCommand(4, val); return;
+    case 0x040001AD: if (ExMemCnt[0] & (1<<11)) NDSCartSlot->SetROMCommand(5, val); return;
+    case 0x040001AE: if (ExMemCnt[0] & (1<<11)) NDSCartSlot->SetROMCommand(6, val); return;
+    case 0x040001AF: if (ExMemCnt[0] & (1<<11)) NDSCartSlot->SetROMCommand(7, val); return;
 
     case 0x040001C2:
         SPI->WriteData(val);
@@ -4287,39 +4287,39 @@ void ARM7IOWrite16(u32 addr, u16 val)
 
     case 0x040001A0:
         if (ExMemCnt[0] & (1<<11))
-            NDSCart::WriteSPICnt(val);
+            NDSCartSlot->WriteSPICnt(val);
         return;
     case 0x040001A2:
         if (ExMemCnt[0] & (1<<11))
-            NDSCart::WriteSPIData(val & 0xFF);
+            NDSCartSlot->WriteSPIData(val & 0xFF);
         return;
 
     case 0x040001A8:
         if (ExMemCnt[0] & (1<<11))
         {
-            NDSCart::ROMCommand[0] = val & 0xFF;
-            NDSCart::ROMCommand[1] = val >> 8;
+            NDSCartSlot->SetROMCommand(0, val & 0xFF);
+            NDSCartSlot->SetROMCommand(1, val >> 8);
         }
         return;
     case 0x040001AA:
         if (ExMemCnt[0] & (1<<11))
         {
-            NDSCart::ROMCommand[2] = val & 0xFF;
-            NDSCart::ROMCommand[3] = val >> 8;
+            NDSCartSlot->SetROMCommand(2, val & 0xFF);
+            NDSCartSlot->SetROMCommand(3, val >> 8);
         }
         return;
     case 0x040001AC:
         if (ExMemCnt[0] & (1<<11))
         {
-            NDSCart::ROMCommand[4] = val & 0xFF;
-            NDSCart::ROMCommand[5] = val >> 8;
+            NDSCartSlot->SetROMCommand(4, val & 0xFF);
+            NDSCartSlot->SetROMCommand(5, val >> 8);
         }
         return;
     case 0x040001AE:
         if (ExMemCnt[0] & (1<<11))
         {
-            NDSCart::ROMCommand[6] = val & 0xFF;
-            NDSCart::ROMCommand[7] = val >> 8;
+            NDSCartSlot->SetROMCommand(6, val & 0xFF);
+            NDSCartSlot->SetROMCommand(7, val >> 8);
         }
         return;
 
@@ -4448,31 +4448,31 @@ void ARM7IOWrite32(u32 addr, u32 val)
     case 0x040001A0:
         if (ExMemCnt[0] & (1<<11))
         {
-            NDSCart::WriteSPICnt(val & 0xFFFF);
-            NDSCart::WriteSPIData((val >> 16) & 0xFF);
+            NDSCartSlot->WriteSPICnt(val & 0xFFFF);
+            NDSCartSlot->WriteSPIData((val >> 16) & 0xFF);
         }
         return;
     case 0x040001A4:
         if (ExMemCnt[0] & (1<<11))
-            NDSCart::WriteROMCnt(val);
+            NDSCartSlot->WriteROMCnt(val);
         return;
 
     case 0x040001A8:
         if (ExMemCnt[0] & (1<<11))
         {
-            NDSCart::ROMCommand[0] = val & 0xFF;
-            NDSCart::ROMCommand[1] = (val >> 8) & 0xFF;
-            NDSCart::ROMCommand[2] = (val >> 16) & 0xFF;
-            NDSCart::ROMCommand[3] = val >> 24;
+            NDSCartSlot->SetROMCommand(0, val & 0xFF);
+            NDSCartSlot->SetROMCommand(1, (val >> 8) & 0xFF);
+            NDSCartSlot->SetROMCommand(2, (val >> 16) & 0xFF);
+            NDSCartSlot->SetROMCommand(3, val >> 24);
         }
         return;
     case 0x040001AC:
         if (ExMemCnt[0] & (1<<11))
         {
-            NDSCart::ROMCommand[4] = val & 0xFF;
-            NDSCart::ROMCommand[5] = (val >> 8) & 0xFF;
-            NDSCart::ROMCommand[6] = (val >> 16) & 0xFF;
-            NDSCart::ROMCommand[7] = val >> 24;
+            NDSCartSlot->SetROMCommand(4, val & 0xFF);
+            NDSCartSlot->SetROMCommand(5, (val >> 8) & 0xFF);
+            NDSCartSlot->SetROMCommand(6, (val >> 16) & 0xFF);
+            NDSCartSlot->SetROMCommand(7, val >> 24);
         }
         return;
 
@@ -4504,7 +4504,7 @@ void ARM7IOWrite32(u32 addr, u32 val)
         return;
 
     case 0x04100010:
-        if (ExMemCnt[0] & (1<<11))  NDSCart::WriteROMData(val);
+        if (ExMemCnt[0] & (1<<11))  NDSCartSlot->WriteROMData(val);
         return;
     }
 

--- a/src/NDS.h
+++ b/src/NDS.h
@@ -26,6 +26,7 @@
 #include "Platform.h"
 #include "Savestate.h"
 #include "types.h"
+#include "NDSCart.h"
 #include "GBACart.h"
 
 // when touching the main loop/timing code, pls test a lot of shit
@@ -259,6 +260,7 @@ extern class SPU* SPU;
 extern class SPIHost* SPI;
 extern class RTC* RTC;
 extern class Wifi* Wifi;
+extern std::unique_ptr<NDSCart::NDSCartSlot> NDSCartSlot;
 extern std::unique_ptr<GBACart::GBACartSlot> GBACartSlot;
 extern class AREngine* AREngine;
 

--- a/src/NDS.h
+++ b/src/NDS.h
@@ -20,11 +20,13 @@
 #define NDS_H
 
 #include <string>
+#include <memory>
 #include <functional>
 
 #include "Platform.h"
 #include "Savestate.h"
 #include "types.h"
+#include "GBACart.h"
 
 // when touching the main loop/timing code, pls test a lot of shit
 // with this enabled, to make sure it doesn't desync
@@ -257,7 +259,7 @@ extern class SPU* SPU;
 extern class SPIHost* SPI;
 extern class RTC* RTC;
 extern class Wifi* Wifi;
-
+extern std::unique_ptr<GBACart::GBACartSlot> GBACartSlot;
 extern class AREngine* AREngine;
 
 const u32 ARM7WRAMSize = 0x10000;

--- a/src/frontend/qt_sdl/ROMInfoDialog.cpp
+++ b/src/frontend/qt_sdl/ROMInfoDialog.cpp
@@ -43,8 +43,8 @@ ROMInfoDialog::ROMInfoDialog(QWidget* parent) : QDialog(parent), ui(new Ui::ROMI
     ui->setupUi(this);
     setAttribute(Qt::WA_DeleteOnClose);
 
-    const NDSBanner* banner = NDSCart::Cart->Banner();
-    const NDSHeader& header = NDSCart::Cart->GetHeader();
+    const NDSBanner* banner = NDS::NDSCartSlot->GetCart()->Banner();
+    const NDSHeader& header = NDS::NDSCartSlot->GetCart()->GetHeader();
     u32 iconData[32 * 32];
     ROMManager::ROMIcon(banner->Icon, banner->Palette, iconData);
     iconImage = QImage(reinterpret_cast<unsigned char*>(iconData), 32, 32, QImage::Format_ARGB32).copy();

--- a/src/frontend/qt_sdl/main.cpp
+++ b/src/frontend/qt_sdl/main.cpp
@@ -384,7 +384,8 @@ void EmuThread::run()
 
         if (Input::HotkeyPressed(HK_SolarSensorDecrease))
         {
-            int level = GBACart::SetInput(GBACart::Input_SolarSensorDown, true);
+            assert(NDS::GBACartSlot != nullptr);
+            int level = NDS::GBACartSlot->SetInput(GBACart::Input_SolarSensorDown, true);
             if (level != -1)
             {
                 char msg[64];
@@ -394,7 +395,8 @@ void EmuThread::run()
         }
         if (Input::HotkeyPressed(HK_SolarSensorIncrease))
         {
-            int level = GBACart::SetInput(GBACart::Input_SolarSensorUp, true);
+            assert(NDS::GBACartSlot != nullptr);
+            int level = NDS::GBACartSlot->SetInput(GBACart::Input_SolarSensorUp, true);
             if (level != -1)
             {
                 char msg[64];


### PR DESCRIPTION
- RAII will now do the heavy lifting
- Mark some methods as const or noexcept