### PR TITLE
Fix some miscellaneous mistakes

### DIFF
--- a/src/ARMJIT_A64/ARMJIT_Compiler.cpp
+++ b/src/ARMJIT_A64/ARMJIT_Compiler.cpp
@@ -276,7 +276,7 @@ Compiler::Compiler(melonDS::NDS& nds) : Arm64Gen::ARM64XEmitter(), NDS(nds)
         VirtualProtect(pageAligned, alignedSize, PAGE_EXECUTE_READWRITE, &dummy);
     #elif defined(__APPLE__)
         pageAligned = (u8*)mmap(NULL, 1024*1024*16, PROT_READ | PROT_WRITE | PROT_EXEC, MAP_PRIVATE | MAP_ANONYMOUS | MAP_JIT,-1, 0);
-        JitEnableWrite();
+        nds.JIT.JitEnableWrite();
     #else
         mprotect(pageAligned, alignedSize, PROT_EXEC | PROT_READ | PROT_WRITE);
     #endif

--- a/src/ARMJIT_A64/ARMJIT_Compiler.h
+++ b/src/ARMJIT_A64/ARMJIT_Compiler.h
@@ -99,7 +99,7 @@ public:
 #ifdef JIT_ENABLED
     explicit Compiler(melonDS::NDS& nds);
 #else
-    explicit Compiler(melonDS::NDS& nds) : XEmitter(), NDS(nds) {}
+    explicit Compiler(melonDS::NDS& nds) : NDS(nds) {}
 #endif
     ~Compiler();
 

--- a/src/ARMJIT_Memory.cpp
+++ b/src/ARMJIT_Memory.cpp
@@ -1071,15 +1071,19 @@ int ARMJIT_Memory::ClassifyAddress9(u32 addr) const noexcept
     }
     else
     {
-        auto& dsi = static_cast<DSi&>(NDS); // ONLY use this if ConsoleType == 1!
-        if (NDS.ConsoleType == 1 && addr >= 0xFFFF0000 && !(dsi.SCFG_BIOS & (1<<1)))
+        if (NDS.ConsoleType == 1)
         {
-            if ((addr >= 0xFFFF8000) && (dsi.SCFG_BIOS & (1<<0)))
-                return memregion_Other;
+            auto& dsi = static_cast<DSi&>(NDS);
+            if (addr >= 0xFFFF0000 && !(dsi.SCFG_BIOS & (1<<1)))
+            {
+                if ((addr >= 0xFFFF8000) && (dsi.SCFG_BIOS & (1<<0)))
+                    return memregion_Other;
 
-            return memregion_BIOS9DSi;
+                return memregion_BIOS9DSi;
+            }
         }
-        else if ((addr & 0xFFFFF000) == 0xFFFF0000)
+
+        if ((addr & 0xFFFFF000) == 0xFFFF0000)
         {
             return memregion_BIOS9;
         }
@@ -1091,6 +1095,7 @@ int ARMJIT_Memory::ClassifyAddress9(u32 addr) const noexcept
         case 0x03000000:
             if (NDS.ConsoleType == 1)
             {
+                auto& dsi = static_cast<DSi&>(NDS);
                 if (addr >= dsi.NWRAMStart[0][0] && addr < dsi.NWRAMEnd[0][0])
                     return memregion_NewSharedWRAM_A;
                 if (addr >= dsi.NWRAMStart[0][1] && addr < dsi.NWRAMEnd[0][1])
@@ -1116,15 +1121,19 @@ int ARMJIT_Memory::ClassifyAddress9(u32 addr) const noexcept
 
 int ARMJIT_Memory::ClassifyAddress7(u32 addr) const noexcept
 {
-    auto& dsi = static_cast<DSi&>(NDS);
-    if (NDS.ConsoleType == 1 && addr < 0x00010000 && !(dsi.SCFG_BIOS & (1<<9)))
+    if (NDS.ConsoleType == 1)
     {
-        if (addr >= 0x00008000 && dsi.SCFG_BIOS & (1<<8))
-            return memregion_Other;
+        auto& dsi = static_cast<DSi&>(NDS);
+        if (addr < 0x00010000 && !(dsi.SCFG_BIOS & (1<<9)))
+        {
+            if (addr >= 0x00008000 && dsi.SCFG_BIOS & (1<<8))
+                return memregion_Other;
 
-        return memregion_BIOS7DSi;
+            return memregion_BIOS7DSi;
+        }
     }
-    else if (addr < 0x00004000)
+
+    if (addr < 0x00004000)
     {
         return memregion_BIOS7;
     }
@@ -1138,6 +1147,7 @@ int ARMJIT_Memory::ClassifyAddress7(u32 addr) const noexcept
         case 0x03000000:
             if (NDS.ConsoleType == 1)
             {
+                auto& dsi = static_cast<DSi&>(NDS);
                 if (addr >= dsi.NWRAMStart[1][0] && addr < dsi.NWRAMEnd[1][0])
                     return memregion_NewSharedWRAM_A;
                 if (addr >= dsi.NWRAMStart[1][1] && addr < dsi.NWRAMEnd[1][1])


### PR DESCRIPTION
This PR fixes two minor instances of undefined behavior (`static_cast`ing something besides a `DSi` to a `DSi`) and a compiler error when building for ARM with the JIT.