### PR TITLE
Exclude JIT-related declarations more aggressively

### DIFF
--- a/src/ARM.cpp
+++ b/src/ARM.cpp
@@ -17,6 +17,7 @@
 */
 
 #include <stdio.h>
+#include <assert.h>
 #include <algorithm>
 #include "NDS.h"
 #include "DSi.h"

--- a/src/ARM.h
+++ b/src/ARM.h
@@ -24,6 +24,7 @@
 
 #include "types.h"
 #include "MemRegion.h"
+#include "MemConstants.h"
 
 #ifdef GDBSTUB_ENABLED
 #include "debug/GdbStub.h"
@@ -41,9 +42,6 @@ enum
     RWFlags_Nonseq = (1<<5),
     RWFlags_ForceUser = (1<<21),
 };
-
-const u32 ITCMPhysicalSize = 0x8000;
-const u32 DTCMPhysicalSize = 0x4000;
 
 struct GDBArgs;
 class ARMJIT;

--- a/src/ARMJIT.h
+++ b/src/ARMJIT.h
@@ -25,9 +25,9 @@
 #include "types.h"
 #include "MemConstants.h"
 #include "Args.h"
+#include "ARMJIT_Memory.h"
 
 #ifdef JIT_ENABLED
-#include "ARMJIT_Memory.h"
 #include "JitBlock.h"
 
 #if defined(__APPLE__) && defined(__aarch64__)

--- a/src/ARMJIT_A64/ARMJIT_Compiler.cpp
+++ b/src/ARMJIT_A64/ARMJIT_Compiler.cpp
@@ -276,7 +276,7 @@ Compiler::Compiler(melonDS::NDS& nds) : Arm64Gen::ARM64XEmitter(), NDS(nds)
         VirtualProtect(pageAligned, alignedSize, PAGE_EXECUTE_READWRITE, &dummy);
     #elif defined(__APPLE__)
         pageAligned = (u8*)mmap(NULL, 1024*1024*16, PROT_READ | PROT_WRITE | PROT_EXEC, MAP_PRIVATE | MAP_ANONYMOUS | MAP_JIT,-1, 0);
-        JitEnableWrite();
+        nds.JIT.JitEnableWrite();
     #else
         mprotect(pageAligned, alignedSize, PROT_EXEC | PROT_READ | PROT_WRITE);
     #endif

--- a/src/ARMJIT_A64/ARMJIT_Compiler.h
+++ b/src/ARMJIT_A64/ARMJIT_Compiler.h
@@ -19,6 +19,8 @@
 #ifndef ARMJIT_A64_COMPILER_H
 #define ARMJIT_A64_COMPILER_H
 
+#if defined(JIT_ENABLED) && defined(__aarch64__)
+
 #include "../ARM.h"
 
 #include "../dolphin/Arm64Emitter.h"
@@ -96,11 +98,7 @@ class Compiler : public Arm64Gen::ARM64XEmitter
 public:
     typedef void (Compiler::*CompileFunc)();
 
-#ifdef JIT_ENABLED
     explicit Compiler(melonDS::NDS& nds);
-#else
-    explicit Compiler(melonDS::NDS& nds) : XEmitter(), NDS(nds) {}
-#endif
     ~Compiler() override;
 
     void PushRegs(bool saveHiRegs, bool saveRegsToBeChanged, bool allowUnload = true);
@@ -289,5 +287,7 @@ public:
 };
 
 }
+
+#endif
 
 #endif

--- a/src/ARMJIT_A64/ARMJIT_Compiler.h
+++ b/src/ARMJIT_A64/ARMJIT_Compiler.h
@@ -101,7 +101,7 @@ public:
 #else
     explicit Compiler(melonDS::NDS& nds) : XEmitter(), NDS(nds) {}
 #endif
-    ~Compiler();
+    ~Compiler() override;
 
     void PushRegs(bool saveHiRegs, bool saveRegsToBeChanged, bool allowUnload = true);
     void PopRegs(bool saveHiRegs, bool saveRegsToBeChanged);

--- a/src/ARMJIT_Compiler.h
+++ b/src/ARMJIT_Compiler.h
@@ -20,10 +20,6 @@
 #define ARMJIT_COMPILER_H
 
 #ifdef JIT_ENABLED
-#define NOOP_IF_NO_JIT
-#else
-#define NOOP_IF_NO_JIT {}
-#endif
 
 #if defined(__x86_64__)
 #include "ARMJIT_x64/ARMJIT_Compiler.h"
@@ -31,6 +27,8 @@
 #include "ARMJIT_A64/ARMJIT_Compiler.h"
 #else
 #error "The current target platform doesn't have a JIT backend"
+#endif
+
 #endif
 
 #endif

--- a/src/ARMJIT_Memory.cpp
+++ b/src/ARMJIT_Memory.cpp
@@ -1073,15 +1073,19 @@ int ARMJIT_Memory::ClassifyAddress9(u32 addr) const noexcept
     }
     else
     {
-        auto& dsi = static_cast<DSi&>(NDS); // ONLY use this if ConsoleType == 1!
-        if (NDS.ConsoleType == 1 && addr >= 0xFFFF0000 && !(dsi.SCFG_BIOS & (1<<1)))
+        if (NDS.ConsoleType == 1)
         {
-            if ((addr >= 0xFFFF8000) && (dsi.SCFG_BIOS & (1<<0)))
-                return memregion_Other;
+            auto& dsi = static_cast<DSi&>(NDS);
+            if (addr >= 0xFFFF0000 && !(dsi.SCFG_BIOS & (1<<1)))
+            {
+                if ((addr >= 0xFFFF8000) && (dsi.SCFG_BIOS & (1<<0)))
+                    return memregion_Other;
 
-            return memregion_BIOS9DSi;
+                return memregion_BIOS9DSi;
+            }
         }
-        else if ((addr & 0xFFFFF000) == 0xFFFF0000)
+
+        if ((addr & 0xFFFFF000) == 0xFFFF0000)
         {
             return memregion_BIOS9;
         }
@@ -1093,6 +1097,7 @@ int ARMJIT_Memory::ClassifyAddress9(u32 addr) const noexcept
         case 0x03000000:
             if (NDS.ConsoleType == 1)
             {
+                auto& dsi = static_cast<DSi&>(NDS);
                 if (addr >= dsi.NWRAMStart[0][0] && addr < dsi.NWRAMEnd[0][0])
                     return memregion_NewSharedWRAM_A;
                 if (addr >= dsi.NWRAMStart[0][1] && addr < dsi.NWRAMEnd[0][1])
@@ -1118,15 +1123,19 @@ int ARMJIT_Memory::ClassifyAddress9(u32 addr) const noexcept
 
 int ARMJIT_Memory::ClassifyAddress7(u32 addr) const noexcept
 {
-    auto& dsi = static_cast<DSi&>(NDS);
-    if (NDS.ConsoleType == 1 && addr < 0x00010000 && !(dsi.SCFG_BIOS & (1<<9)))
+    if (NDS.ConsoleType == 1)
     {
-        if (addr >= 0x00008000 && dsi.SCFG_BIOS & (1<<8))
-            return memregion_Other;
+        auto& dsi = static_cast<DSi&>(NDS);
+        if (addr < 0x00010000 && !(dsi.SCFG_BIOS & (1<<9)))
+        {
+            if (addr >= 0x00008000 && dsi.SCFG_BIOS & (1<<8))
+                return memregion_Other;
 
-        return memregion_BIOS7DSi;
+            return memregion_BIOS7DSi;
+        }
     }
-    else if (addr < 0x00004000)
+
+    if (addr < 0x00004000)
     {
         return memregion_BIOS7;
     }
@@ -1140,6 +1149,7 @@ int ARMJIT_Memory::ClassifyAddress7(u32 addr) const noexcept
         case 0x03000000:
             if (NDS.ConsoleType == 1)
             {
+                auto& dsi = static_cast<DSi&>(NDS);
                 if (addr >= dsi.NWRAMStart[1][0] && addr < dsi.NWRAMEnd[1][0])
                     return memregion_NewSharedWRAM_A;
                 if (addr >= dsi.NWRAMStart[1][1] && addr < dsi.NWRAMEnd[1][1])

--- a/src/ARMJIT_Memory.cpp
+++ b/src/ARMJIT_Memory.cpp
@@ -473,8 +473,10 @@ void ARMJIT_Memory::RemapDTCM(u32 newBase, u32 newSize) noexcept
 
 void ARMJIT_Memory::RemapNWRAM(int num) noexcept
 {
-    auto* dsi = dynamic_cast<DSi*>(&NDS);
-    assert(dsi != nullptr);
+    if (NDS.ConsoleType == 0)
+        return;
+
+    auto* dsi = static_cast<DSi*>(&NDS);
     for (int i = 0; i < Mappings[memregion_SharedWRAM].Length;)
     {
         Mapping& mapping = Mappings[memregion_SharedWRAM][i];

--- a/src/ARMJIT_Memory.h
+++ b/src/ARMJIT_Memory.h
@@ -20,33 +20,33 @@
 #define ARMJIT_MEMORY
 
 #include "types.h"
-#include "TinyVector.h"
-
-#include "ARM.h"
 #include "MemConstants.h"
 
-#if defined(__SWITCH__)
-#include <switch.h>
-#elif defined(_WIN32)
+#ifdef JIT_ENABLED
+#  include "TinyVector.h"
+#  include "ARM.h"
+#  if defined(__SWITCH__)
+#    include <switch.h>
+#  elif defined(_WIN32)
 #include <windows.h>
+#  else
+#    include <sys/mman.h>
+#    include <sys/stat.h>
+#    include <fcntl.h>
+#    include <unistd.h>
+#    include <signal.h>
+#  endif
 #else
-#include <sys/mman.h>
-#include <sys/stat.h>
-#include <fcntl.h>
-#include <unistd.h>
-#include <signal.h>
-#endif
-
-#ifndef JIT_ENABLED
-#include <array>
-#include "NDS.h"
+# include <array>
 #endif
 
 namespace melonDS
 {
+#ifdef JIT_ENABLED
 namespace Platform { struct DynamicLibrary; }
 class Compiler;
 class ARMJIT;
+#endif
 
 constexpr u32 RoundUp(u32 size) noexcept
 {

--- a/src/ARMJIT_x64/ARMJIT_Compiler.h
+++ b/src/ARMJIT_x64/ARMJIT_Compiler.h
@@ -19,6 +19,8 @@
 #ifndef ARMJIT_X64_COMPILER_H
 #define ARMJIT_X64_COMPILER_H
 
+#if defined(JIT_ENABLED) && defined(__x86_64__)
+
 #include "../dolphin/x64Emitter.h"
 
 #include "../ARMJIT_Internal.h"
@@ -81,11 +83,7 @@ struct Op2
 class Compiler : public Gen::XEmitter
 {
 public:
-#ifdef JIT_ENABLED
     explicit Compiler(melonDS::NDS& nds);
-#else
-    explicit Compiler(melonDS::NDS& nds) : XEmitter(), NDS(nds) {}
-#endif
 
     void Reset();
 
@@ -284,5 +282,6 @@ public:
 };
 
 }
+#endif
 
 #endif

--- a/src/DSi.cpp
+++ b/src/DSi.cpp
@@ -93,7 +93,7 @@ DSi::DSi(DSiArgs&& args) noexcept :
     // Memory is owned by ARMJIT_Memory, don't free it
     NWRAM_A = JIT.Memory.GetNWRAM_A();
     NWRAM_B = JIT.Memory.GetNWRAM_B();
-    NWRAM_C = NDS::JIT.Memory.GetNWRAM_C();
+    NWRAM_C = JIT.Memory.GetNWRAM_C();
 }
 
 DSi::~DSi() noexcept

--- a/src/DSi.cpp
+++ b/src/DSi.cpp
@@ -17,6 +17,7 @@
 */
 
 #include <stdio.h>
+#include <assert.h>
 #include <string.h>
 #include <inttypes.h>
 #include "Args.h"

--- a/src/MemConstants.h
+++ b/src/MemConstants.h
@@ -30,6 +30,8 @@ constexpr u32 NWRAMSize = 0x40000;
 constexpr u32 ARM9BIOSSize = 0x1000;
 constexpr u32 ARM7BIOSSize = 0x4000;
 constexpr u32 DSiBIOSSize = 0x10000;
+constexpr u32 ITCMPhysicalSize = 0x8000;
+constexpr u32 DTCMPhysicalSize = 0x4000;
 }
 
 #endif // MELONDS_MEMCONSTANTS_H

--- a/src/NDS.h
+++ b/src/NDS.h
@@ -36,6 +36,9 @@
 #include "AREngine.h"
 #include "GPU.h"
 #include "ARMJIT.h"
+#include "MemRegion.h"
+#include "ARMJIT_Memory.h"
+#include "ARM.h"
 #include "DMA.h"
 #include "FreeBIOS.h"
 

--- a/src/NDS.h
+++ b/src/NDS.h
@@ -437,6 +437,9 @@ public:
 #ifdef JIT_ENABLED
     [[nodiscard]] bool IsJITEnabled() const noexcept { return EnableJIT; }
     void SetJITArgs(std::optional<JITArgs> args) noexcept;
+#else
+    [[nodiscard]] bool IsJITEnabled() const noexcept { return false; }
+    void SetJITArgs(std::optional<JITArgs> args) noexcept {}
 #endif
 
 private:

--- a/src/frontend/qt_sdl/main.cpp
+++ b/src/frontend/qt_sdl/main.cpp
@@ -386,17 +386,19 @@ bool EmuThread::UpdateConsole(UpdateConsoleNDSArgs&& ndsargs, UpdateConsoleGBAAr
         NDS->SetGBACart(std::move(nextgbacart));
     }
 
+#ifdef JIT_ENABLED
     JITArgs jitargs {
         static_cast<unsigned>(Config::JIT_MaxBlockSize),
         Config::JIT_LiteralOptimisations,
         Config::JIT_BranchOptimisations,
         Config::JIT_FastMemory,
     };
+    NDS->SetJITArgs(Config::JIT_Enable ? std::make_optional(jitargs) : std::nullopt);
+#endif
     NDS->ARM7BIOS = *arm7bios;
     NDS->ARM9BIOS = *arm9bios;
     NDS->SetFirmware(std::move(*firmware));
     NDS->SetNDSCart(std::move(nextndscart));
-    NDS->SetJITArgs(Config::JIT_Enable ? std::make_optional(jitargs) : std::nullopt);
     NDS->SPU.SetInterpolation(static_cast<AudioInterpolation>(Config::AudioInterp));
     NDS->SPU.SetDegrade10Bit(static_cast<AudioBitDepth>(Config::AudioBitDepth));
 


### PR DESCRIPTION
This reduces the risk of linker errors occurring when building on ARM without the JIT.