### PR TITLE
When the first vertex is clipped against the last vertex, make the new vertex the last vertex

### DIFF
--- a/src/GPU3D.cpp
+++ b/src/GPU3D.cpp
@@ -769,6 +769,8 @@ int ClipAgainstPlane(const GPU3D& gpu, Vertex* vertices, int nverts, int clipsta
         temp[1] = vertices[1];
     }
 
+    Vertex holdit;
+    bool heldit = false;
     for (int i = clipstart; i < nverts; i++)
     {
         prev = i-1; if (prev < 0) prev = nverts-1;
@@ -782,8 +784,16 @@ int ClipAgainstPlane(const GPU3D& gpu, Vertex* vertices, int nverts, int clipsta
             Vertex* vprev = &vertices[prev];
             if (vprev->Position[comp] <= vprev->Position[3])
             {
-                ClipSegment<comp, 1, attribs>(&temp[c], &vtx, vprev);
-                c++;
+                if (i == 0)
+                {
+                    ClipSegment<comp, 1, attribs>(&holdit, &vtx, vprev);
+                    heldit = true;
+                }
+                else
+                {
+                    ClipSegment<comp, 1, attribs>(&temp[c], &vtx, vprev);
+                    c++;
+                }
             }
 
             Vertex* vnext = &vertices[next];
@@ -797,6 +807,12 @@ int ClipAgainstPlane(const GPU3D& gpu, Vertex* vertices, int nverts, int clipsta
             temp[c++] = vtx;
     }
 
+    if (heldit)
+    {
+        temp[c++] = holdit;
+    }
+    heldit = false;
+
     nverts = c; c = clipstart;
     for (int i = clipstart; i < nverts; i++)
     {
@@ -809,8 +825,17 @@ int ClipAgainstPlane(const GPU3D& gpu, Vertex* vertices, int nverts, int clipsta
             Vertex* vprev = &temp[prev];
             if (vprev->Position[comp] >= -vprev->Position[3])
             {
-                ClipSegment<comp, -1, attribs>(&vertices[c], &vtx, vprev);
-                c++;
+                
+                if (i == 0)
+                {
+                    ClipSegment<comp, -1, attribs>(&holdit, &vtx, vprev);
+                    heldit = true;
+                }
+                else
+                {
+                    ClipSegment<comp, -1, attribs>(&vertices[c], &vtx, vprev);
+                    c++;
+                }
             }
 
             Vertex* vnext = &temp[next];
@@ -822,6 +847,11 @@ int ClipAgainstPlane(const GPU3D& gpu, Vertex* vertices, int nverts, int clipsta
         }
         else
             vertices[c++] = vtx;
+    }
+    
+    if (heldit)
+    {
+        vertices[c++] = holdit;
     }
 
     // checkme


### PR DESCRIPTION
Implements a theory on clipping I had.
Fixes horizontal line polygons rendering inaccurately when the first vertex is clipped.
Can't really give a solid reason *why* this is a thing. It just seems to be the simplest and least arbitrary explanation for horizontal line polygon behavior.
Don't ask why the last vertex being clipped against the first vertex doesn't make a new first vertex, it just doesn't seem to.
Maybe the clipping order just decides to clip vtx 1 against the final vertex last instead of first for some reason?
Hopefully the specifics don't matter!

Fixes the last bug mentioned in https://github.com/melonDS-emu/melonDS/issues/664
Fixes some tests in https://github.com/Jaklyy/polyrastertest