### PR TITLE
Make AREngine::RunCheat public

### DIFF
--- a/src/AREngine.h
+++ b/src/AREngine.h
@@ -32,7 +32,7 @@ public:
     void SetCodeFile(ARCodeFile* file) { CodeFile = file; }
 
     void RunCheats();
-
+    void RunCheat(ARCode& arcode);
 private:
     ARCodeFile* CodeFile; // AR code file - frontend is responsible for managing this
 
@@ -43,8 +43,6 @@ private:
     void (*BusWrite8)(u32 addr, u8 val);
     void (*BusWrite16)(u32 addr, u16 val);
     void (*BusWrite32)(u32 addr, u32 val);
-
-    void RunCheat(ARCode& arcode);
 };
 
 #endif // ARENGINE_H


### PR DESCRIPTION
- I use it directly in melonDS DS [to apply single cheats](https://github.com/JesseTG/melonds-ds/blob/main/src/libretro/cheats.cpp#L54-L100) without using ARCodeFile
- Before the AREngine refactor I could just redeclare the function in my code
- Now I can't