### PR TITLE
Refactor the JIT to be object-oriented

### DIFF
--- a/src/ARM.h
+++ b/src/ARM.h
@@ -42,13 +42,15 @@ enum
 const u32 ITCMPhysicalSize = 0x8000;
 const u32 DTCMPhysicalSize = 0x4000;
 
+class ARMJIT_Memory;
+
 class ARM
 #ifdef GDBSTUB_ENABLED
     : public Gdb::StubCallbacks
 #endif
 {
 public:
-    ARM(u32 num);
+    ARM(u32 num, ARMJIT_Memory& memory);
     virtual ~ARM(); // destroy shit
 
     virtual void Reset();
@@ -174,12 +176,13 @@ public:
     u64* FastBlockLookup;
 #endif
 
-    static u32 ConditionTable[16];
+    static const u32 ConditionTable[16];
 #ifdef GDBSTUB_ENABLED
     Gdb::GdbStub GdbStub;
 #endif
 
 protected:
+    ARMJIT_Memory& Memory;
     u8 (*BusRead8)(u32 addr);
     u16 (*BusRead16)(u32 addr);
     u32 (*BusRead32)(u32 addr);
@@ -214,7 +217,7 @@ protected:
 class ARMv5 : public ARM
 {
 public:
-    ARMv5();
+    ARMv5(ARMJIT_Memory& memory);
     ~ARMv5();
 
     void Reset() override;
@@ -358,7 +361,7 @@ public:
 class ARMv4 : public ARM
 {
 public:
-    ARMv4();
+    ARMv4(ARMJIT_Memory& memory);
 
     void Reset() override;
 

--- a/src/ARM.h
+++ b/src/ARM.h
@@ -42,6 +42,10 @@ enum
 const u32 ITCMPhysicalSize = 0x8000;
 const u32 DTCMPhysicalSize = 0x4000;
 
+namespace ARMJIT
+{
+class ARMJIT;
+}
 namespace Melon
 {
 class GPU;
@@ -55,7 +59,7 @@ class ARM
 #endif
 {
 public:
-    ARM(u32 num, ARMJIT_Memory& memory, Melon::GPU& gpu);
+    ARM(u32 num, ARMJIT::ARMJIT& jit, Melon::GPU& gpu);
     virtual ~ARM(); // destroy shit
 
     virtual void Reset();
@@ -186,8 +190,8 @@ public:
     Gdb::GdbStub GdbStub;
 #endif
 
+    ARMJIT::ARMJIT& JIT;
 protected:
-    ARMJIT_Memory& Memory;
     u8 (*BusRead8)(u32 addr);
     u16 (*BusRead16)(u32 addr);
     u32 (*BusRead32)(u32 addr);
@@ -224,7 +228,7 @@ private:
 class ARMv5 : public ARM
 {
 public:
-    ARMv5(ARMJIT_Memory& memory, Melon::GPU& gpu);
+    ARMv5(ARMJIT::ARMJIT& jit, Melon::GPU& gpu);
     ~ARMv5();
 
     void Reset() override;
@@ -368,7 +372,7 @@ public:
 class ARMv4 : public ARM
 {
 public:
-    ARMv4(ARMJIT_Memory& memory, Melon::GPU& gpu);
+    ARMv4(ARMJIT::ARMJIT& jit, Melon::GPU& gpu);
 
     void Reset() override;
 

--- a/src/ARMJIT.cpp
+++ b/src/ARMJIT.cpp
@@ -229,8 +229,6 @@ void SlowBlockTransfer7(u32 addr, u64* data, u32 num)
 INSTANTIATE_SLOWMEM(0)
 INSTANTIATE_SLOWMEM(1)
 
-std::unique_ptr<ARMJIT_Memory> Memory;
-
 ARMJIT::ARMJIT() noexcept : JITCompiler(*this), Memory(*this)
 {
 }

--- a/src/ARMJIT.cpp
+++ b/src/ARMJIT.cpp
@@ -229,10 +229,6 @@ void SlowBlockTransfer7(u32 addr, u64* data, u32 num)
 INSTANTIATE_SLOWMEM(0)
 INSTANTIATE_SLOWMEM(1)
 
-ARMJIT::ARMJIT() noexcept : JITCompiler(*this), Memory(*this)
-{
-}
-
 ARMJIT::~ARMJIT() noexcept
 {
     JitEnableWrite();

--- a/src/ARMJIT.h
+++ b/src/ARMJIT.h
@@ -19,10 +19,12 @@
 #ifndef ARMJIT_H
 #define ARMJIT_H
 
+#include <memory>
 #include "types.h"
 
 #include "ARM.h"
 #include "ARM_InstrInfo.h"
+#include "ARMJIT_Memory.h"
 
 #if defined(__APPLE__) && defined(__aarch64__)
     #include <pthread.h>
@@ -49,7 +51,11 @@ void CheckAndInvalidateWVRAM(int bank);
 void InvalidateByAddr(u32 pseudoPhysical);
 
 template <u32 num, int region>
+#ifdef JIT_ENABLED
 void CheckAndInvalidate(u32 addr);
+#else
+inline void CheckAndInvalidate(u32 addr) {}
+#endif
 
 void CompileBlock(ARM* cpu);
 

--- a/src/ARMJIT.h
+++ b/src/ARMJIT.h
@@ -39,14 +39,16 @@ class JitBlock;
 class ARMJIT
 {
 public:
-    ARMJIT() noexcept;
-    ~ARMJIT() noexcept;
-    void Reset() noexcept;
-
-    void CheckAndInvalidateITCM() noexcept;
-    void CheckAndInvalidateWVRAM(int bank) noexcept;
-
-    void InvalidateByAddr(u32 pseudoPhysical) noexcept;
+    ARMJIT() noexcept : JITCompiler(*this), Memory(*this) {}
+    ~ARMJIT() noexcept NOOP_IF_NO_JIT;
+    void InvalidateByAddr(u32) noexcept NOOP_IF_NO_JIT;
+    void CheckAndInvalidateWVRAM(int) noexcept NOOP_IF_NO_JIT;
+    void CheckAndInvalidateITCM() noexcept NOOP_IF_NO_JIT;
+    void Reset() noexcept NOOP_IF_NO_JIT;
+    void JitEnableWrite() noexcept NOOP_IF_NO_JIT;
+    void JitEnableExecute() noexcept NOOP_IF_NO_JIT;
+    void CompileBlock(ARM* cpu) noexcept NOOP_IF_NO_JIT;
+    void ResetBlockCache() noexcept NOOP_IF_NO_JIT;
 
 #ifdef JIT_ENABLED
     template <u32 num, int region>
@@ -56,65 +58,60 @@ public:
         if (CodeMemRegions[region][(localAddr & 0x7FFFFFF) / 512].Code & (1 << ((localAddr & 0x1FF) / 16)))
             InvalidateByAddr(localAddr);
     }
-#else
-    template <u32 num, int region>
-    void CheckAndInvalidate(u32 addr) noexcept {}
-#endif
-
-    void CompileBlock(ARM* cpu) noexcept;
-    void ResetBlockCache() noexcept;
     JitBlockEntry LookUpBlock(u32 num, u64* entries, u32 offset, u32 addr) noexcept;
     bool SetupExecutableRegion(u32 num, u32 blockAddr, u64*& entry, u32& start, u32& size) noexcept;
-    void JitEnableWrite() noexcept;
-    void JitEnableExecute() noexcept;
     u32 LocaliseCodeAddress(u32 num, u32 addr) const noexcept;
+#else
+    template <u32, int>
+    void CheckAndInvalidate(u32) noexcept {}
+#endif
 
     ARMJIT_Memory Memory;
-    int MaxBlockSize;
+    int MaxBlockSize {};
     bool LiteralOptimizations = false;
     bool BranchOptimizations = false;
     bool FastMemory = false;
 
-    TinyVector<u32> InvalidLiterals;
+    TinyVector<u32> InvalidLiterals {};
 private:
     friend class ::ARMJIT_Memory;
     void blockSanityCheck(u32 num, u32 blockAddr, JitBlockEntry entry) noexcept;
     void RetireJitBlock(JitBlock* block) noexcept;
 
     Compiler JITCompiler;
-    std::unordered_map<u32, JitBlock*> JitBlocks9;
-    std::unordered_map<u32, JitBlock*> JitBlocks7;
+    std::unordered_map<u32, JitBlock*> JitBlocks9 {};
+    std::unordered_map<u32, JitBlock*> JitBlocks7 {};
 
-    std::unordered_map<u32, JitBlock*> RestoreCandidates;
+    std::unordered_map<u32, JitBlock*> RestoreCandidates {};
 
 
-    AddressRange CodeIndexITCM[ITCMPhysicalSize / 512];
-    AddressRange CodeIndexMainRAM[NDS::MainRAMMaxSize / 512];
-    AddressRange CodeIndexSWRAM[NDS::SharedWRAMSize / 512];
-    AddressRange CodeIndexVRAM[0x100000 / 512];
-    AddressRange CodeIndexARM9BIOS[sizeof(NDS::ARM9BIOS) / 512];
-    AddressRange CodeIndexARM7BIOS[sizeof(NDS::ARM7BIOS) / 512];
-    AddressRange CodeIndexARM7WRAM[NDS::ARM7WRAMSize / 512];
-    AddressRange CodeIndexARM7WVRAM[0x40000 / 512];
-    AddressRange CodeIndexBIOS9DSi[0x10000 / 512];
-    AddressRange CodeIndexBIOS7DSi[0x10000 / 512];
-    AddressRange CodeIndexNWRAM_A[DSi::NWRAMSize / 512];
-    AddressRange CodeIndexNWRAM_B[DSi::NWRAMSize / 512];
-    AddressRange CodeIndexNWRAM_C[DSi::NWRAMSize / 512];
+    AddressRange CodeIndexITCM[ITCMPhysicalSize / 512] {};
+    AddressRange CodeIndexMainRAM[NDS::MainRAMMaxSize / 512] {};
+    AddressRange CodeIndexSWRAM[NDS::SharedWRAMSize / 512] {};
+    AddressRange CodeIndexVRAM[0x100000 / 512] {};
+    AddressRange CodeIndexARM9BIOS[sizeof(NDS::ARM9BIOS) / 512] {};
+    AddressRange CodeIndexARM7BIOS[sizeof(NDS::ARM7BIOS) / 512] {};
+    AddressRange CodeIndexARM7WRAM[NDS::ARM7WRAMSize / 512] {};
+    AddressRange CodeIndexARM7WVRAM[0x40000 / 512] {};
+    AddressRange CodeIndexBIOS9DSi[0x10000 / 512] {};
+    AddressRange CodeIndexBIOS7DSi[0x10000 / 512] {};
+    AddressRange CodeIndexNWRAM_A[DSi::NWRAMSize / 512] {};
+    AddressRange CodeIndexNWRAM_B[DSi::NWRAMSize / 512] {};
+    AddressRange CodeIndexNWRAM_C[DSi::NWRAMSize / 512] {};
 
-    u64 FastBlockLookupITCM[ITCMPhysicalSize / 2];
-    u64 FastBlockLookupMainRAM[NDS::MainRAMMaxSize / 2];
-    u64 FastBlockLookupSWRAM[NDS::SharedWRAMSize / 2];
-    u64 FastBlockLookupVRAM[0x100000 / 2];
-    u64 FastBlockLookupARM9BIOS[sizeof(NDS::ARM9BIOS) / 2];
-    u64 FastBlockLookupARM7BIOS[sizeof(NDS::ARM7BIOS) / 2];
-    u64 FastBlockLookupARM7WRAM[NDS::ARM7WRAMSize / 2];
-    u64 FastBlockLookupARM7WVRAM[0x40000 / 2];
-    u64 FastBlockLookupBIOS9DSi[0x10000 / 2];
-    u64 FastBlockLookupBIOS7DSi[0x10000 / 2];
-    u64 FastBlockLookupNWRAM_A[DSi::NWRAMSize / 2];
-    u64 FastBlockLookupNWRAM_B[DSi::NWRAMSize / 2];
-    u64 FastBlockLookupNWRAM_C[DSi::NWRAMSize / 2];
+    u64 FastBlockLookupITCM[ITCMPhysicalSize / 2] {};
+    u64 FastBlockLookupMainRAM[NDS::MainRAMMaxSize / 2] {};
+    u64 FastBlockLookupSWRAM[NDS::SharedWRAMSize / 2] {};
+    u64 FastBlockLookupVRAM[0x100000 / 2] {};
+    u64 FastBlockLookupARM9BIOS[sizeof(NDS::ARM9BIOS) / 2] {};
+    u64 FastBlockLookupARM7BIOS[sizeof(NDS::ARM7BIOS) / 2] {};
+    u64 FastBlockLookupARM7WRAM[NDS::ARM7WRAMSize / 2] {};
+    u64 FastBlockLookupARM7WVRAM[0x40000 / 2] {};
+    u64 FastBlockLookupBIOS9DSi[0x10000 / 2] {};
+    u64 FastBlockLookupBIOS7DSi[0x10000 / 2] {};
+    u64 FastBlockLookupNWRAM_A[DSi::NWRAMSize / 2] {};
+    u64 FastBlockLookupNWRAM_B[DSi::NWRAMSize / 2] {};
+    u64 FastBlockLookupNWRAM_C[DSi::NWRAMSize / 2] {};
 
     AddressRange* const CodeMemRegions[ARMJIT_Memory::memregions_Count] =
     {

--- a/src/ARMJIT.h
+++ b/src/ARMJIT.h
@@ -40,6 +40,7 @@ extern bool LiteralOptimizations;
 extern bool BranchOptimizations;
 extern bool FastMemory;
 
+extern std::unique_ptr<ARMJIT_Memory> Memory;
 void Init();
 void DeInit();
 

--- a/src/ARMJIT.h
+++ b/src/ARMJIT.h
@@ -22,53 +22,147 @@
 #include <memory>
 #include "types.h"
 
-#include "ARM.h"
-#include "ARM_InstrInfo.h"
 #include "ARMJIT_Memory.h"
+#include "JitBlock.h"
 
 #if defined(__APPLE__) && defined(__aarch64__)
     #include <pthread.h>
 #endif
 
+#include "ARMJIT_Compiler.h"
+
+class ARM;
+
 namespace ARMJIT
 {
+class JitBlock;
+class ARMJIT
+{
+public:
+    ARMJIT() noexcept;
+    ~ARMJIT() noexcept;
+    void Reset() noexcept;
 
-typedef void (*JitBlockEntry)();
+    void CheckAndInvalidateITCM() noexcept;
+    void CheckAndInvalidateWVRAM(int bank) noexcept;
 
-extern int MaxBlockSize;
-extern bool LiteralOptimizations;
-extern bool BranchOptimizations;
-extern bool FastMemory;
+    void InvalidateByAddr(u32 pseudoPhysical) noexcept;
 
-extern std::unique_ptr<ARMJIT_Memory> Memory;
-void Init();
-void DeInit();
-
-void Reset();
-
-void CheckAndInvalidateITCM();
-void CheckAndInvalidateWVRAM(int bank);
-
-void InvalidateByAddr(u32 pseudoPhysical);
-
-template <u32 num, int region>
 #ifdef JIT_ENABLED
-void CheckAndInvalidate(u32 addr);
+    template <u32 num, int region>
+    void CheckAndInvalidate(u32 addr) noexcept
+    {
+        u32 localAddr = Memory.LocaliseAddress(region, num, addr);
+        if (CodeMemRegions[region][(localAddr & 0x7FFFFFF) / 512].Code & (1 << ((localAddr & 0x1FF) / 16)))
+            InvalidateByAddr(localAddr);
+    }
 #else
-inline void CheckAndInvalidate(u32 addr) {}
+    template <u32 num, int region>
+    void CheckAndInvalidate(u32 addr) noexcept {}
 #endif
 
-void CompileBlock(ARM* cpu);
+    void CompileBlock(ARM* cpu) noexcept;
+    void ResetBlockCache() noexcept;
+    JitBlockEntry LookUpBlock(u32 num, u64* entries, u32 offset, u32 addr) noexcept;
+    bool SetupExecutableRegion(u32 num, u32 blockAddr, u64*& entry, u32& start, u32& size) noexcept;
+    void JitEnableWrite() noexcept;
+    void JitEnableExecute() noexcept;
+    u32 LocaliseCodeAddress(u32 num, u32 addr) const noexcept;
 
-void ResetBlockCache();
+    ARMJIT_Memory Memory;
+    int MaxBlockSize;
+    bool LiteralOptimizations = false;
+    bool BranchOptimizations = false;
+    bool FastMemory = false;
 
-JitBlockEntry LookUpBlock(u32 num, u64* entries, u32 offset, u32 addr);
-bool SetupExecutableRegion(u32 num, u32 blockAddr, u64*& entry, u32& start, u32& size);
+    TinyVector<u32> InvalidLiterals;
+private:
+    friend class ::ARMJIT_Memory;
+    void blockSanityCheck(u32 num, u32 blockAddr, JitBlockEntry entry) noexcept;
+    void RetireJitBlock(JitBlock* block) noexcept;
 
-void JitEnableWrite();
-void JitEnableExecute();
+    Compiler JITCompiler;
+    std::unordered_map<u32, JitBlock*> JitBlocks9;
+    std::unordered_map<u32, JitBlock*> JitBlocks7;
+
+    std::unordered_map<u32, JitBlock*> RestoreCandidates;
+
+
+    AddressRange CodeIndexITCM[ITCMPhysicalSize / 512];
+    AddressRange CodeIndexMainRAM[NDS::MainRAMMaxSize / 512];
+    AddressRange CodeIndexSWRAM[NDS::SharedWRAMSize / 512];
+    AddressRange CodeIndexVRAM[0x100000 / 512];
+    AddressRange CodeIndexARM9BIOS[sizeof(NDS::ARM9BIOS) / 512];
+    AddressRange CodeIndexARM7BIOS[sizeof(NDS::ARM7BIOS) / 512];
+    AddressRange CodeIndexARM7WRAM[NDS::ARM7WRAMSize / 512];
+    AddressRange CodeIndexARM7WVRAM[0x40000 / 512];
+    AddressRange CodeIndexBIOS9DSi[0x10000 / 512];
+    AddressRange CodeIndexBIOS7DSi[0x10000 / 512];
+    AddressRange CodeIndexNWRAM_A[DSi::NWRAMSize / 512];
+    AddressRange CodeIndexNWRAM_B[DSi::NWRAMSize / 512];
+    AddressRange CodeIndexNWRAM_C[DSi::NWRAMSize / 512];
+
+    u64 FastBlockLookupITCM[ITCMPhysicalSize / 2];
+    u64 FastBlockLookupMainRAM[NDS::MainRAMMaxSize / 2];
+    u64 FastBlockLookupSWRAM[NDS::SharedWRAMSize / 2];
+    u64 FastBlockLookupVRAM[0x100000 / 2];
+    u64 FastBlockLookupARM9BIOS[sizeof(NDS::ARM9BIOS) / 2];
+    u64 FastBlockLookupARM7BIOS[sizeof(NDS::ARM7BIOS) / 2];
+    u64 FastBlockLookupARM7WRAM[NDS::ARM7WRAMSize / 2];
+    u64 FastBlockLookupARM7WVRAM[0x40000 / 2];
+    u64 FastBlockLookupBIOS9DSi[0x10000 / 2];
+    u64 FastBlockLookupBIOS7DSi[0x10000 / 2];
+    u64 FastBlockLookupNWRAM_A[DSi::NWRAMSize / 2];
+    u64 FastBlockLookupNWRAM_B[DSi::NWRAMSize / 2];
+    u64 FastBlockLookupNWRAM_C[DSi::NWRAMSize / 2];
+
+    AddressRange* const CodeMemRegions[ARMJIT_Memory::memregions_Count] =
+    {
+        NULL,
+        CodeIndexITCM,
+        NULL,
+        CodeIndexARM9BIOS,
+        CodeIndexMainRAM,
+        CodeIndexSWRAM,
+        NULL,
+        CodeIndexVRAM,
+        CodeIndexARM7BIOS,
+        CodeIndexARM7WRAM,
+        NULL,
+        NULL,
+        CodeIndexARM7WVRAM,
+        CodeIndexBIOS9DSi,
+        CodeIndexBIOS7DSi,
+        CodeIndexNWRAM_A,
+        CodeIndexNWRAM_B,
+        CodeIndexNWRAM_C
+    };
+
+    u64* const FastBlockLookupRegions[ARMJIT_Memory::memregions_Count] =
+    {
+        NULL,
+        FastBlockLookupITCM,
+        NULL,
+        FastBlockLookupARM9BIOS,
+        FastBlockLookupMainRAM,
+        FastBlockLookupSWRAM,
+        NULL,
+        FastBlockLookupVRAM,
+        FastBlockLookupARM7BIOS,
+        FastBlockLookupARM7WRAM,
+        NULL,
+        NULL,
+        FastBlockLookupARM7WVRAM,
+        FastBlockLookupBIOS9DSi,
+        FastBlockLookupBIOS7DSi,
+        FastBlockLookupNWRAM_A,
+        FastBlockLookupNWRAM_B,
+        FastBlockLookupNWRAM_C
+    };
+};
 }
 
+// Defined in assembly
 extern "C" void ARM_Dispatch(ARM* cpu, ARMJIT::JitBlockEntry entry);
 
 #endif

--- a/src/ARMJIT_A64/ARMJIT_Compiler.cpp
+++ b/src/ARMJIT_A64/ARMJIT_Compiler.cpp
@@ -219,7 +219,7 @@ void Compiler::PopRegs(bool saveHiRegs, bool saveRegsToBeChanged)
     }
 }
 
-Compiler::Compiler()
+Compiler::Compiler(ARMJIT_Memory& memory) : Arm64Gen::ARM64XEmitter(), Memory(memory)
 {
 #ifdef __SWITCH__
     JitRWBase = aligned_alloc(0x1000, JitMemSize);
@@ -722,7 +722,7 @@ JitBlockEntry Compiler::CompileBlock(ARM* cpu, bool thumb, FetchedInstr instrs[]
     CPSRDirty = false;
 
     if (hasMemInstr)
-        MOVP2R(RMemBase, Num == 0 ? ARMJIT_Memory::FastMem9Start : ARMJIT_Memory::FastMem7Start);
+        MOVP2R(RMemBase, Num == 0 ? Memory.FastMem9Start : Memory.FastMem7Start);
 
     for (int i = 0; i < instrsCount; i++)
     {

--- a/src/ARMJIT_A64/ARMJIT_Compiler.cpp
+++ b/src/ARMJIT_A64/ARMJIT_Compiler.cpp
@@ -699,17 +699,17 @@ void Compiler::Comp_BranchSpecialBehaviour(bool taken)
     }
 }
 
-JitBlockEntry Compiler::CompileBlock(ARM* cpu, bool thumb, FetchedInstr instrs[], int instrsCount, bool hasMemInstr)
+JitBlockEntry Compiler::CompileBlock(ARM* cpu, bool thumb, FetchedInstr instrs[], int instrsCount, bool hasMemInstr, ARMJIT::ARMJIT& jit)
 {
     if (JitMemMainSize - GetCodeOffset() < 1024 * 16)
     {
         Log(LogLevel::Debug, "JIT near memory full, resetting...\n");
-        ResetBlockCache();
+        jit.ResetBlockCache();
     }
     if ((JitMemMainSize +  JitMemSecondarySize) - OtherCodeRegion < 1024 * 8)
     {
         Log(LogLevel::Debug, "JIT far memory full, resetting...\n");
-        ResetBlockCache();
+        jit.ResetBlockCache();
     }
 
     JitBlockEntry res = (JitBlockEntry)GetRXPtr();

--- a/src/ARMJIT_A64/ARMJIT_Compiler.h
+++ b/src/ARMJIT_A64/ARMJIT_Compiler.h
@@ -20,7 +20,6 @@
 #define ARMJIT_A64_COMPILER_H
 
 #include "../ARM.h"
-#include "../ARMJIT.h"
 
 #include "../dolphin/Arm64Emitter.h"
 
@@ -31,7 +30,7 @@
 
 namespace ARMJIT
 {
-
+class ARMJIT;
 const Arm64Gen::ARM64Reg RMemBase = Arm64Gen::X26;
 const Arm64Gen::ARM64Reg RCPSR = Arm64Gen::W27;
 const Arm64Gen::ARM64Reg RCycles = Arm64Gen::W28;
@@ -97,7 +96,7 @@ class Compiler : public Arm64Gen::ARM64XEmitter
 public:
     typedef void (Compiler::*CompileFunc)();
 
-    Compiler(ARMJIT_Memory& memory);
+    Compiler(ARMJIT& jit);
     ~Compiler();
 
     void PushRegs(bool saveHiRegs, bool saveRegsToBeChanged, bool allowUnload = true);
@@ -243,7 +242,7 @@ public:
         OtherCodeRegion = offset;
     }
 
-    ARMJIT_Memory& Memory;
+    ARMJIT& JIT;
     ptrdiff_t OtherCodeRegion;
 
     bool Exit;

--- a/src/ARMJIT_A64/ARMJIT_Compiler.h
+++ b/src/ARMJIT_A64/ARMJIT_Compiler.h
@@ -97,7 +97,7 @@ class Compiler : public Arm64Gen::ARM64XEmitter
 public:
     typedef void (Compiler::*CompileFunc)();
 
-    Compiler();
+    Compiler(ARMJIT_Memory& memory);
     ~Compiler();
 
     void PushRegs(bool saveHiRegs, bool saveRegsToBeChanged, bool allowUnload = true);
@@ -243,6 +243,7 @@ public:
         OtherCodeRegion = offset;
     }
 
+    ARMJIT_Memory& Memory;
     ptrdiff_t OtherCodeRegion;
 
     bool Exit;

--- a/src/ARMJIT_A64/ARMJIT_LoadStore.cpp
+++ b/src/ARMJIT_A64/ARMJIT_LoadStore.cpp
@@ -62,9 +62,9 @@ u8* Compiler::RewriteMemAccess(u8* pc)
 
 bool Compiler::Comp_MemLoadLiteral(int size, bool signExtend, int rd, u32 addr)
 {
-    u32 localAddr = LocaliseCodeAddress(Num, addr);
+    u32 localAddr = JIT.LocaliseCodeAddress(Num, addr);
 
-    int invalidLiteralIdx = InvalidLiterals.Find(localAddr);
+    int invalidLiteralIdx = JIT.InvalidLiterals.Find(localAddr);
     if (invalidLiteralIdx != -1)
     {
         return false;
@@ -111,7 +111,7 @@ void Compiler::Comp_MemAccess(int rd, int rn, Op2 offset, int size, int flags)
     if (size == 16)
         addressMask = ~1;
 
-    if (ARMJIT::LiteralOptimizations && rn == 15 && rd != 15 && offset.IsImm && !(flags & (memop_Post|memop_Store|memop_Writeback)))
+    if (JIT.LiteralOptimizations && rn == 15 && rd != 15 && offset.IsImm && !(flags & (memop_Post|memop_Store|memop_Writeback)))
     {
         u32 addr = R15 + offset.Imm * ((flags & memop_SubtractOffset) ? -1 : 1);
         
@@ -146,7 +146,7 @@ void Compiler::Comp_MemAccess(int rd, int rn, Op2 offset, int size, int flags)
         MOV(W0, rnMapped);
     }
 
-    bool addrIsStatic = ARMJIT::LiteralOptimizations
+    bool addrIsStatic = JIT.LiteralOptimizations
         && RegCache.IsLiteral(rn) && offset.IsImm && !(flags & (memop_Writeback|memop_Post));
     u32 staticAddress;
     if (addrIsStatic)
@@ -185,10 +185,10 @@ void Compiler::Comp_MemAccess(int rd, int rn, Op2 offset, int size, int flags)
         MOV(rnMapped, W0);
 
     u32 expectedTarget = Num == 0
-        ? Memory.ClassifyAddress9(addrIsStatic ? staticAddress : CurInstr.DataRegion)
-        : Memory.ClassifyAddress7(addrIsStatic ? staticAddress : CurInstr.DataRegion);
+        ? JIT.Memory.ClassifyAddress9(addrIsStatic ? staticAddress : CurInstr.DataRegion)
+        : JIT.Memory.ClassifyAddress7(addrIsStatic ? staticAddress : CurInstr.DataRegion);
 
-    if (ARMJIT::FastMemory && ((!Thumb && CurInstr.Cond() != 0xE) || Memory.IsFastmemCompatible(expectedTarget)))
+    if (JIT.FastMemory && ((!Thumb && CurInstr.Cond() != 0xE) || JIT.Memory.IsFastmemCompatible(expectedTarget)))
     {
         ptrdiff_t memopStart = GetCodeOffset();
         LoadStorePatch patch;
@@ -225,7 +225,7 @@ void Compiler::Comp_MemAccess(int rd, int rn, Op2 offset, int size, int flags)
     {
         void* func = NULL;
         if (addrIsStatic)
-            func = Memory.GetFuncForAddr(CurCPU, staticAddress, flags & memop_Store, size);
+            func = JIT.Memory.GetFuncForAddr(CurCPU, staticAddress, flags & memop_Store, size);
 
         PushRegs(false, false);
 
@@ -452,7 +452,7 @@ void Compiler::T_Comp_LoadPCRel()
     u32 offset = ((CurInstr.Instr & 0xFF) << 2);
     u32 addr = (R15 & ~0x2) + offset;
 
-    if (!ARMJIT::LiteralOptimizations || !Comp_MemLoadLiteral(32, false, CurInstr.T_Reg(8), addr))
+    if (!JIT.LiteralOptimizations || !Comp_MemLoadLiteral(32, false, CurInstr.T_Reg(8), addr))
         Comp_MemAccess(CurInstr.T_Reg(8), 15, Op2(offset), 32, 0);
 }
 
@@ -494,11 +494,11 @@ s32 Compiler::Comp_MemAccessBlock(int rn, BitSet16 regs, bool store, bool preinc
         Comp_AddCycles_CDI();
 
     int expectedTarget = Num == 0
-        ? Memory.ClassifyAddress9(CurInstr.DataRegion)
-        : Memory.ClassifyAddress7(CurInstr.DataRegion);
+        ? JIT.Memory.ClassifyAddress9(CurInstr.DataRegion)
+        : JIT.Memory.ClassifyAddress7(CurInstr.DataRegion);
 
-    bool compileFastPath = ARMJIT::FastMemory
-        && store && !usermode && (CurInstr.Cond() < 0xE || Memory.IsFastmemCompatible(expectedTarget));
+    bool compileFastPath = JIT.FastMemory
+        && store && !usermode && (CurInstr.Cond() < 0xE || JIT.Memory.IsFastmemCompatible(expectedTarget));
 
     {
         s32 offset = decrement

--- a/src/ARMJIT_A64/ARMJIT_LoadStore.cpp
+++ b/src/ARMJIT_A64/ARMJIT_LoadStore.cpp
@@ -185,10 +185,10 @@ void Compiler::Comp_MemAccess(int rd, int rn, Op2 offset, int size, int flags)
         MOV(rnMapped, W0);
 
     u32 expectedTarget = Num == 0
-        ? ARMJIT_Memory::ClassifyAddress9(addrIsStatic ? staticAddress : CurInstr.DataRegion)
-        : ARMJIT_Memory::ClassifyAddress7(addrIsStatic ? staticAddress : CurInstr.DataRegion);
+        ? Memory.ClassifyAddress9(addrIsStatic ? staticAddress : CurInstr.DataRegion)
+        : Memory.ClassifyAddress7(addrIsStatic ? staticAddress : CurInstr.DataRegion);
 
-    if (ARMJIT::FastMemory && ((!Thumb && CurInstr.Cond() != 0xE) || ARMJIT_Memory::IsFastmemCompatible(expectedTarget)))
+    if (ARMJIT::FastMemory && ((!Thumb && CurInstr.Cond() != 0xE) || Memory.IsFastmemCompatible(expectedTarget)))
     {
         ptrdiff_t memopStart = GetCodeOffset();
         LoadStorePatch patch;
@@ -225,7 +225,7 @@ void Compiler::Comp_MemAccess(int rd, int rn, Op2 offset, int size, int flags)
     {
         void* func = NULL;
         if (addrIsStatic)
-            func = ARMJIT_Memory::GetFuncForAddr(CurCPU, staticAddress, flags & memop_Store, size);
+            func = Memory.GetFuncForAddr(CurCPU, staticAddress, flags & memop_Store, size);
 
         PushRegs(false, false);
 
@@ -494,11 +494,11 @@ s32 Compiler::Comp_MemAccessBlock(int rn, BitSet16 regs, bool store, bool preinc
         Comp_AddCycles_CDI();
 
     int expectedTarget = Num == 0
-        ? ARMJIT_Memory::ClassifyAddress9(CurInstr.DataRegion)
-        : ARMJIT_Memory::ClassifyAddress7(CurInstr.DataRegion);
+        ? Memory.ClassifyAddress9(CurInstr.DataRegion)
+        : Memory.ClassifyAddress7(CurInstr.DataRegion);
 
     bool compileFastPath = ARMJIT::FastMemory
-        && store && !usermode && (CurInstr.Cond() < 0xE || ARMJIT_Memory::IsFastmemCompatible(expectedTarget));
+        && store && !usermode && (CurInstr.Cond() < 0xE || Memory.IsFastmemCompatible(expectedTarget));
 
     {
         s32 offset = decrement

--- a/src/ARMJIT_Compiler.h
+++ b/src/ARMJIT_Compiler.h
@@ -27,9 +27,4 @@
 #error "The current target platform doesn't have a JIT backend"
 #endif
 
-namespace ARMJIT
-{
-extern Compiler* JITCompiler;
-}
-
 #endif

--- a/src/ARMJIT_Compiler.h
+++ b/src/ARMJIT_Compiler.h
@@ -19,6 +19,12 @@
 #ifndef ARMJIT_COMPILER_H
 #define ARMJIT_COMPILER_H
 
+#ifdef JIT_ENABLED
+#define NOOP_IF_NO_JIT
+#else
+#define NOOP_IF_NO_JIT {}
+#endif
+
 #if defined(__x86_64__)
 #include "ARMJIT_x64/ARMJIT_Compiler.h"
 #elif defined(__aarch64__)

--- a/src/ARMJIT_Internal.h
+++ b/src/ARMJIT_Internal.h
@@ -95,9 +95,6 @@ inline bool PageContainsCode(AddressRange* range)
     return false;
 }
 
-template <u32 Num>
-void LinkBlock(ARM* cpu, u32 codeOffset);
-
 template <typename T, int ConsoleType> T SlowRead9(u32 addr, ARMv5* cpu);
 template <typename T, int ConsoleType> void SlowWrite9(u32 addr, ARMv5* cpu, u32 val);
 template <typename T, int ConsoleType> T SlowRead7(u32 addr);

--- a/src/ARMJIT_Memory.cpp
+++ b/src/ARMJIT_Memory.cpp
@@ -192,12 +192,12 @@ void ARMJIT_Memory::SigsegvHandler(int sig, siginfo_t* info, void* rawContext)
     ucontext_t* context = (ucontext_t*)rawContext;
 
     FaultDescription desc {};
-    u8* curArea = (u8*)(NDS::CurCPU == 0 ? ARMJIT::Memory->FastMem9Start : ARMJIT::Memory->FastMem7Start);
+    u8* curArea = (u8*)(NDS::CurCPU == 0 ? NDS::JIT->Memory.FastMem9Start : NDS::JIT->Memory.FastMem7Start);
 
     desc.EmulatedFaultAddr = (u8*)info->si_addr - curArea;
     desc.FaultPC = (u8*)context->CONTEXT_PC;
 
-    if (FaultHandler(desc, *ARMJIT::Memory))
+    if (FaultHandler(desc, *NDS::JIT))
     {
         context->CONTEXT_PC = (u64)desc.FaultPC;
         return;

--- a/src/ARMJIT_Memory.cpp
+++ b/src/ARMJIT_Memory.cpp
@@ -102,7 +102,6 @@ using Platform::LogLevel;
 
 #if defined(__ANDROID__)
 #define ASHMEM_DEVICE "/dev/ashmem"
-Platform::DynamicLibrary* Libandroid = nullptr;
 #endif
 
 #if defined(__SWITCH__)

--- a/src/ARMJIT_Memory.cpp
+++ b/src/ARMJIT_Memory.cpp
@@ -72,17 +72,6 @@ using Platform::LogLevel;
 
 */
 
-namespace ARMJIT_Memory
-{
-struct FaultDescription
-{
-    u32 EmulatedFaultAddr;
-    u8* FaultPC;
-};
-
-bool FaultHandler(FaultDescription& faultDesc);
-}
-
 // Yes I know this looks messy, but better here than somewhere else in the code
 #if defined(__x86_64__)
     #if defined(_WIN32)
@@ -146,7 +135,7 @@ void __libnx_exception_handler(ThreadExceptionDump* ctx)
     integerRegisters[31] = ctx->sp.x;
     integerRegisters[32] = ctx->pc.x;
 
-    if (ARMJIT_Memory::FaultHandler(desc))
+    if (Melon::FaultHandler(desc))
     {
         integerRegisters[32] = (u64)desc.FaultPC;
 
@@ -160,19 +149,19 @@ void __libnx_exception_handler(ThreadExceptionDump* ctx)
 
 #elif defined(_WIN32)
 
-static LONG ExceptionHandler(EXCEPTION_POINTERS* exceptionInfo)
+LONG ARMJIT_Memory::ExceptionHandler(EXCEPTION_POINTERS* exceptionInfo)
 {
     if (exceptionInfo->ExceptionRecord->ExceptionCode != EXCEPTION_ACCESS_VIOLATION)
     {
         return EXCEPTION_CONTINUE_SEARCH;
     }
 
-    ARMJIT_Memory::FaultDescription desc;
-    u8* curArea = (u8*)(NDS::CurCPU == 0 ? ARMJIT_Memory::FastMem9Start : ARMJIT_Memory::FastMem7Start);
+    u8* curArea = (u8*)(NDS::CurCPU == 0 ? ARMJIT::Memory->FastMem9Start : ARMJIT::Memory->FastMem7Start);
+    FaultDescription desc {};
     desc.EmulatedFaultAddr = (u8*)exceptionInfo->ExceptionRecord->ExceptionInformation[1] - curArea;
     desc.FaultPC = (u8*)exceptionInfo->ContextRecord->CONTEXT_PC;
 
-    if (ARMJIT_Memory::FaultHandler(desc))
+    if (FaultHandler(desc, *ARMJIT::Memory))
     {
         exceptionInfo->ContextRecord->CONTEXT_PC = (u64)desc.FaultPC;
         return EXCEPTION_CONTINUE_EXECUTION;
@@ -186,7 +175,7 @@ static LONG ExceptionHandler(EXCEPTION_POINTERS* exceptionInfo)
 static struct sigaction OldSaSegv;
 static struct sigaction OldSaBus;
 
-static void SigsegvHandler(int sig, siginfo_t* info, void* rawContext)
+void ARMJIT_Memory::SigsegvHandler(int sig, siginfo_t* info, void* rawContext)
 {
     if (sig != SIGSEGV && sig != SIGBUS)
     {
@@ -201,13 +190,13 @@ static void SigsegvHandler(int sig, siginfo_t* info, void* rawContext)
 
     ucontext_t* context = (ucontext_t*)rawContext;
 
-    ARMJIT_Memory::FaultDescription desc;
-    u8* curArea = (u8*)(NDS::CurCPU == 0 ? ARMJIT_Memory::FastMem9Start : ARMJIT_Memory::FastMem7Start);
+    FaultDescription desc {};
+    u8* curArea = (u8*)(NDS::CurCPU == 0 ? ARMJIT::Memory->FastMem9Start : ARMJIT::Memory->FastMem7Start);
 
     desc.EmulatedFaultAddr = (u8*)info->si_addr - curArea;
     desc.FaultPC = (u8*)context->CONTEXT_PC;
 
-    if (ARMJIT_Memory::FaultHandler(desc))
+    if (FaultHandler(desc, *ARMJIT::Memory))
     {
         context->CONTEXT_PC = (u64)desc.FaultPC;
         return;
@@ -239,33 +228,7 @@ static void SigsegvHandler(int sig, siginfo_t* info, void* rawContext)
 
 #endif
 
-namespace ARMJIT_Memory
-{
-
-void* FastMem9Start, *FastMem7Start;
-
-#ifdef _WIN32
-inline u32 RoundUp(u32 size)
-{
-    return (size + 0xFFFF) & ~0xFFFF;
-}
-#else
-inline u32 RoundUp(u32 size)
-{
-    return size;
-}
-#endif
-
-const u32 MemBlockMainRAMOffset = 0;
-const u32 MemBlockSWRAMOffset = RoundUp(NDS::MainRAMMaxSize);
-const u32 MemBlockARM7WRAMOffset = MemBlockSWRAMOffset + RoundUp(NDS::SharedWRAMSize);
-const u32 MemBlockDTCMOffset = MemBlockARM7WRAMOffset + RoundUp(NDS::ARM7WRAMSize);
-const u32 MemBlockNWRAM_AOffset = MemBlockDTCMOffset + RoundUp(DTCMPhysicalSize);
-const u32 MemBlockNWRAM_BOffset = MemBlockNWRAM_AOffset + RoundUp(DSi::NWRAMSize);
-const u32 MemBlockNWRAM_COffset = MemBlockNWRAM_BOffset + RoundUp(DSi::NWRAMSize);
-const u32 MemoryTotalSize = MemBlockNWRAM_COffset + RoundUp(DSi::NWRAMSize);
-
-const u32 OffsetsPerRegion[memregions_Count] =
+const u32 OffsetsPerRegion[ARMJIT_Memory::memregions_Count] =
 {
     UINT32_MAX,
     UINT32_MAX,
@@ -295,23 +258,9 @@ enum
     memstate_MappedProtected,
 };
 
-u8 MappingStatus9[1 << (32-12)];
-u8 MappingStatus7[1 << (32-12)];
 
-#if defined(__SWITCH__)
-VirtmemReservation* FastMem9Reservation, *FastMem7Reservation;
-u8* MemoryBase;
-u8* MemoryBaseCodeMem;
-#elif defined(_WIN32)
-u8* MemoryBase;
-HANDLE MemoryFile;
-LPVOID ExceptionHandlerHandle;
-#else
-u8* MemoryBase;
-int MemoryFile = -1;
-#endif
 
-bool MapIntoRange(u32 addr, u32 num, u32 offset, u32 size)
+bool ARMJIT_Memory::MapIntoRange(u32 addr, u32 num, u32 offset, u32 size) noexcept
 {
     u8* dst = (u8*)(num == 0 ? FastMem9Start : FastMem7Start) + addr;
 #ifdef __SWITCH__
@@ -326,7 +275,7 @@ bool MapIntoRange(u32 addr, u32 num, u32 offset, u32 size)
 #endif
 }
 
-bool UnmapFromRange(u32 addr, u32 num, u32 offset, u32 size)
+bool ARMJIT_Memory::UnmapFromRange(u32 addr, u32 num, u32 offset, u32 size) noexcept
 {
     u8* dst = (u8*)(num == 0 ? FastMem9Start : FastMem7Start) + addr;
 #ifdef __SWITCH__
@@ -341,7 +290,7 @@ bool UnmapFromRange(u32 addr, u32 num, u32 offset, u32 size)
 }
 
 #ifndef __SWITCH__
-void SetCodeProtectionRange(u32 addr, u32 size, u32 num, int protection)
+void ARMJIT_Memory::SetCodeProtectionRange(u32 addr, u32 size, u32 num, int protection) noexcept
 {
     u8* dst = (u8*)(num == 0 ? FastMem9Start : FastMem7Start) + addr;
 #if defined(_WIN32)
@@ -367,82 +316,74 @@ void SetCodeProtectionRange(u32 addr, u32 size, u32 num, int protection)
 }
 #endif
 
-struct Mapping
+void ARMJIT_Memory::Mapping::Unmap(int region, ARMJIT_Memory& memory) noexcept
 {
-    u32 Addr;
-    u32 Size, LocalOffset;
-    u32 Num;
-
-    void Unmap(int region)
+    u32 dtcmStart = NDS::ARM9->DTCMBase;
+    u32 dtcmSize = ~NDS::ARM9->DTCMMask + 1;
+    bool skipDTCM = Num == 0 && region != memregion_DTCM;
+    u8* statuses = Num == 0 ? memory.MappingStatus9 : memory.MappingStatus7;
+    u32 offset = 0;
+    while (offset < Size)
     {
-        u32 dtcmStart = NDS::ARM9->DTCMBase;
-        u32 dtcmSize = ~NDS::ARM9->DTCMMask + 1;
-        bool skipDTCM = Num == 0 && region != memregion_DTCM;
-        u8* statuses = Num == 0 ? MappingStatus9 : MappingStatus7;
-        u32 offset = 0;
-        while (offset < Size)
+        if (skipDTCM && Addr + offset == dtcmStart)
         {
-            if (skipDTCM && Addr + offset == dtcmStart)
+            offset += dtcmSize;
+        }
+        else
+        {
+            u32 segmentOffset = offset;
+            u8 status = statuses[(Addr + offset) >> 12];
+            while (statuses[(Addr + offset) >> 12] == status
+                   && offset < Size
+                   && (!skipDTCM || Addr + offset != dtcmStart))
             {
-                offset += dtcmSize;
+                assert(statuses[(Addr + offset) >> 12] != memstate_Unmapped);
+                statuses[(Addr + offset) >> 12] = memstate_Unmapped;
+                offset += 0x1000;
             }
-            else
-            {
-                u32 segmentOffset = offset;
-                u8 status = statuses[(Addr + offset) >> 12];
-                while (statuses[(Addr + offset) >> 12] == status
-                    && offset < Size
-                    && (!skipDTCM || Addr + offset != dtcmStart))
-                {
-                    assert(statuses[(Addr + offset) >> 12] != memstate_Unmapped);
-                    statuses[(Addr + offset) >> 12] = memstate_Unmapped;
-                    offset += 0x1000;
-                }
 
 #ifdef __SWITCH__
-                if (status == memstate_MappedRW)
-                {
-                    u32 segmentSize = offset - segmentOffset;
-                    Log(LogLevel::Debug, "unmapping %x %x %x %x\n", Addr + segmentOffset, Num, segmentOffset + LocalOffset + OffsetsPerRegion[region], segmentSize);
-                    bool success = UnmapFromRange(Addr + segmentOffset, Num, segmentOffset + LocalOffset + OffsetsPerRegion[region], segmentSize);
-                    assert(success);
-                }
-#endif
+            if (status == memstate_MappedRW)
+            {
+                u32 segmentSize = offset - segmentOffset;
+                Log(LogLevel::Debug, "unmapping %x %x %x %x\n", Addr + segmentOffset, Num, segmentOffset + LocalOffset + OffsetsPerRegion[region], segmentSize);
+                bool success = memory.UnmapFromRange(Addr + segmentOffset, Num, segmentOffset + LocalOffset + OffsetsPerRegion[region], segmentSize);
+                assert(success);
             }
+#endif
         }
+    }
 
 #ifndef __SWITCH__
 #ifndef _WIN32
-        u32 dtcmEnd = dtcmStart + dtcmSize;
-        if (Num == 0
-            && dtcmEnd >= Addr
-            && dtcmStart < Addr + Size)
+    u32 dtcmEnd = dtcmStart + dtcmSize;
+    if (Num == 0
+        && dtcmEnd >= Addr
+        && dtcmStart < Addr + Size)
+    {
+        bool success;
+        if (dtcmStart > Addr)
         {
-            bool success;
-            if (dtcmStart > Addr)
-            {
-                success = UnmapFromRange(Addr, 0, OffsetsPerRegion[region] + LocalOffset, dtcmStart - Addr);
-                assert(success);
-            }
-            if (dtcmEnd < Addr + Size)
-            {
-                u32 offset = dtcmStart - Addr + dtcmSize;
-                success = UnmapFromRange(dtcmEnd, 0, OffsetsPerRegion[region] + LocalOffset + offset, Size - offset);
-                assert(success);
-            }
+            success = memory.UnmapFromRange(Addr, 0, OffsetsPerRegion[region] + LocalOffset, dtcmStart - Addr);
+            assert(success);
         }
-        else
-#endif
+        if (dtcmEnd < Addr + Size)
         {
-            bool succeded = UnmapFromRange(Addr, Num, OffsetsPerRegion[region] + LocalOffset, Size);
-            assert(succeded);
+            u32 offset = dtcmStart - Addr + dtcmSize;
+            success = memory.UnmapFromRange(dtcmEnd, 0, OffsetsPerRegion[region] + LocalOffset + offset, Size - offset);
+            assert(success);
         }
-#endif
     }
-};
-ARMJIT::TinyVector<Mapping> Mappings[memregions_Count];
+    else
+#endif
+    {
+        bool succeded = memory.UnmapFromRange(Addr, Num, OffsetsPerRegion[region] + LocalOffset, Size);
+        assert(succeded);
+    }
+#endif
+}
 
-void SetCodeProtection(int region, u32 offset, bool protect)
+void ARMJIT_Memory::SetCodeProtection(int region, u32 offset, bool protect) noexcept
 {
     offset &= ~0xFFF;
     //printf("set code protection %d %x %d\n", region, offset, protect);
@@ -479,7 +420,7 @@ void SetCodeProtection(int region, u32 offset, bool protect)
     }
 }
 
-void RemapDTCM(u32 newBase, u32 newSize)
+void ARMJIT_Memory::RemapDTCM(u32 newBase, u32 newSize) noexcept
 {
     // this first part could be made more efficient
     // by unmapping DTCM first and then map the holes
@@ -510,7 +451,7 @@ void RemapDTCM(u32 newBase, u32 newSize)
 
             if (mapping.Num == 0 && overlap)
             {
-                mapping.Unmap(region);
+                mapping.Unmap(region, *this);
                 Mappings[region].Remove(i);
             }
             else
@@ -522,12 +463,12 @@ void RemapDTCM(u32 newBase, u32 newSize)
 
     for (int i = 0; i < Mappings[memregion_DTCM].Length; i++)
     {
-        Mappings[memregion_DTCM][i].Unmap(memregion_DTCM);
+        Mappings[memregion_DTCM][i].Unmap(memregion_DTCM, *this);
     }
     Mappings[memregion_DTCM].Clear();
 }
 
-void RemapNWRAM(int num)
+void ARMJIT_Memory::RemapNWRAM(int num) noexcept
 {
     for (int i = 0; i < Mappings[memregion_SharedWRAM].Length;)
     {
@@ -535,7 +476,7 @@ void RemapNWRAM(int num)
         if (DSi::NWRAMStart[mapping.Num][num] < mapping.Addr + mapping.Size
             && DSi::NWRAMEnd[mapping.Num][num] > mapping.Addr)
         {
-            mapping.Unmap(memregion_SharedWRAM);
+            mapping.Unmap(memregion_SharedWRAM, *this);
             Mappings[memregion_SharedWRAM].Remove(i);
         }
         else
@@ -545,12 +486,12 @@ void RemapNWRAM(int num)
     }
     for (int i = 0; i < Mappings[memregion_NewSharedWRAM_A + num].Length; i++)
     {
-        Mappings[memregion_NewSharedWRAM_A + num][i].Unmap(memregion_NewSharedWRAM_A + num);
+        Mappings[memregion_NewSharedWRAM_A + num][i].Unmap(memregion_NewSharedWRAM_A + num, *this);
     }
     Mappings[memregion_NewSharedWRAM_A + num].Clear();
 }
 
-void RemapSWRAM()
+void ARMJIT_Memory::RemapSWRAM() noexcept
 {
     Log(LogLevel::Debug, "remapping SWRAM\n");
     for (int i = 0; i < Mappings[memregion_WRAM7].Length;)
@@ -558,7 +499,7 @@ void RemapSWRAM()
         Mapping& mapping = Mappings[memregion_WRAM7][i];
         if (mapping.Addr + mapping.Size <= 0x03800000)
         {
-            mapping.Unmap(memregion_WRAM7);
+            mapping.Unmap(memregion_WRAM7, *this);
             Mappings[memregion_WRAM7].Remove(i);
         }
         else
@@ -566,12 +507,12 @@ void RemapSWRAM()
     }
     for (int i = 0; i < Mappings[memregion_SharedWRAM].Length; i++)
     {
-        Mappings[memregion_SharedWRAM][i].Unmap(memregion_SharedWRAM);
+        Mappings[memregion_SharedWRAM][i].Unmap(memregion_SharedWRAM, *this);
     }
     Mappings[memregion_SharedWRAM].Clear();
 }
 
-bool MapAtAddress(u32 addr)
+bool ARMJIT_Memory::MapAtAddress(u32 addr) noexcept
 {
     u32 num = NDS::CurCPU;
 
@@ -676,16 +617,16 @@ bool MapAtAddress(u32 addr)
     return true;
 }
 
-bool FaultHandler(FaultDescription& faultDesc)
+bool ARMJIT_Memory::FaultHandler(FaultDescription& faultDesc, ARMJIT_Memory& armjit)
 {
     if (ARMJIT::JITCompiler->IsJITFault(faultDesc.FaultPC))
     {
         bool rewriteToSlowPath = true;
 
-        u8* memStatus = NDS::CurCPU == 0 ? MappingStatus9 : MappingStatus7;
+        u8* memStatus = NDS::CurCPU == 0 ? armjit.MappingStatus9 : armjit.MappingStatus7;
 
         if (memStatus[faultDesc.EmulatedFaultAddr >> 12] == memstate_Unmapped)
-            rewriteToSlowPath = !MapAtAddress(faultDesc.EmulatedFaultAddr);
+            rewriteToSlowPath = !armjit.MapAtAddress(faultDesc.EmulatedFaultAddr);
 
         if (rewriteToSlowPath)
             faultDesc.FaultPC = ARMJIT::JITCompiler->RewriteMemAccess(faultDesc.FaultPC);
@@ -697,7 +638,7 @@ bool FaultHandler(FaultDescription& faultDesc)
 
 const u64 AddrSpaceSize = 0x100000000;
 
-void Init()
+ARMJIT_Memory::ARMJIT_Memory() noexcept
 {
 #if defined(__SWITCH__)
     MemoryBase = (u8*)aligned_alloc(0x1000, MemoryTotalSize);
@@ -740,8 +681,6 @@ void Init()
     MemoryBase = MemoryBase + AddrSpaceSize*3;
 
     MapViewOfFileEx(MemoryFile, FILE_MAP_READ | FILE_MAP_WRITE, 0, 0, MemoryTotalSize, MemoryBase);
-
-    u8* basePtr = MemoryBase;
 #else
     // this used to be allocated with three different mmaps
     // The idea was to give the OS more freedom where to position the buffers,
@@ -798,16 +737,9 @@ void Init()
 
     u8* basePtr = MemoryBase;
 #endif
-    NDS::MainRAM = basePtr + MemBlockMainRAMOffset;
-    NDS::SharedWRAM = basePtr + MemBlockSWRAMOffset;
-    NDS::ARM7WRAM = basePtr + MemBlockARM7WRAMOffset;
-    NDS::ARM9->DTCM = basePtr + MemBlockDTCMOffset;
-    DSi::NWRAM_A = basePtr + MemBlockNWRAM_AOffset;
-    DSi::NWRAM_B = basePtr + MemBlockNWRAM_BOffset;
-    DSi::NWRAM_C = basePtr + MemBlockNWRAM_COffset;
 }
 
-void DeInit()
+ARMJIT_Memory::~ARMJIT_Memory() noexcept
 {
 #if defined(__SWITCH__)
     virtmemLock();
@@ -875,12 +807,12 @@ void DeInit()
 #endif
 }
 
-void Reset()
+void ARMJIT_Memory::Reset() noexcept
 {
     for (int region = 0; region < memregions_Count; region++)
     {
         for (int i = 0; i < Mappings[region].Length; i++)
-            Mappings[region][i].Unmap(region);
+            Mappings[region][i].Unmap(region, *this);
         Mappings[region].Clear();
     }
 
@@ -893,7 +825,7 @@ void Reset()
     Log(LogLevel::Debug, "done resetting jit mem\n");
 }
 
-bool IsFastmemCompatible(int region)
+bool ARMJIT_Memory::IsFastmemCompatible(int region) const noexcept
 {
 #ifdef _WIN32
     /*
@@ -909,7 +841,7 @@ bool IsFastmemCompatible(int region)
     return OffsetsPerRegion[region] != UINT32_MAX;
 }
 
-bool GetMirrorLocation(int region, u32 num, u32 addr, u32& memoryOffset, u32& mirrorStart, u32& mirrorSize)
+bool ARMJIT_Memory::GetMirrorLocation(int region, u32 num, u32 addr, u32& memoryOffset, u32& mirrorStart, u32& mirrorSize) const noexcept
 {
     memoryOffset = 0;
     switch (region)
@@ -1048,7 +980,7 @@ bool GetMirrorLocation(int region, u32 num, u32 addr, u32& memoryOffset, u32& mi
     }
 }
 
-u32 LocaliseAddress(int region, u32 num, u32 addr)
+u32 ARMJIT_Memory::LocaliseAddress(int region, u32 num, u32 addr) const noexcept
 {
     switch (region)
     {
@@ -1062,9 +994,9 @@ u32 LocaliseAddress(int region, u32 num, u32 addr)
         return (addr & 0x3FFF) | (memregion_BIOS7 << 27);
     case memregion_SharedWRAM:
         if (num == 0)
-            return ((addr & NDS::SWRAM_ARM9.Mask) + (NDS::SWRAM_ARM9.Mem - NDS::SharedWRAM)) | (memregion_SharedWRAM << 27);
+            return ((addr & NDS::SWRAM_ARM9.Mask) + (NDS::SWRAM_ARM9.Mem - GetSharedWRAM())) | (memregion_SharedWRAM << 27);
         else
-            return ((addr & NDS::SWRAM_ARM7.Mask) + (NDS::SWRAM_ARM7.Mem - NDS::SharedWRAM)) | (memregion_SharedWRAM << 27);
+            return ((addr & NDS::SWRAM_ARM7.Mask) + (NDS::SWRAM_ARM7.Mem - GetSharedWRAM())) | (memregion_SharedWRAM << 27);
     case memregion_WRAM7:
         return (addr & (NDS::ARM7WRAMSize - 1)) | (memregion_WRAM7 << 27);
     case memregion_VRAM:
@@ -1077,7 +1009,7 @@ u32 LocaliseAddress(int region, u32 num, u32 addr)
         {
             u8* ptr = DSi::NWRAMMap_A[num][(addr >> 16) & DSi::NWRAMMask[num][0]];
             if (ptr)
-                return (ptr - DSi::NWRAM_A + (addr & 0xFFFF)) | (memregion_NewSharedWRAM_A << 27);
+                return (ptr - GetNWRAM_A() + (addr & 0xFFFF)) | (memregion_NewSharedWRAM_A << 27);
             else
                 return memregion_Other << 27; // zero filled memory
         }
@@ -1085,7 +1017,7 @@ u32 LocaliseAddress(int region, u32 num, u32 addr)
         {
             u8* ptr = DSi::NWRAMMap_B[num][(addr >> 15) & DSi::NWRAMMask[num][1]];
             if (ptr)
-                return (ptr - DSi::NWRAM_B + (addr & 0x7FFF)) | (memregion_NewSharedWRAM_B << 27);
+                return (ptr - GetNWRAM_B() + (addr & 0x7FFF)) | (memregion_NewSharedWRAM_B << 27);
             else
                 return memregion_Other << 27;
         }
@@ -1093,7 +1025,7 @@ u32 LocaliseAddress(int region, u32 num, u32 addr)
         {
             u8* ptr = DSi::NWRAMMap_C[num][(addr >> 15) & DSi::NWRAMMask[num][2]];
             if (ptr)
-                return (ptr - DSi::NWRAM_C + (addr & 0x7FFF)) | (memregion_NewSharedWRAM_C << 27);
+                return (ptr - GetNWRAM_C() + (addr & 0x7FFF)) | (memregion_NewSharedWRAM_C << 27);
             else
                 return memregion_Other << 27;
         }
@@ -1106,7 +1038,7 @@ u32 LocaliseAddress(int region, u32 num, u32 addr)
     }
 }
 
-int ClassifyAddress9(u32 addr)
+int ARMJIT_Memory::ClassifyAddress9(u32 addr) const noexcept
 {
     if (addr < NDS::ARM9->ITCMSize)
     {
@@ -1160,7 +1092,7 @@ int ClassifyAddress9(u32 addr)
     }
 }
 
-int ClassifyAddress7(u32 addr)
+int ARMJIT_Memory::ClassifyAddress7(u32 addr) const noexcept
 {
     if (NDS::ConsoleType == 1 && addr < 0x00010000 && !(DSi::SCFG_BIOS & (1<<9)))
     {
@@ -1248,7 +1180,7 @@ T VRAMRead(u32 addr)
     }
 }
 
-void* GetFuncForAddr(ARM* cpu, u32 addr, bool store, int size)
+void* ARMJIT_Memory::GetFuncForAddr(ARM* cpu, u32 addr, bool store, int size) const noexcept
 {
     if (cpu->Num == 0)
     {
@@ -1385,6 +1317,4 @@ void* GetFuncForAddr(ARM* cpu, u32 addr, bool store, int size)
         }
     }
     return NULL;
-}
-
 }

--- a/src/ARMJIT_Memory.cpp
+++ b/src/ARMJIT_Memory.cpp
@@ -888,14 +888,14 @@ bool ARMJIT_Memory::GetMirrorLocation(int region, u32 num, u32 addr, u32& memory
         {
             mirrorStart = addr & ~NDS::SWRAM_ARM9.Mask;
             mirrorSize = NDS::SWRAM_ARM9.Mask + 1;
-            memoryOffset = NDS::SWRAM_ARM9.Mem - NDS::SharedWRAM;
+            memoryOffset = NDS::SWRAM_ARM9.Mem - GetSharedWRAM();
             return true;
         }
         else if (num == 1 && NDS::SWRAM_ARM7.Mem)
         {
             mirrorStart = addr & ~NDS::SWRAM_ARM7.Mask;
             mirrorSize = NDS::SWRAM_ARM7.Mask + 1;
-            memoryOffset = NDS::SWRAM_ARM7.Mem - NDS::SharedWRAM;
+            memoryOffset = NDS::SWRAM_ARM7.Mem - GetSharedWRAM();
             return true;
         }
         return false;
@@ -928,7 +928,7 @@ bool ARMJIT_Memory::GetMirrorLocation(int region, u32 num, u32 addr, u32& memory
             u8* ptr = DSi::NWRAMMap_A[num][(addr >> 16) & DSi::NWRAMMask[num][0]];
             if (ptr)
             {
-                memoryOffset = ptr - DSi::NWRAM_A;
+                memoryOffset = ptr - GetNWRAM_A();
                 mirrorStart = addr & ~0xFFFF;
                 mirrorSize = 0x10000;
                 return true;
@@ -940,7 +940,7 @@ bool ARMJIT_Memory::GetMirrorLocation(int region, u32 num, u32 addr, u32& memory
             u8* ptr = DSi::NWRAMMap_B[num][(addr >> 15) & DSi::NWRAMMask[num][1]];
             if (ptr)
             {
-                memoryOffset = ptr - DSi::NWRAM_B;
+                memoryOffset = ptr - GetNWRAM_B();
                 mirrorStart = addr & ~0x7FFF;
                 mirrorSize = 0x8000;
                 return true;
@@ -952,7 +952,7 @@ bool ARMJIT_Memory::GetMirrorLocation(int region, u32 num, u32 addr, u32& memory
             u8* ptr = DSi::NWRAMMap_C[num][(addr >> 15) & DSi::NWRAMMask[num][2]];
             if (ptr)
             {
-                memoryOffset = ptr - DSi::NWRAM_C;
+                memoryOffset = ptr - GetNWRAM_C();
                 mirrorStart = addr & ~0x7FFF;
                 mirrorSize = 0x8000;
                 return true;

--- a/src/ARMJIT_Memory.h
+++ b/src/ARMJIT_Memory.h
@@ -45,6 +45,7 @@
 namespace ARMJIT
 {
 class Compiler;
+class ARMJIT;
 }
 
 constexpr u32 RoundUp(u32 size) noexcept
@@ -96,7 +97,7 @@ public:
 
 #ifdef JIT_ENABLED
 public:
-    ARMJIT_Memory() noexcept;
+    ARMJIT_Memory(ARMJIT::ARMJIT& jit) noexcept;
     ~ARMJIT_Memory() noexcept;
     ARMJIT_Memory(const ARMJIT_Memory&) = delete;
     ARMJIT_Memory(ARMJIT_Memory&&) = delete;
@@ -152,11 +153,12 @@ private:
         u32 EmulatedFaultAddr;
         u8* FaultPC;
     };
-    static bool FaultHandler(FaultDescription& faultDesc, ARMJIT_Memory& armjit);
+    static bool FaultHandler(FaultDescription& faultDesc, ARMJIT::ARMJIT& jit);
     bool MapIntoRange(u32 addr, u32 num, u32 offset, u32 size) noexcept;
     bool UnmapFromRange(u32 addr, u32 num, u32 offset, u32 size) noexcept;
     void SetCodeProtectionRange(u32 addr, u32 size, u32 num, int protection) noexcept;
 
+    ARMJIT::ARMJIT& JIT;
     void* FastMem9Start;
     void* FastMem7Start;
     u8* MemoryBase = nullptr;
@@ -176,7 +178,7 @@ private:
     ARMJIT::TinyVector<Mapping> Mappings[memregions_Count] {};
 #else
 public:
-    ARMJIT_Memory() = default;
+    ARMJIT_Memory(ARMJIT::ARMJIT& jit) = default;
     ~ARMJIT_Memory() = default;
     ARMJIT_Memory(const ARMJIT_Memory&) = delete;
     ARMJIT_Memory(ARMJIT_Memory&&) = delete;

--- a/src/ARMJIT_Memory.h
+++ b/src/ARMJIT_Memory.h
@@ -23,60 +23,201 @@
 #include "TinyVector.h"
 
 #include "ARM.h"
+#include "DSi.h"
 
-namespace ARMJIT_Memory
+#if defined(__SWITCH__)
+#include <switch.h>
+#elif defined(_WIN32)
+#include <windows.h>
+#else
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <signal.h>
+#endif
+
+#ifndef JIT_ENABLED
+#include <array>
+#include "NDS.h"
+#endif
+
+namespace ARMJIT
 {
-
-extern void* FastMem9Start;
-extern void* FastMem7Start;
-
-void Init();
-void DeInit();
-
-void Reset();
-
-enum
-{
-    memregion_Other = 0,
-    memregion_ITCM,
-    memregion_DTCM,
-    memregion_BIOS9,
-    memregion_MainRAM,
-    memregion_SharedWRAM,
-    memregion_IO9,
-    memregion_VRAM,
-    memregion_BIOS7,
-    memregion_WRAM7,
-    memregion_IO7,
-    memregion_Wifi,
-    memregion_VWRAM,
-
-    // DSi
-    memregion_BIOS9DSi,
-    memregion_BIOS7DSi,
-    memregion_NewSharedWRAM_A,
-    memregion_NewSharedWRAM_B,
-    memregion_NewSharedWRAM_C,
-
-    memregions_Count
-};
-
-int ClassifyAddress9(u32 addr);
-int ClassifyAddress7(u32 addr);
-
-bool GetMirrorLocation(int region, u32 num, u32 addr, u32& memoryOffset, u32& mirrorStart, u32& mirrorSize);
-u32 LocaliseAddress(int region, u32 num, u32 addr);
-
-bool IsFastmemCompatible(int region);
-
-void RemapDTCM(u32 newBase, u32 newSize);
-void RemapSWRAM();
-void RemapNWRAM(int num);
-
-void SetCodeProtection(int region, u32 offset, bool protect);
-
-void* GetFuncForAddr(ARM* cpu, u32 addr, bool store, int size);
-
+class Compiler;
 }
+
+constexpr u32 RoundUp(u32 size) noexcept
+{
+#ifdef _WIN32
+    return (size + 0xFFFF) & ~0xFFFF;
+#else
+    return size;
+#endif
+}
+
+const u32 MemBlockMainRAMOffset = 0;
+const u32 MemBlockSWRAMOffset = RoundUp(NDS::MainRAMMaxSize);
+const u32 MemBlockARM7WRAMOffset = MemBlockSWRAMOffset + RoundUp(NDS::SharedWRAMSize);
+const u32 MemBlockDTCMOffset = MemBlockARM7WRAMOffset + RoundUp(NDS::ARM7WRAMSize);
+const u32 MemBlockNWRAM_AOffset = MemBlockDTCMOffset + RoundUp(DTCMPhysicalSize);
+const u32 MemBlockNWRAM_BOffset = MemBlockNWRAM_AOffset + RoundUp(DSi::NWRAMSize);
+const u32 MemBlockNWRAM_COffset = MemBlockNWRAM_BOffset + RoundUp(DSi::NWRAMSize);
+const u32 MemoryTotalSize = MemBlockNWRAM_COffset + RoundUp(DSi::NWRAMSize);
+
+class ARMJIT_Memory
+{
+public:
+    enum
+    {
+        memregion_Other = 0,
+        memregion_ITCM,
+        memregion_DTCM,
+        memregion_BIOS9,
+        memregion_MainRAM,
+        memregion_SharedWRAM,
+        memregion_IO9,
+        memregion_VRAM,
+        memregion_BIOS7,
+        memregion_WRAM7,
+        memregion_IO7,
+        memregion_Wifi,
+        memregion_VWRAM,
+
+        // DSi
+        memregion_BIOS9DSi,
+        memregion_BIOS7DSi,
+        memregion_NewSharedWRAM_A,
+        memregion_NewSharedWRAM_B,
+        memregion_NewSharedWRAM_C,
+
+        memregions_Count
+    };
+
+#ifdef JIT_ENABLED
+public:
+    ARMJIT_Memory() noexcept;
+    ~ARMJIT_Memory() noexcept;
+    ARMJIT_Memory(const ARMJIT_Memory&) = delete;
+    ARMJIT_Memory(ARMJIT_Memory&&) = delete;
+    ARMJIT_Memory& operator=(const ARMJIT_Memory&) = delete;
+    ARMJIT_Memory& operator=(ARMJIT_Memory&&) = delete;
+    void Reset() noexcept;
+    void RemapDTCM(u32 newBase, u32 newSize) noexcept;
+    void RemapSWRAM() noexcept;
+    void RemapNWRAM(int num) noexcept;
+    void SetCodeProtection(int region, u32 offset, bool protect) noexcept;
+
+    [[nodiscard]] u8* GetMainRAM() noexcept { return MemoryBase + MemBlockMainRAMOffset; }
+    [[nodiscard]] const u8* GetMainRAM() const noexcept { return MemoryBase + MemBlockMainRAMOffset; }
+
+    [[nodiscard]] u8* GetSharedWRAM() noexcept { return MemoryBase + MemBlockSWRAMOffset; }
+    [[nodiscard]] const u8* GetSharedWRAM() const noexcept { return MemoryBase + MemBlockSWRAMOffset; }
+
+    [[nodiscard]] u8* GetARM7WRAM() noexcept { return MemoryBase + MemBlockARM7WRAMOffset; }
+    [[nodiscard]] const u8* GetARM7WRAM() const noexcept { return MemoryBase + MemBlockARM7WRAMOffset; }
+
+    [[nodiscard]] u8* GetARM9DTCM() noexcept { return MemoryBase + MemBlockDTCMOffset; }
+    [[nodiscard]] const u8* GetARM9DTCM() const noexcept { return MemoryBase + MemBlockDTCMOffset; }
+
+    [[nodiscard]] u8* GetNWRAM_A() noexcept { return MemoryBase + MemBlockNWRAM_AOffset; }
+    [[nodiscard]] const u8* GetNWRAM_A() const noexcept { return MemoryBase + MemBlockNWRAM_AOffset; }
+
+    [[nodiscard]] u8* GetNWRAM_B() noexcept { return MemoryBase + MemBlockNWRAM_BOffset; }
+    [[nodiscard]] const u8* GetNWRAM_B() const noexcept { return MemoryBase + MemBlockNWRAM_BOffset; }
+
+    [[nodiscard]] u8* GetNWRAM_C() noexcept { return MemoryBase + MemBlockNWRAM_COffset; }
+    [[nodiscard]] const u8* GetNWRAM_C() const noexcept { return MemoryBase + MemBlockNWRAM_COffset; }
+
+    int ClassifyAddress9(u32 addr) const noexcept;
+    int ClassifyAddress7(u32 addr) const noexcept;
+    bool GetMirrorLocation(int region, u32 num, u32 addr, u32& memoryOffset, u32& mirrorStart, u32& mirrorSize) const noexcept;
+    u32 LocaliseAddress(int region, u32 num, u32 addr) const noexcept;
+    bool IsFastmemCompatible(int region) const noexcept;
+    void* GetFuncForAddr(ARM* cpu, u32 addr, bool store, int size) const noexcept;
+    bool MapAtAddress(u32 addr) noexcept;
+private:
+    friend class ARMJIT::Compiler;
+    struct Mapping
+    {
+        u32 Addr;
+        u32 Size, LocalOffset;
+        u32 Num;
+
+        void Unmap(int region, ARMJIT_Memory& memory) noexcept;
+    };
+
+    struct FaultDescription
+    {
+        u32 EmulatedFaultAddr;
+        u8* FaultPC;
+    };
+    static bool FaultHandler(FaultDescription& faultDesc, ARMJIT_Memory& armjit);
+    bool MapIntoRange(u32 addr, u32 num, u32 offset, u32 size) noexcept;
+    bool UnmapFromRange(u32 addr, u32 num, u32 offset, u32 size) noexcept;
+    void SetCodeProtectionRange(u32 addr, u32 size, u32 num, int protection) noexcept;
+
+    void* FastMem9Start;
+    void* FastMem7Start;
+    u8* MemoryBase = nullptr;
+#if defined(__SWITCH__)
+    VirtmemReservation* FastMem9Reservation, *FastMem7Reservation;
+    u8* MemoryBaseCodeMem;
+#elif defined(_WIN32)
+    static LONG ExceptionHandler(EXCEPTION_POINTERS* exceptionInfo);
+    HANDLE MemoryFile = INVALID_HANDLE_VALUE;
+    LPVOID ExceptionHandlerHandle = nullptr;
+#else
+    static void SigsegvHandler(int sig, siginfo_t* info, void* rawContext);
+    int MemoryFile = -1;
+#endif
+    u8 MappingStatus9[1 << (32-12)] {};
+    u8 MappingStatus7[1 << (32-12)] {};
+    ARMJIT::TinyVector<Mapping> Mappings[memregions_Count] {};
+#else
+public:
+    ARMJIT_Memory() = default;
+    ~ARMJIT_Memory() = default;
+    ARMJIT_Memory(const ARMJIT_Memory&) = delete;
+    ARMJIT_Memory(ARMJIT_Memory&&) = delete;
+    ARMJIT_Memory& operator=(const ARMJIT_Memory&) = delete;
+    ARMJIT_Memory& operator=(ARMJIT_Memory&&) = delete;
+
+    void Reset() noexcept {}
+    void RemapDTCM(u32 newBase, u32 newSize) noexcept {}
+    void RemapSWRAM() noexcept {}
+    void RemapNWRAM(int num) noexcept {}
+    void SetCodeProtection(int region, u32 offset, bool protect) noexcept {}
+
+    [[nodiscard]] u8* GetMainRAM() noexcept { return MainRAM.data(); }
+    [[nodiscard]] const u8* GetMainRAM() const noexcept { return MainRAM.data(); }
+
+    [[nodiscard]] u8* GetSharedWRAM() noexcept { return SharedWRAM.data(); }
+    [[nodiscard]] const u8* GetSharedWRAM() const noexcept { return SharedWRAM.data(); }
+
+    [[nodiscard]] u8* GetARM7WRAM() noexcept { return ARM7WRAM.data(); }
+    [[nodiscard]] const u8* GetARM7WRAM() const noexcept { return ARM7WRAM.data(); }
+
+    [[nodiscard]] u8* GetARM9DTCM() noexcept { return DTCM.data(); }
+    [[nodiscard]] const u8* GetARM9DTCM() const noexcept { return DTCM.data(); }
+
+    [[nodiscard]] u8* GetNWRAM_A() noexcept { return NWRAM_A.data(); }
+    [[nodiscard]] const u8* GetNWRAM_A() const noexcept { return NWRAM_A.data(); }
+
+    [[nodiscard]] u8* GetNWRAM_B() noexcept { return NWRAM_B.data(); }
+    [[nodiscard]] const u8* GetNWRAM_B() const noexcept { return NWRAM_B.data(); }
+
+    [[nodiscard]] u8* GetNWRAM_C() noexcept { return NWRAM_C.data(); }
+    [[nodiscard]] const u8* GetNWRAM_C() const noexcept { return NWRAM_C.data(); }
+private:
+    std::array<u8, NDS::MainRAMMaxSize> MainRAM {};
+    std::array<u8, NDS::ARM7WRAMSize> ARM7WRAM {};
+    std::array<u8, NDS::SharedWRAMSize> SharedWRAM {};
+    std::array<u8, DTCMPhysicalSize> DTCM {};
+    std::array<u8, DSi::NWRAMSize> NWRAM_A {};
+    std::array<u8, DSi::NWRAMSize> NWRAM_B {};
+    std::array<u8, DSi::NWRAMSize> NWRAM_C {};
+#endif
+};
 
 #endif

--- a/src/ARMJIT_Memory.h
+++ b/src/ARMJIT_Memory.h
@@ -97,7 +97,7 @@ public:
 
 #ifdef JIT_ENABLED
 public:
-    ARMJIT_Memory(ARMJIT::ARMJIT& jit) noexcept;
+    explicit ARMJIT_Memory(ARMJIT::ARMJIT& jit) noexcept;
     ~ARMJIT_Memory() noexcept;
     ARMJIT_Memory(const ARMJIT_Memory&) = delete;
     ARMJIT_Memory(ARMJIT_Memory&&) = delete;
@@ -181,7 +181,7 @@ private:
     ARMJIT::TinyVector<Mapping> Mappings[memregions_Count] {};
 #else
 public:
-    ARMJIT_Memory(ARMJIT::ARMJIT& jit) = default;
+    explicit ARMJIT_Memory(ARMJIT::ARMJIT&) {};
     ~ARMJIT_Memory() = default;
     ARMJIT_Memory(const ARMJIT_Memory&) = delete;
     ARMJIT_Memory(ARMJIT_Memory&&) = delete;

--- a/src/ARMJIT_Memory.h
+++ b/src/ARMJIT_Memory.h
@@ -20,6 +20,7 @@
 #define ARMJIT_MEMORY
 
 #include "types.h"
+#include "TinyVector.h"
 
 #include "ARM.h"
 

--- a/src/ARMJIT_Memory.h
+++ b/src/ARMJIT_Memory.h
@@ -173,6 +173,9 @@ private:
     static void SigsegvHandler(int sig, siginfo_t* info, void* rawContext);
     int MemoryFile = -1;
 #endif
+#ifdef ANDROID
+    Platform::DynamicLibrary* Libandroid = nullptr;
+#endif
     u8 MappingStatus9[1 << (32-12)] {};
     u8 MappingStatus7[1 << (32-12)] {};
     ARMJIT::TinyVector<Mapping> Mappings[memregions_Count] {};

--- a/src/ARMJIT_RegisterCache.h
+++ b/src/ARMJIT_RegisterCache.h
@@ -19,7 +19,6 @@
 #ifndef ARMJIT_REGCACHE_H
 #define ARMJIT_REGCACHE_H
 
-#include "ARMJIT.h"
 #include "ARMJIT_Internal.h"
 #include "Platform.h"
 

--- a/src/ARMJIT_x64/ARMJIT_ALU.cpp
+++ b/src/ARMJIT_x64/ARMJIT_ALU.cpp
@@ -17,6 +17,7 @@
 */
 
 #include "ARMJIT_Compiler.h"
+#include "../ARM.h"
 
 using namespace Gen;
 

--- a/src/ARMJIT_x64/ARMJIT_Branch.cpp
+++ b/src/ARMJIT_x64/ARMJIT_Branch.cpp
@@ -17,6 +17,7 @@
 */
 
 #include "ARMJIT_Compiler.h"
+#include "../ARM.h"
 
 using namespace Gen;
 

--- a/src/ARMJIT_x64/ARMJIT_Compiler.cpp
+++ b/src/ARMJIT_x64/ARMJIT_Compiler.cpp
@@ -18,6 +18,7 @@
 
 #include "ARMJIT_Compiler.h"
 
+#include "../ARMJIT.h"
 #include "../ARMInterpreter.h"
 
 #include <assert.h>
@@ -232,7 +233,7 @@ void Compiler::A_Comp_MSR()
  */
 u8 CodeMemory[1024 * 1024 * 32];
 
-Compiler::Compiler(ARMJIT_Memory& memory) : XEmitter(), Memory(memory)
+Compiler::Compiler(ARMJIT& jit) : XEmitter(), JIT(jit)
 {
     {
     #ifdef _WIN32
@@ -712,12 +713,12 @@ JitBlockEntry Compiler::CompileBlock(ARM* cpu, bool thumb, FetchedInstr instrs[]
     if (NearSize - (GetCodePtr() - NearStart) < 1024 * 32) // guess...
     {
         Log(LogLevel::Debug, "near reset\n");
-        ResetBlockCache();
+        JIT.ResetBlockCache();
     }
     if (FarSize - (FarCode - FarStart) < 1024 * 32) // guess...
     {
         Log(LogLevel::Debug, "far reset\n");
-        ResetBlockCache();
+        JIT.ResetBlockCache();
     }
 
     ConstantCycles = 0;

--- a/src/ARMJIT_x64/ARMJIT_Compiler.cpp
+++ b/src/ARMJIT_x64/ARMJIT_Compiler.cpp
@@ -232,7 +232,7 @@ void Compiler::A_Comp_MSR()
  */
 u8 CodeMemory[1024 * 1024 * 32];
 
-Compiler::Compiler()
+Compiler::Compiler(ARMJIT_Memory& memory) : XEmitter(), Memory(memory)
 {
     {
     #ifdef _WIN32

--- a/src/ARMJIT_x64/ARMJIT_Compiler.h
+++ b/src/ARMJIT_x64/ARMJIT_Compiler.h
@@ -31,6 +31,11 @@
 
 #include <unordered_map>
 
+namespace Melon
+{
+class ARMJIT_Memory;
+}
+
 namespace ARMJIT
 {
 
@@ -79,7 +84,7 @@ struct Op2
 class Compiler : public Gen::XEmitter
 {
 public:
-    Compiler();
+    Compiler(ARMJIT_Memory& memory);
 
     void Reset();
 
@@ -238,6 +243,7 @@ public:
     void CreateMethod(const char* namefmt, void* start, ...);
 #endif
 
+    ARMJIT_Memory& Memory;
     u8* FarCode;
     u8* NearCode;
     u32 FarSize;

--- a/src/ARMJIT_x64/ARMJIT_Compiler.h
+++ b/src/ARMJIT_x64/ARMJIT_Compiler.h
@@ -240,42 +240,42 @@ public:
 #endif
 
     ARMJIT& JIT;
-    u8* FarCode;
-    u8* NearCode;
-    u32 FarSize;
-    u32 NearSize;
+    u8* FarCode {};
+    u8* NearCode {};
+    u32 FarSize {};
+    u32 NearSize {};
 
-    u8* NearStart;
-    u8* FarStart;
+    u8* NearStart {};
+    u8* FarStart {};
 
-    void* PatchedStoreFuncs[2][2][3][16];
-    void* PatchedLoadFuncs[2][2][3][2][16];
+    void* PatchedStoreFuncs[2][2][3][16] {};
+    void* PatchedLoadFuncs[2][2][3][2][16] {};
 
-    std::unordered_map<u8*, LoadStorePatch> LoadStorePatches;
+    std::unordered_map<u8*, LoadStorePatch> LoadStorePatches {};
 
-    u8* ResetStart;
-    u32 CodeMemSize;
+    u8* ResetStart {};
+    u32 CodeMemSize {};
 
-    bool Exit;
-    bool IrregularCycles;
+    bool Exit {};
+    bool IrregularCycles {};
 
-    void* ReadBanked;
-    void* WriteBanked;
+    void* ReadBanked {};
+    void* WriteBanked {};
 
     bool CPSRDirty = false;
 
-    FetchedInstr CurInstr;
+    FetchedInstr CurInstr {};
 
-    RegisterCache<Compiler, Gen::X64Reg> RegCache;
+    RegisterCache<Compiler, Gen::X64Reg> RegCache {};
 
-    bool Thumb;
-    u32 Num;
-    u32 R15;
-    u32 CodeRegion;
+    bool Thumb {};
+    u32 Num {};
+    u32 R15 {};
+    u32 CodeRegion {};
 
-    u32 ConstantCycles;
+    u32 ConstantCycles {};
 
-    ARM* CurCPU;
+    ARM* CurCPU {};
 };
 
 }

--- a/src/ARMJIT_x64/ARMJIT_Compiler.h
+++ b/src/ARMJIT_x64/ARMJIT_Compiler.h
@@ -21,7 +21,6 @@
 
 #include "../dolphin/x64Emitter.h"
 
-#include "../ARMJIT.h"
 #include "../ARMJIT_Internal.h"
 #include "../ARMJIT_RegisterCache.h"
 
@@ -31,14 +30,11 @@
 
 #include <unordered_map>
 
-namespace Melon
-{
 class ARMJIT_Memory;
-}
 
 namespace ARMJIT
 {
-
+class ARMJIT;
 const Gen::X64Reg RCPU = Gen::RBP;
 const Gen::X64Reg RCPSR = Gen::R15;
 
@@ -84,7 +80,7 @@ struct Op2
 class Compiler : public Gen::XEmitter
 {
 public:
-    Compiler(ARMJIT_Memory& memory);
+    explicit Compiler(ARMJIT& jit);
 
     void Reset();
 
@@ -243,7 +239,7 @@ public:
     void CreateMethod(const char* namefmt, void* start, ...);
 #endif
 
-    ARMJIT_Memory& Memory;
+    ARMJIT& JIT;
     u8* FarCode;
     u8* NearCode;
     u32 FarSize;

--- a/src/ARMJIT_x64/ARMJIT_Compiler.h
+++ b/src/ARMJIT_x64/ARMJIT_Compiler.h
@@ -80,7 +80,11 @@ struct Op2
 class Compiler : public Gen::XEmitter
 {
 public:
+#ifdef JIT_ENABLED
     explicit Compiler(ARMJIT& jit);
+#else
+    explicit Compiler(ARMJIT& jit) : XEmitter(), JIT(jit) {}
+#endif
 
     void Reset();
 

--- a/src/ARMJIT_x64/ARMJIT_LoadStore.cpp
+++ b/src/ARMJIT_x64/ARMJIT_LoadStore.cpp
@@ -17,6 +17,7 @@
 */
 
 #include "ARMJIT_Compiler.h"
+#include "../ARMJIT.h"
 
 using namespace Gen;
 
@@ -67,9 +68,9 @@ u8* Compiler::RewriteMemAccess(u8* pc)
 
 bool Compiler::Comp_MemLoadLiteral(int size, bool signExtend, int rd, u32 addr)
 {
-    u32 localAddr = LocaliseCodeAddress(Num, addr);
+    u32 localAddr = JIT.LocaliseCodeAddress(Num, addr);
 
-    int invalidLiteralIdx = InvalidLiterals.Find(localAddr);
+    int invalidLiteralIdx = JIT.InvalidLiterals.Find(localAddr);
     if (invalidLiteralIdx != -1)
     {
         return false;
@@ -117,7 +118,7 @@ void Compiler::Comp_MemAccess(int rd, int rn, const Op2& op2, int size, int flag
     if (size == 16)
         addressMask = ~1;
 
-    if (LiteralOptimizations && rn == 15 && rd != 15 && op2.IsImm && !(flags & (memop_Post|memop_Store|memop_Writeback)))
+    if (JIT.LiteralOptimizations && rn == 15 && rd != 15 && op2.IsImm && !(flags & (memop_Post|memop_Store|memop_Writeback)))
     {
         u32 addr = R15 + op2.Imm * ((flags & memop_SubtractOffset) ? -1 : 1);
 
@@ -134,7 +135,7 @@ void Compiler::Comp_MemAccess(int rd, int rn, const Op2& op2, int size, int flag
         Comp_AddCycles_CDI();
     }
 
-    bool addrIsStatic = LiteralOptimizations
+    bool addrIsStatic = JIT.LiteralOptimizations
         && RegCache.IsLiteral(rn) && op2.IsImm && !(flags & (memop_Writeback|memop_Post));
     u32 staticAddress;
     if (addrIsStatic)
@@ -195,10 +196,10 @@ void Compiler::Comp_MemAccess(int rd, int rn, const Op2& op2, int size, int flag
         MOV(32, rnMapped, R(finalAddr));
 
     u32 expectedTarget = Num == 0
-        ? Memory.ClassifyAddress9(CurInstr.DataRegion)
-        : Memory.ClassifyAddress7(CurInstr.DataRegion);
+        ? JIT.Memory.ClassifyAddress9(CurInstr.DataRegion)
+        : JIT.Memory.ClassifyAddress7(CurInstr.DataRegion);
 
-    if (ARMJIT::FastMemory && ((!Thumb && CurInstr.Cond() != 0xE) || Memory.IsFastmemCompatible(expectedTarget)))
+    if (JIT.FastMemory && ((!Thumb && CurInstr.Cond() != 0xE) || JIT.Memory.IsFastmemCompatible(expectedTarget)))
     {
         if (rdMapped.IsImm())
         {
@@ -216,7 +217,7 @@ void Compiler::Comp_MemAccess(int rd, int rn, const Op2& op2, int size, int flag
 
         assert(patch.PatchFunc != NULL);
 
-        MOV(64, R(RSCRATCH), ImmPtr(Num == 0 ? Memory.FastMem9Start : Memory.FastMem7Start));
+        MOV(64, R(RSCRATCH), ImmPtr(Num == 0 ? JIT.Memory.FastMem9Start : JIT.Memory.FastMem7Start));
 
         X64Reg maskedAddr = RSCRATCH3;
         if (size > 8)
@@ -267,7 +268,7 @@ void Compiler::Comp_MemAccess(int rd, int rn, const Op2& op2, int size, int flag
 
         void* func = NULL;
         if (addrIsStatic)
-            func = Memory.GetFuncForAddr(CurCPU, staticAddress, flags & memop_Store, size);
+            func = JIT.Memory.GetFuncForAddr(CurCPU, staticAddress, flags & memop_Store, size);
 
         if (func)
         {
@@ -421,16 +422,16 @@ s32 Compiler::Comp_MemAccessBlock(int rn, BitSet16 regs, bool store, bool preinc
     s32 offset = (regsCount * 4) * (decrement ? -1 : 1);
 
     int expectedTarget = Num == 0
-        ? Memory.ClassifyAddress9(CurInstr.DataRegion)
-        : Memory.ClassifyAddress7(CurInstr.DataRegion);
+        ? JIT.Memory.ClassifyAddress9(CurInstr.DataRegion)
+        : JIT.Memory.ClassifyAddress7(CurInstr.DataRegion);
 
     if (!store)
         Comp_AddCycles_CDI();
     else
         Comp_AddCycles_CD();
 
-    bool compileFastPath = FastMemory
-        && !usermode && (CurInstr.Cond() < 0xE || Memory.IsFastmemCompatible(expectedTarget));
+    bool compileFastPath = JIT.FastMemory
+        && !usermode && (CurInstr.Cond() < 0xE || JIT.Memory.IsFastmemCompatible(expectedTarget));
 
     // we need to make sure that the stack stays aligned to 16 bytes
 #ifdef _WIN32
@@ -453,7 +454,7 @@ s32 Compiler::Comp_MemAccessBlock(int rn, BitSet16 regs, bool store, bool preinc
         u8* fastPathStart = GetWritableCodePtr();
         u8* loadStoreAddr[16];
 
-        MOV(64, R(RSCRATCH2), ImmPtr(Num == 0 ? Memory.FastMem9Start : Memory.FastMem7Start));
+        MOV(64, R(RSCRATCH2), ImmPtr(Num == 0 ? JIT.Memory.FastMem9Start : JIT.Memory.FastMem7Start));
         ADD(64, R(RSCRATCH2), R(RSCRATCH4));
 
         u32 offset = 0;
@@ -807,7 +808,7 @@ void Compiler::T_Comp_LoadPCRel()
 {
     u32 offset = (CurInstr.Instr & 0xFF) << 2;
     u32 addr = (R15 & ~0x2) + offset;
-    if (!LiteralOptimizations || !Comp_MemLoadLiteral(32, false, CurInstr.T_Reg(8), addr))
+    if (!JIT.LiteralOptimizations || !Comp_MemLoadLiteral(32, false, CurInstr.T_Reg(8), addr))
         Comp_MemAccess(CurInstr.T_Reg(8), 15, Op2(offset), 32, 0);
 }
 

--- a/src/ARMJIT_x64/ARMJIT_LoadStore.cpp
+++ b/src/ARMJIT_x64/ARMJIT_LoadStore.cpp
@@ -195,10 +195,10 @@ void Compiler::Comp_MemAccess(int rd, int rn, const Op2& op2, int size, int flag
         MOV(32, rnMapped, R(finalAddr));
 
     u32 expectedTarget = Num == 0
-        ? ARMJIT_Memory::ClassifyAddress9(CurInstr.DataRegion)
-        : ARMJIT_Memory::ClassifyAddress7(CurInstr.DataRegion);
+        ? Memory.ClassifyAddress9(CurInstr.DataRegion)
+        : Memory.ClassifyAddress7(CurInstr.DataRegion);
 
-    if (ARMJIT::FastMemory && ((!Thumb && CurInstr.Cond() != 0xE) || ARMJIT_Memory::IsFastmemCompatible(expectedTarget)))
+    if (ARMJIT::FastMemory && ((!Thumb && CurInstr.Cond() != 0xE) || Memory.IsFastmemCompatible(expectedTarget)))
     {
         if (rdMapped.IsImm())
         {
@@ -216,7 +216,7 @@ void Compiler::Comp_MemAccess(int rd, int rn, const Op2& op2, int size, int flag
 
         assert(patch.PatchFunc != NULL);
 
-        MOV(64, R(RSCRATCH), ImmPtr(Num == 0 ? ARMJIT_Memory::FastMem9Start : ARMJIT_Memory::FastMem7Start));
+        MOV(64, R(RSCRATCH), ImmPtr(Num == 0 ? Memory.FastMem9Start : Memory.FastMem7Start));
 
         X64Reg maskedAddr = RSCRATCH3;
         if (size > 8)
@@ -267,7 +267,7 @@ void Compiler::Comp_MemAccess(int rd, int rn, const Op2& op2, int size, int flag
 
         void* func = NULL;
         if (addrIsStatic)
-            func = ARMJIT_Memory::GetFuncForAddr(CurCPU, staticAddress, flags & memop_Store, size);
+            func = Memory.GetFuncForAddr(CurCPU, staticAddress, flags & memop_Store, size);
 
         if (func)
         {
@@ -421,8 +421,8 @@ s32 Compiler::Comp_MemAccessBlock(int rn, BitSet16 regs, bool store, bool preinc
     s32 offset = (regsCount * 4) * (decrement ? -1 : 1);
 
     int expectedTarget = Num == 0
-        ? ARMJIT_Memory::ClassifyAddress9(CurInstr.DataRegion)
-        : ARMJIT_Memory::ClassifyAddress7(CurInstr.DataRegion);
+        ? Memory.ClassifyAddress9(CurInstr.DataRegion)
+        : Memory.ClassifyAddress7(CurInstr.DataRegion);
 
     if (!store)
         Comp_AddCycles_CDI();
@@ -430,7 +430,7 @@ s32 Compiler::Comp_MemAccessBlock(int rn, BitSet16 regs, bool store, bool preinc
         Comp_AddCycles_CD();
 
     bool compileFastPath = FastMemory
-        && !usermode && (CurInstr.Cond() < 0xE || ARMJIT_Memory::IsFastmemCompatible(expectedTarget));
+        && !usermode && (CurInstr.Cond() < 0xE || Memory.IsFastmemCompatible(expectedTarget));
 
     // we need to make sure that the stack stays aligned to 16 bytes
 #ifdef _WIN32
@@ -453,7 +453,7 @@ s32 Compiler::Comp_MemAccessBlock(int rn, BitSet16 regs, bool store, bool preinc
         u8* fastPathStart = GetWritableCodePtr();
         u8* loadStoreAddr[16];
 
-        MOV(64, R(RSCRATCH2), ImmPtr(Num == 0 ? ARMJIT_Memory::FastMem9Start : ARMJIT_Memory::FastMem7Start));
+        MOV(64, R(RSCRATCH2), ImmPtr(Num == 0 ? Memory.FastMem9Start : Memory.FastMem7Start));
         ADD(64, R(RSCRATCH2), R(RSCRATCH4));
 
         u32 offset = 0;

--- a/src/ARM_InstrInfo.cpp
+++ b/src/ARM_InstrInfo.cpp
@@ -315,7 +315,7 @@ const u32 T_SVC = T_BranchAlways | T_WriteR14 | tk(tk_SVC);
 #include "ARM_InstrTable.h"
 #undef INSTRFUNC_PROTO
 
-Info Decode(bool thumb, u32 num, u32 instr)
+Info Decode(bool thumb, u32 num, u32 instr, bool literaloptimizations)
 {
     const u8 FlagsReadPerCond[7] = {
         flag_Z,
@@ -386,7 +386,7 @@ Info Decode(bool thumb, u32 num, u32 instr)
         {
             if (res.Kind == tk_LDR_PCREL)
             {
-                if (!ARMJIT::LiteralOptimizations)
+                if (!literaloptimizations)
                     res.SrcRegs |= 1 << 15;
                 res.SpecialKind = special_LoadLiteral;
             }

--- a/src/ARM_InstrInfo.h
+++ b/src/ARM_InstrInfo.h
@@ -274,7 +274,7 @@ struct Info
     }
 };
 
-Info Decode(bool thumb, u32 num, u32 instr);
+Info Decode(bool thumb, u32 num, u32 instr, bool literaloptimizations);
 
 }
 

--- a/src/CP15.cpp
+++ b/src/CP15.cpp
@@ -125,7 +125,7 @@ void ARMv5::UpdateDTCMSetting()
 
     if (newDTCMBase != DTCMBase || newDTCMMask != DTCMMask)
     {
-        Memory.RemapDTCM(newDTCMBase, newDTCMSize);
+        JIT.Memory.RemapDTCM(newDTCMBase, newDTCMSize);
         DTCMBase = newDTCMBase;
         DTCMMask = newDTCMMask;
     }
@@ -924,9 +924,7 @@ void ARMv5::DataWrite8(u32 addr, u8 val)
     {
         DataCycles = 1;
         *(u8*)&ITCM[addr & (ITCMPhysicalSize - 1)] = val;
-#ifdef JIT_ENABLED
-        ARMJIT::CheckAndInvalidate<0, ARMJIT_Memory::memregion_ITCM>(addr);
-#endif
+        JIT.CheckAndInvalidate<0, ARMJIT_Memory::memregion_ITCM>(addr);
         return;
     }
     if ((addr & DTCMMask) == DTCMBase)
@@ -956,9 +954,7 @@ void ARMv5::DataWrite16(u32 addr, u16 val)
     {
         DataCycles = 1;
         *(u16*)&ITCM[addr & (ITCMPhysicalSize - 1)] = val;
-#ifdef JIT_ENABLED
-        ARMJIT::CheckAndInvalidate<0, ARMJIT_Memory::memregion_ITCM>(addr);
-#endif
+        JIT.CheckAndInvalidate<0, ARMJIT_Memory::memregion_ITCM>(addr);
         return;
     }
     if ((addr & DTCMMask) == DTCMBase)
@@ -988,9 +984,7 @@ void ARMv5::DataWrite32(u32 addr, u32 val)
     {
         DataCycles = 1;
         *(u32*)&ITCM[addr & (ITCMPhysicalSize - 1)] = val;
-#ifdef JIT_ENABLED
-        ARMJIT::CheckAndInvalidate<0, ARMJIT_Memory::memregion_ITCM>(addr);
-#endif
+        JIT.CheckAndInvalidate<0, ARMJIT_Memory::memregion_ITCM>(addr);
         return;
     }
     if ((addr & DTCMMask) == DTCMBase)
@@ -1013,7 +1007,7 @@ void ARMv5::DataWrite32S(u32 addr, u32 val)
         DataCycles += 1;
         *(u32*)&ITCM[addr & (ITCMPhysicalSize - 1)] = val;
 #ifdef JIT_ENABLED
-        ARMJIT::CheckAndInvalidate<0, ARMJIT_Memory::memregion_ITCM>(addr);
+        JIT.CheckAndInvalidate<0, ARMJIT_Memory::memregion_ITCM>(addr);
 #endif
         return;
     }

--- a/src/CP15.cpp
+++ b/src/CP15.cpp
@@ -22,10 +22,10 @@
 #include "DSi.h"
 #include "ARM.h"
 #include "Platform.h"
+#include "ARMJIT_Memory.h"
 
 #ifdef JIT_ENABLED
 #include "ARMJIT.h"
-#include "ARMJIT_Memory.h"
 #endif
 
 using Platform::Log;
@@ -125,9 +125,7 @@ void ARMv5::UpdateDTCMSetting()
 
     if (newDTCMBase != DTCMBase || newDTCMMask != DTCMMask)
     {
-#ifdef JIT_ENABLED
-        ARMJIT_Memory::RemapDTCM(newDTCMBase, newDTCMSize);
-#endif
+        Memory.RemapDTCM(newDTCMBase, newDTCMSize);
         DTCMBase = newDTCMBase;
         DTCMMask = newDTCMMask;
     }

--- a/src/CP15.cpp
+++ b/src/CP15.cpp
@@ -23,10 +23,7 @@
 #include "ARM.h"
 #include "Platform.h"
 #include "ARMJIT_Memory.h"
-
-#ifdef JIT_ENABLED
 #include "ARMJIT.h"
-#endif
 
 using Platform::Log;
 using Platform::LogLevel;

--- a/src/GPU.cpp
+++ b/src/GPU.cpp
@@ -66,7 +66,7 @@ enum
                 VRAMDirty need to be reset for the respective VRAM bank.
 */
 
-GPU::GPU() noexcept : GPU2D_A(0, *this), GPU2D_B(1, *this)
+GPU::GPU(ARMJIT::ARMJIT& jit) noexcept : GPU2D_A(0, *this), GPU2D_B(1, *this), JIT(jit)
 {
     NDS::RegisterEventFunc(NDS::Event_LCD, LCD_StartHBlank, MemberEventFunc(GPU, StartHBlank));
     NDS::RegisterEventFunc(NDS::Event_LCD, LCD_StartScanline, MemberEventFunc(GPU, StartScanline));
@@ -590,9 +590,7 @@ void GPU::MapVRAM_CD(u32 bank, u8 cnt) noexcept
             VRAMMap_ARM7[ofs] |= bankmask;
             memset(VRAMDirty[bank].Data, 0xFF, sizeof(VRAMDirty[bank].Data));
             VRAMSTAT |= (1 << (bank-2));
-#ifdef JIT_ENABLED
-            ARMJIT::CheckAndInvalidateWVRAM(ofs);
-#endif
+            JIT.CheckAndInvalidateWVRAM(ofs);
             break;
 
         case 3: // texture

--- a/src/GPU.cpp
+++ b/src/GPU.cpp
@@ -20,9 +20,7 @@
 #include "NDS.h"
 #include "GPU.h"
 
-#ifdef JIT_ENABLED
 #include "ARMJIT.h"
-#endif
 
 #include "GPU2D_Soft.h"
 #include "GPU3D_Soft.h"

--- a/src/GPU.h
+++ b/src/GPU.h
@@ -35,6 +35,11 @@ namespace GPU3D
 class GPU3D;
 }
 
+namespace ARMJIT
+{
+class ARMJIT;
+}
+
 namespace Melon
 {
 static constexpr u32 VRAMDirtyGranularity = 512;
@@ -70,7 +75,7 @@ struct RenderSettings
 class GPU
 {
 public:
-    GPU() noexcept;
+    GPU(ARMJIT::ARMJIT& jit) noexcept;
     ~GPU() noexcept;
     void Reset() noexcept;
     void Stop() noexcept;
@@ -539,6 +544,7 @@ public:
 
     void SyncDirtyFlags() noexcept;
 
+    ARMJIT::ARMJIT& JIT;
     u16 VCount = 0;
     u16 TotalScanlines = 0;
     u16 DispStat[2] {};

--- a/src/JitBlock.h
+++ b/src/JitBlock.h
@@ -1,0 +1,61 @@
+/*
+    Copyright 2016-2023 melonDS team
+
+    This file is part of melonDS.
+
+    melonDS is free software: you can redistribute it and/or modify it under
+    the terms of the GNU General Public License as published by the Free
+    Software Foundation, either version 3 of the License, or (at your option)
+    any later version.
+
+    melonDS is distributed in the hope that it will be useful, but WITHOUT ANY
+    WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+    FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with melonDS. If not, see http://www.gnu.org/licenses/.
+*/
+
+#ifndef MELONDS_JITBLOCK_H
+#define MELONDS_JITBLOCK_H
+
+#include "types.h"
+#include "TinyVector.h"
+
+namespace ARMJIT
+{
+typedef void (*JitBlockEntry)();
+
+class JitBlock
+{
+public:
+    JitBlock(u32 num, u32 literalHash, u32 numAddresses, u32 numLiterals)
+    {
+        Num = num;
+        NumAddresses = numAddresses;
+        NumLiterals = numLiterals;
+        Data.SetLength(numAddresses * 2 + numLiterals);
+    }
+
+    u32 StartAddr;
+    u32 StartAddrLocal;
+    u32 InstrHash, LiteralHash;
+    u8 Num;
+    u16 NumAddresses;
+    u16 NumLiterals;
+
+    JitBlockEntry EntryPoint;
+
+    u32* AddressRanges()
+    { return &Data[0]; }
+    u32* AddressMasks()
+    { return &Data[NumAddresses]; }
+    u32* Literals()
+    { return &Data[NumAddresses * 2]; }
+
+private:
+    TinyVector<u32> Data;
+};
+}
+
+#endif //MELONDS_JITBLOCK_H

--- a/src/NDS.h
+++ b/src/NDS.h
@@ -46,6 +46,11 @@ namespace Melon
 class GPU;
 }
 
+namespace ARMJIT
+{
+class ARMJIT;
+}
+
 namespace NDS
 {
 
@@ -269,6 +274,7 @@ extern class Wifi* Wifi;
 extern std::unique_ptr<NDSCart::NDSCartSlot> NDSCartSlot;
 extern std::unique_ptr<GBACart::GBACartSlot> GBACartSlot;
 extern std::unique_ptr<Melon::GPU> GPU;
+extern std::unique_ptr<ARMJIT::ARMJIT> JIT;
 extern class AREngine* AREngine;
 
 const u32 ARM7WRAMSize = 0x10000;

--- a/src/NDSCart.h
+++ b/src/NDSCart.h
@@ -19,6 +19,7 @@
 #ifndef NDSCART_H
 #define NDSCART_H
 
+#include <array>
 #include <string>
 #include <memory>
 

--- a/src/TinyVector.h
+++ b/src/TinyVector.h
@@ -20,6 +20,7 @@
 #define MELONDS_TINYVECTOR_H
 
 #include <assert.h>
+#include <string.h>
 #include "types.h"
 
 namespace ARMJIT

--- a/src/TinyVector.h
+++ b/src/TinyVector.h
@@ -19,6 +19,7 @@
 #ifndef MELONDS_TINYVECTOR_H
 #define MELONDS_TINYVECTOR_H
 
+#include <assert.h>
 #include "types.h"
 
 namespace ARMJIT

--- a/src/TinyVector.h
+++ b/src/TinyVector.h
@@ -1,0 +1,129 @@
+/*
+    Copyright 2016-2023 melonDS team, RSDuck
+
+    This file is part of melonDS.
+
+    melonDS is free software: you can redistribute it and/or modify it under
+    the terms of the GNU General Public License as published by the Free
+    Software Foundation, either version 3 of the License, or (at your option)
+    any later version.
+
+    melonDS is distributed in the hope that it will be useful, but WITHOUT ANY
+    WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+    FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with melonDS. If not, see http://www.gnu.org/licenses/.
+*/
+
+#ifndef MELONDS_TINYVECTOR_H
+#define MELONDS_TINYVECTOR_H
+
+#include "types.h"
+
+namespace ARMJIT
+{
+/*
+    TinyVector
+        - because reinventing the wheel is the best!
+
+    - meant to be used very often, with not so many elements
+    max 1 << 16 elements
+    - doesn't allocate while no elements are inserted
+    - not stl confirmant of course
+    - probably only works with POD types
+    - remove operations don't preserve order, but O(1)!
+*/
+template<typename T>
+struct __attribute__((packed)) TinyVector
+{
+    T* Data = NULL;
+    u16 Capacity = 0;
+    u16 Length = 0;
+
+    ~TinyVector()
+    {
+        delete[] Data;
+    }
+
+    void MakeCapacity(u32 capacity)
+    {
+        assert(capacity <= UINT16_MAX);
+        assert(capacity > Capacity);
+        T* newMem = new T[capacity];
+        if (Data != NULL)
+            memcpy(newMem, Data, sizeof(T) * Length);
+
+        T* oldData = Data;
+        Data = newMem;
+        if (oldData != NULL)
+            delete[] oldData;
+
+        Capacity = capacity;
+    }
+
+    void SetLength(u16 length)
+    {
+        if (Capacity < length)
+            MakeCapacity(length);
+
+        Length = length;
+    }
+
+    void Clear()
+    {
+        Length = 0;
+    }
+
+    void Add(T element)
+    {
+        assert(Length + 1 <= UINT16_MAX);
+        if (Length + 1 > Capacity)
+            MakeCapacity(((Capacity + 4) * 3) / 2);
+
+        Data[Length++] = element;
+    }
+
+    void Remove(int index)
+    {
+        assert(Length > 0);
+        assert(index >= 0 && index < Length);
+
+        Length--;
+        Data[index] = Data[Length];
+        /*for (int i = index; i < Length; i++)
+            Data[i] = Data[i + 1];*/
+    }
+
+    int Find(T needle)
+    {
+        for (int i = 0; i < Length; i++)
+        {
+            if (Data[i] == needle)
+                return i;
+        }
+        return -1;
+    }
+
+    bool RemoveByValue(T needle)
+    {
+        for (int i = 0; i < Length; i++)
+        {
+            if (Data[i] == needle)
+            {
+                Remove(i);
+                return true;
+            }
+        }
+        return false;
+    }
+
+    T& operator[](int index)
+    {
+        assert(index >= 0 && index < Length);
+        return Data[index];
+    }
+};
+}
+
+#endif //MELONDS_TINYVECTOR_H


### PR DESCRIPTION
This PR refactors the JIT to remove as much global state as possible.

However, there are some caveats:

- `ARMJIT::CodeMemory` (the array used to store generated code). For reasons discussed in Discord (involving jumps and addresses), leaving this as a global variable can benefit performance. However, it may need to be extended later to accommodate up to 16 players.
- There are some crashes that occur, both at exit and when starting a game. At least one of these crashes is Linux-specific. However, I think these can be resolved after `NDS` itself is refactored.
- We may need to get creative with signal handlers once we actually start multi-instancing emulators.