### PR TITLE
DSi_Camera: fix gcc-14 build issue

### DIFF
--- a/src/DSi_Camera.cpp
+++ b/src/DSi_Camera.cpp
@@ -16,6 +16,7 @@
     with melonDS. If not, see http://www.gnu.org/licenses/.
 */
 
+#include <algorithm>
 #include <stdio.h>
 #include <string.h>
 #include "DSi.h"


### PR DESCRIPTION
```
melonDS/src/DSi_Camera.cpp:190:23: error: 'clamp' is not a member of 'std'
  190 |             r1 = std::clamp(r1, 0, 255); g1 = std::clamp(g1, 0, 255); b1 = std::clamp(b1, 0, 255);
      |                       ^~~~~
```
Reference: https://en.cppreference.com/w/cpp/algorithm/clamp