### PR TITLE
Slot-2 addon support, take 2 (v1.0)

### DIFF
--- a/src/GBACart.cpp
+++ b/src/GBACart.cpp
@@ -691,6 +691,36 @@ void CartRAMExpansion::ROMWrite(u32 addr, u16 val)
     }
 }
 
+CartRumblePak::CartRumblePak() : CartCommon()
+{
+}
+
+CartRumblePak::~CartRumblePak()
+{
+}
+
+void CartRumblePak::Reset()
+{
+    RumbleState = 0;
+}
+
+u16 CartRumblePak::ROMRead(u32 addr) const
+{
+    // TODO: Verify this
+    return 0xFFFD;
+}
+
+void CartRumblePak::ROMWrite(u32 addr, u16 val)
+{
+    addr &= 0x01FFFFFF;
+    if (((addr == 0) || (addr == 0x1000)) && (RumbleState != val))
+    {
+	Platform::Rumble_Stop();
+	RumbleState = val;
+	Platform::Rumble_Start(16);
+    }
+}
+
 void GBACartSlot::Reset() noexcept
 {
     if (Cart) Cart->Reset();
@@ -850,6 +880,9 @@ void GBACartSlot::LoadAddon(int type) noexcept
     {
     case NDS::GBAAddon_RAMExpansion:
         Cart = std::make_unique<CartRAMExpansion>();
+        break;
+    case NDS::GBAAddon_RumblePak:
+        Cart = std::make_unique<CartRumblePak>();
         break;
 
     default:

--- a/src/GBACart.h
+++ b/src/GBACart.h
@@ -32,6 +32,7 @@ enum CartType
     Game = 0x101,
     GameSolarSensor = 0x102,
     RAMExpansion = 0x201,
+    RumblePak = 0x202,
 };
 
 // CartCommon -- base code shared by all cart types
@@ -186,6 +187,24 @@ public:
 private:
     u8 RAM[0x800000];
     u16 RAMEnable;
+};
+
+// Rumble Pak - Used on various NDS games
+class CartRumblePak : public CartCommon
+{
+public:
+    CartRumblePak();
+    ~CartRumblePak() override;
+
+    virtual u32 Type() const override { return CartType::RumblePak; }
+
+    void Reset() override;
+
+    u16 ROMRead(u32 addr) const override;
+    void ROMWrite(u32 addr, u16 val) override;
+
+private:
+    u16 RumbleState = 0;
 };
 
 // possible inputs for GBA carts that might accept user input

--- a/src/NDS.h
+++ b/src/NDS.h
@@ -208,6 +208,10 @@ struct MemRegion
 enum
 {
     GBAAddon_RAMExpansion = 1,
+    GBAAddon_RumblePak = 2,
+    GBAAddon_GuitarGrip = 3,
+    GBAAddon_PianoKeyboard = 4,
+    GBAAddon_MaguSlider = 5
 };
 
 #ifdef JIT_ENABLED

--- a/src/Platform.h
+++ b/src/Platform.h
@@ -370,6 +370,11 @@ void Camera_Start(int num);
 void Camera_Stop(int num);
 void Camera_CaptureFrame(int num, u32* frame, int width, int height, bool yuv);
 
+// interface for rumble emulation
+// len is in milliseconds
+void Rumble_Start(int len);
+void Rumble_Stop();
+
 struct DynamicLibrary;
 
 /**

--- a/src/frontend/qt_sdl/Input.cpp
+++ b/src/frontend/qt_sdl/Input.cpp
@@ -28,6 +28,7 @@ namespace Input
 
 int JoystickID;
 SDL_Joystick* Joystick = nullptr;
+SDL_GameController* Controller = nullptr;
 
 u32 KeyInputMask, JoyInputMask;
 u32 KeyHotkeyMask, JoyHotkeyMask;
@@ -35,6 +36,8 @@ u32 HotkeyMask, LastHotkeyMask;
 u32 HotkeyPress, HotkeyRelease;
 
 u32 InputMask;
+bool IsRumbling;
+bool HasRumble;
 
 
 void Init()
@@ -42,6 +45,9 @@ void Init()
     KeyInputMask = 0xFFF;
     JoyInputMask = 0xFFF;
     InputMask = 0xFFF;
+
+    IsRumbling = false;
+    HasRumble = false;
 
     KeyHotkeyMask = 0;
     JoyHotkeyMask = 0;
@@ -52,6 +58,7 @@ void Init()
 
 void OpenJoystick()
 {
+    if (Controller) SDL_GameControllerClose(Controller);
     if (Joystick) SDL_JoystickClose(Joystick);
 
     int num = SDL_NumJoysticks();
@@ -65,14 +72,48 @@ void OpenJoystick()
         JoystickID = 0;
 
     Joystick = SDL_JoystickOpen(JoystickID);
+
+    if (SDL_IsGameController(JoystickID))
+    {
+	Controller = SDL_GameControllerOpen(JoystickID);
+
+	if (SDL_GameControllerHasRumble(Controller))
+	{
+	    HasRumble = true;
+	}
+    }
 }
 
 void CloseJoystick()
 {
+    if (Controller)
+    {
+        SDL_GameControllerClose(Controller);
+        Controller = nullptr;
+    }
+
     if (Joystick)
     {
         SDL_JoystickClose(Joystick);
         Joystick = nullptr;
+    }
+}
+
+void RumbleStart(int len_ms)
+{
+    if (Controller && HasRumble && !IsRumbling)
+    {
+	SDL_GameControllerRumble(Controller, 0xFFFF, 0xFFFF, len_ms);
+	IsRumbling = true;
+    }
+}
+
+void RumbleStop()
+{
+    if (Controller && HasRumble && IsRumbling)
+    {
+	SDL_GameControllerRumble(Controller, 0, 0, 0);
+	IsRumbling = false;
     }
 }
 

--- a/src/frontend/qt_sdl/Input.h
+++ b/src/frontend/qt_sdl/Input.h
@@ -26,8 +26,11 @@ namespace Input
 
 extern int JoystickID;
 extern SDL_Joystick* Joystick;
+extern SDL_GameController* Controller;
 
 extern u32 InputMask;
+extern bool IsRumbling;
+extern bool HasRumble;
 
 void Init();
 
@@ -37,6 +40,8 @@ void CloseJoystick();
 
 void KeyPress(QKeyEvent* event);
 void KeyRelease(QKeyEvent* event);
+void RumbleStart(int len);
+void RumbleStop();
 
 void Process();
 

--- a/src/frontend/qt_sdl/Platform.cpp
+++ b/src/frontend/qt_sdl/Platform.cpp
@@ -30,6 +30,8 @@
 #include <QMutex>
 #include <QOpenGLContext>
 #include <QSharedMemory>
+#include <QKeyEvent>
+#include <SDL2/SDL.h>
 #include <SDL_loadso.h>
 
 #include "Platform.h"
@@ -41,6 +43,8 @@
 #include "LocalMP.h"
 #include "OSD.h"
 #include "SPI_Firmware.h"
+
+#include "Input.h"
 
 #ifdef __WIN32__
 #define fseek _fseeki64
@@ -732,6 +736,16 @@ void Camera_Stop(int num)
 void Camera_CaptureFrame(int num, u32* frame, int width, int height, bool yuv)
 {
     return camManager[num]->captureFrame(frame, width, height, yuv);
+}
+
+void Rumble_Start(int len)
+{
+    Input::RumbleStart(len);
+}
+
+void Rumble_Stop()
+{
+    Input::RumbleStop();
 }
 
 DynamicLibrary* DynamicLibrary_Load(const char* lib)

--- a/src/frontend/qt_sdl/main.cpp
+++ b/src/frontend/qt_sdl/main.cpp
@@ -1474,6 +1474,11 @@ MainWindow::MainWindow(QWidget* parent) : QMainWindow(parent)
             actInsertGBAAddon[0] = submenu->addAction("Memory expansion");
             actInsertGBAAddon[0]->setData(QVariant(NDS::GBAAddon_RAMExpansion));
             connect(actInsertGBAAddon[0], &QAction::triggered, this, &MainWindow::onInsertGBAAddon);
+
+	    actInsertGBAAddon[1] = submenu->addAction("Rumble Pak");
+	    actInsertGBAAddon[1]->setData(QVariant(NDS::GBAAddon_RumblePak));
+	    connect(actInsertGBAAddon[1], &QAction::triggered, this, &MainWindow::onInsertGBAAddon);
+	    
         }
 
         actEjectGBACart = menu->addAction("Eject cart");
@@ -1798,7 +1803,7 @@ MainWindow::MainWindow(QWidget* parent) : QMainWindow(parent)
     if (Config::ConsoleType == 1)
     {
         actInsertGBACart->setEnabled(false);
-        for (int i = 0; i < 1; i++)
+        for (int i = 0; i < 2; i++)
             actInsertGBAAddon[i]->setEnabled(false);
     }
 

--- a/src/frontend/qt_sdl/main.h
+++ b/src/frontend/qt_sdl/main.h
@@ -386,7 +386,7 @@ public:
     QAction* actEjectCart;
     QAction* actCurrentGBACart;
     QAction* actInsertGBACart;
-    QAction* actInsertGBAAddon[1];
+    QAction* actInsertGBAAddon[5];
     QAction* actEjectGBACart;
     QAction* actImportSavefile;
     QAction* actSaveState[9];


### PR DESCRIPTION
This PR, as it currently stands, adds support for the following Slot-2 addons:

Rumble Pak

Future updates to this PR will add support for the following Slot-2 addons:

HCV-1000
Magic Reader
Easy Piano
Slide Controller (used in Magukiddo)
Araknoid Paddle

This PR also supersedes PR #719.