### PR TITLE
Fix a crash when initializing `NDS`

### DIFF
--- a/src/GPU.cpp
+++ b/src/GPU.cpp
@@ -75,7 +75,7 @@ GPU::GPU(melonDS::NDS& nds, std::unique_ptr<Renderer3D>&& renderer3d, std::uniqu
     NDS.RegisterEventFunc(Event_LCD, LCD_FinishFrame, MemberEventFunc(GPU, FinishFrame));
     NDS.RegisterEventFunc(Event_DisplayFIFO, 0, MemberEventFunc(GPU, DisplayFIFO));
 
-    FrontBuffer = 0;
+    InitFramebuffers();
 }
 
 GPU::~GPU() noexcept
@@ -298,6 +298,11 @@ void GPU::SetRenderer3D(std::unique_ptr<Renderer3D>&& renderer) noexcept
     else
         GPU3D.SetCurrentRenderer(std::move(renderer));
 
+    InitFramebuffers();
+}
+
+void GPU::InitFramebuffers() noexcept
+{
     int fbsize;
     if (GPU3D.IsRendererAccelerated())
         fbsize = (256*3 + 1) * 192;

--- a/src/GPU.h
+++ b/src/GPU.h
@@ -607,6 +607,7 @@ public:
 private:
     void ResetVRAMCache() noexcept;
     void AssignFramebuffers() noexcept;
+    void InitFramebuffers() noexcept;
     template<typename T>
     T ReadVRAM_ABGExtPal(u32 addr) const noexcept
     {


### PR DESCRIPTION
This PR fixes a crash caused when using the default 3D renderer without explicitly setting it; `GPU::Framebuffer` is now initialized in (a method called by) the constructor, as well as when calling `GPU::SetRenderer3D`.