### PR TITLE
Split some types and declarations into their own header files

### DIFF
--- a/src/ARMJIT.h
+++ b/src/ARMJIT.h
@@ -86,22 +86,22 @@ private:
 
 
     AddressRange CodeIndexITCM[ITCMPhysicalSize / 512] {};
-    AddressRange CodeIndexMainRAM[NDS::MainRAMMaxSize / 512] {};
-    AddressRange CodeIndexSWRAM[NDS::SharedWRAMSize / 512] {};
+    AddressRange CodeIndexMainRAM[melonDS::MainRAMMaxSize / 512] {};
+    AddressRange CodeIndexSWRAM[melonDS::SharedWRAMSize / 512] {};
     AddressRange CodeIndexVRAM[0x100000 / 512] {};
-    AddressRange CodeIndexARM9BIOS[sizeof(NDS::ARM9BIOS) / 512] {};
-    AddressRange CodeIndexARM7BIOS[sizeof(NDS::ARM7BIOS) / 512] {};
-    AddressRange CodeIndexARM7WRAM[NDS::ARM7WRAMSize / 512] {};
+    AddressRange CodeIndexARM9BIOS[melonDS::ARM9BIOSSize / 512] {};
+    AddressRange CodeIndexARM7BIOS[melonDS::ARM7BIOSSize / 512] {};
+    AddressRange CodeIndexARM7WRAM[melonDS::ARM7WRAMSize / 512] {};
     AddressRange CodeIndexARM7WVRAM[0x40000 / 512] {};
     AddressRange CodeIndexBIOS9DSi[0x10000 / 512] {};
     AddressRange CodeIndexBIOS7DSi[0x10000 / 512] {};
-    AddressRange CodeIndexNWRAM_A[DSi::NWRAMSize / 512] {};
-    AddressRange CodeIndexNWRAM_B[DSi::NWRAMSize / 512] {};
-    AddressRange CodeIndexNWRAM_C[DSi::NWRAMSize / 512] {};
+    AddressRange CodeIndexNWRAM_A[melonDS::NWRAMSize / 512] {};
+    AddressRange CodeIndexNWRAM_B[melonDS::NWRAMSize / 512] {};
+    AddressRange CodeIndexNWRAM_C[melonDS::NWRAMSize / 512] {};
 
     u64 FastBlockLookupITCM[ITCMPhysicalSize / 2] {};
-    u64 FastBlockLookupMainRAM[NDS::MainRAMMaxSize / 2] {};
-    u64 FastBlockLookupSWRAM[NDS::SharedWRAMSize / 2] {};
+    u64 FastBlockLookupMainRAM[melonDS::MainRAMMaxSize / 2] {};
+    u64 FastBlockLookupSWRAM[melonDS::SharedWRAMSize / 2] {};
     u64 FastBlockLookupVRAM[0x100000 / 2] {};
     u64 FastBlockLookupARM9BIOS[sizeof(NDS::ARM9BIOS) / 2] {};
     u64 FastBlockLookupARM7BIOS[sizeof(NDS::ARM7BIOS) / 2] {};
@@ -109,9 +109,9 @@ private:
     u64 FastBlockLookupARM7WVRAM[0x40000 / 2] {};
     u64 FastBlockLookupBIOS9DSi[0x10000 / 2] {};
     u64 FastBlockLookupBIOS7DSi[0x10000 / 2] {};
-    u64 FastBlockLookupNWRAM_A[DSi::NWRAMSize / 2] {};
-    u64 FastBlockLookupNWRAM_B[DSi::NWRAMSize / 2] {};
-    u64 FastBlockLookupNWRAM_C[DSi::NWRAMSize / 2] {};
+    u64 FastBlockLookupNWRAM_A[melonDS::NWRAMSize / 2] {};
+    u64 FastBlockLookupNWRAM_B[melonDS::NWRAMSize / 2] {};
+    u64 FastBlockLookupNWRAM_C[melonDS::NWRAMSize / 2] {};
 
     AddressRange* const CodeMemRegions[ARMJIT_Memory::memregions_Count] =
     {

--- a/src/ARMJIT_Memory.h
+++ b/src/ARMJIT_Memory.h
@@ -23,7 +23,7 @@
 #include "TinyVector.h"
 
 #include "ARM.h"
-#include "DSi.h"
+#include "Constants.h"
 
 #if defined(__SWITCH__)
 #include <switch.h>
@@ -58,13 +58,13 @@ constexpr u32 RoundUp(u32 size) noexcept
 }
 
 const u32 MemBlockMainRAMOffset = 0;
-const u32 MemBlockSWRAMOffset = RoundUp(NDS::MainRAMMaxSize);
-const u32 MemBlockARM7WRAMOffset = MemBlockSWRAMOffset + RoundUp(NDS::SharedWRAMSize);
-const u32 MemBlockDTCMOffset = MemBlockARM7WRAMOffset + RoundUp(NDS::ARM7WRAMSize);
+const u32 MemBlockSWRAMOffset = RoundUp(melonDS::MainRAMMaxSize);
+const u32 MemBlockARM7WRAMOffset = MemBlockSWRAMOffset + RoundUp(melonDS::SharedWRAMSize);
+const u32 MemBlockDTCMOffset = MemBlockARM7WRAMOffset + RoundUp(melonDS::ARM7WRAMSize);
 const u32 MemBlockNWRAM_AOffset = MemBlockDTCMOffset + RoundUp(DTCMPhysicalSize);
-const u32 MemBlockNWRAM_BOffset = MemBlockNWRAM_AOffset + RoundUp(DSi::NWRAMSize);
-const u32 MemBlockNWRAM_COffset = MemBlockNWRAM_BOffset + RoundUp(DSi::NWRAMSize);
-const u32 MemoryTotalSize = MemBlockNWRAM_COffset + RoundUp(DSi::NWRAMSize);
+const u32 MemBlockNWRAM_BOffset = MemBlockNWRAM_AOffset + RoundUp(melonDS::NWRAMSize);
+const u32 MemBlockNWRAM_COffset = MemBlockNWRAM_BOffset + RoundUp(melonDS::NWRAMSize);
+const u32 MemoryTotalSize = MemBlockNWRAM_COffset + RoundUp(melonDS::NWRAMSize);
 
 class ARMJIT_Memory
 {

--- a/src/Constants.h
+++ b/src/Constants.h
@@ -28,4 +28,27 @@ constexpr u32 ARM7WRAMSize = 0x10000;
 constexpr u32 DSiNWRAMSize = 0x40000;
 constexpr u32 ARM9BIOSLength = 0x1000;
 constexpr u32 ARM7BIOSLength = 0x4000;
+
+// matching NDMA modes for DSi
+constexpr u32 NDMAModes[] =
+{
+    // ARM9
+
+    0x10, // immediate
+    0x06, // VBlank
+    0x07, // HBlank
+    0x08, // scanline start
+    0x09, // mainmem FIFO
+    0x04, // DS cart slot
+    0xFF, // GBA cart slot
+    0x0A, // GX FIFO
+    0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+
+    // ARM7
+
+    0x30, // immediate
+    0x26, // VBlank
+    0x24, // DS cart slot
+    0xFF, // wifi / GBA cart slot (TODO)
+};
 }

--- a/src/Constants.h
+++ b/src/Constants.h
@@ -25,9 +25,9 @@ namespace melonDS
 constexpr u32 MainRAMMaxSize = 0x1000000;
 constexpr u32 SharedWRAMSize = 0x8000;
 constexpr u32 ARM7WRAMSize = 0x10000;
-constexpr u32 DSiNWRAMSize = 0x40000;
-constexpr u32 ARM9BIOSLength = 0x1000;
-constexpr u32 ARM7BIOSLength = 0x4000;
+constexpr u32 NWRAMSize = 0x40000;
+constexpr u32 ARM9BIOSSize = 0x1000;
+constexpr u32 ARM7BIOSSize = 0x4000;
 
 // matching NDMA modes for DSi
 constexpr u32 NDMAModes[] =

--- a/src/Constants.h
+++ b/src/Constants.h
@@ -1,0 +1,31 @@
+/*
+    Copyright 2016-2023 melonDS team
+
+    This file is part of melonDS.
+
+    melonDS is free software: you can redistribute it and/or modify it under
+    the terms of the GNU General Public License as published by the Free
+    Software Foundation, either version 3 of the License, or (at your option)
+    any later version.
+
+    melonDS is distributed in the hope that it will be useful, but WITHOUT ANY
+    WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+    FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with melonDS. If not, see http://www.gnu.org/licenses/.
+*/
+
+#pragma once
+
+#include "types.h"
+
+namespace melonDS
+{
+constexpr u32 MainRAMMaxSize = 0x1000000;
+constexpr u32 SharedWRAMSize = 0x8000;
+constexpr u32 ARM7WRAMSize = 0x10000;
+constexpr u32 DSiNWRAMSize = 0x40000;
+constexpr u32 ARM9BIOSLength = 0x1000;
+constexpr u32 ARM7BIOSLength = 0x4000;
+}

--- a/src/DSi.cpp
+++ b/src/DSi.cpp
@@ -26,6 +26,7 @@
 #include "NDSCart.h"
 #include "SPI.h"
 #include "DSi_SPI_TSC.h"
+#include "DSi_I2CHost.h"
 #include "Platform.h"
 
 #include "ARMJIT.h"

--- a/src/DSi_Camera.cpp
+++ b/src/DSi_Camera.cpp
@@ -20,6 +20,7 @@
 #include <stdio.h>
 #include <string.h>
 #include "DSi.h"
+#include "DSi_I2CHost.h"
 #include "DSi_Camera.h"
 #include "Platform.h"
 

--- a/src/DSi_I2C.cpp
+++ b/src/DSi_I2C.cpp
@@ -21,6 +21,7 @@
 #include <math.h>
 #include "DSi.h"
 #include "DSi_I2C.h"
+#include "DSi_I2CHost.h"
 #include "DSi_Camera.h"
 #include "ARM.h"
 #include "SPI.h"

--- a/src/DSi_I2C.h
+++ b/src/DSi_I2C.h
@@ -147,37 +147,4 @@ private:
     bool CheckVolumeSwitchKeysValid();
 };
 
-
-class DSi_I2CHost
-{
-public:
-    DSi_I2CHost();
-    ~DSi_I2CHost();
-    void Reset();
-    void DoSavestate(Savestate* file);
-
-    DSi_BPTWL* GetBPTWL() { return BPTWL; }
-    DSi_Camera* GetOuterCamera() { return Camera0; }
-    DSi_Camera* GetInnerCamera() { return Camera1; }
-
-    u8 ReadCnt() { return Cnt; }
-    void WriteCnt(u8 val);
-
-    u8 ReadData();
-    void WriteData(u8 val);
-
-private:
-    u8 Cnt;
-    u8 Data;
-
-    DSi_BPTWL* BPTWL;       // 4A / BPTWL IC
-    DSi_Camera* Camera0;    // 78 / facing outside
-    DSi_Camera* Camera1;    // 7A / selfie cam
-
-    u8 CurDeviceID;
-    DSi_I2CDevice* CurDevice;
-
-    void GetCurDevice();
-};
-
 #endif // DSI_I2C_H

--- a/src/DSi_I2CHost.h
+++ b/src/DSi_I2CHost.h
@@ -1,0 +1,61 @@
+/*
+    Copyright 2016-2023 melonDS team
+
+    This file is part of melonDS.
+
+    melonDS is free software: you can redistribute it and/or modify it under
+    the terms of the GNU General Public License as published by the Free
+    Software Foundation, either version 3 of the License, or (at your option)
+    any later version.
+
+    melonDS is distributed in the hope that it will be useful, but WITHOUT ANY
+    WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+    FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with melonDS. If not, see http://www.gnu.org/licenses/.
+*/
+
+#ifndef MELONDS_DSI_I2CHOST_H
+#define MELONDS_DSI_I2CHOST_H
+
+#include "types.h"
+
+class Savestate;
+class DSi_BPTWL;
+class DSi_Camera;
+class DSi_I2CDevice;
+
+class DSi_I2CHost
+{
+public:
+    DSi_I2CHost();
+    ~DSi_I2CHost();
+    void Reset();
+    void DoSavestate(Savestate* file);
+
+    DSi_BPTWL* GetBPTWL() { return BPTWL; }
+    DSi_Camera* GetOuterCamera() { return Camera0; }
+    DSi_Camera* GetInnerCamera() { return Camera1; }
+
+    u8 ReadCnt() { return Cnt; }
+    void WriteCnt(u8 val);
+
+    u8 ReadData();
+    void WriteData(u8 val);
+
+private:
+    u8 Cnt;
+    u8 Data;
+
+    DSi_BPTWL* BPTWL;       // 4A / BPTWL IC
+    DSi_Camera* Camera0;    // 78 / facing outside
+    DSi_Camera* Camera1;    // 7A / selfie cam
+
+    u8 CurDeviceID;
+    DSi_I2CDevice* CurDevice;
+
+    void GetCurDevice();
+};
+
+#endif //MELONDS_DSI_I2CHOST_H

--- a/src/MemRegion.h
+++ b/src/MemRegion.h
@@ -1,0 +1,33 @@
+/*
+    Copyright 2016-2023 melonDS team
+
+    This file is part of melonDS.
+
+    melonDS is free software: you can redistribute it and/or modify it under
+    the terms of the GNU General Public License as published by the Free
+    Software Foundation, either version 3 of the License, or (at your option)
+    any later version.
+
+    melonDS is distributed in the hope that it will be useful, but WITHOUT ANY
+    WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+    FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with melonDS. If not, see http://www.gnu.org/licenses/.
+*/
+
+#ifndef MELONDS_MEMREGION_H
+#define MELONDS_MEMREGION_H
+
+#include "types.h"
+
+// this file exists to break #include cycle loops
+namespace melonDS
+{
+struct MemRegion
+{
+    u8* Mem;
+    u32 Mask;
+};
+}
+#endif //MELONDS_MEMREGION_H

--- a/src/frontend/qt_sdl/AudioSettingsDialog.cpp
+++ b/src/frontend/qt_sdl/AudioSettingsDialog.cpp
@@ -26,6 +26,7 @@
 #include "NDS.h"
 #include "DSi.h"
 #include "DSi_I2C.h"
+#include "DSi_I2CHost.h"
 
 #include "AudioSettingsDialog.h"
 #include "ui_AudioSettingsDialog.h"

--- a/src/frontend/qt_sdl/PowerManagement/PowerManagementDialog.cpp
+++ b/src/frontend/qt_sdl/PowerManagement/PowerManagementDialog.cpp
@@ -21,6 +21,7 @@
 
 #include "SPI.h"
 #include "DSi_I2C.h"
+#include "DSi_I2CHost.h"
 #include "NDS.h"
 #include "DSi.h"
 #include "Config.h"

--- a/src/frontend/qt_sdl/ROMManager.cpp
+++ b/src/frontend/qt_sdl/ROMManager.cpp
@@ -43,6 +43,7 @@
 #include "SPI.h"
 #include "RTC.h"
 #include "DSi_I2C.h"
+#include "DSi_I2CHost.h"
 #include "FreeBIOS.h"
 
 using std::make_unique;

--- a/src/frontend/qt_sdl/main.cpp
+++ b/src/frontend/qt_sdl/main.cpp
@@ -93,6 +93,7 @@
 #include "RTC.h"
 #include "DSi.h"
 #include "DSi_I2C.h"
+#include "DSi_I2CHost.h"
 
 #include "Savestate.h"
 


### PR DESCRIPTION
This is to break `#include` cycles that crop up in commits I intend to cherry-pick from [this PR](https://github.com/melonDS-emu/melonDS/pull/1883).