### PR TITLE
Sprinkle `const` around where appropriate

### DIFF
--- a/src/AREngine.cpp
+++ b/src/AREngine.cpp
@@ -40,16 +40,16 @@ AREngine::AREngine(melonDS::NDS& nds) : NDS(nds)
     case ((x)+0x08): case ((x)+0x09): case ((x)+0x0A): case ((x)+0x0B): \
     case ((x)+0x0C): case ((x)+0x0D): case ((x)+0x0E): case ((x)+0x0F)
 
-void AREngine::RunCheat(ARCode& arcode)
+void AREngine::RunCheat(const ARCode& arcode)
 {
-    u32* code = &arcode.Code[0];
+    const u32* code = &arcode.Code[0];
 
     u32 offset = 0;
     u32 datareg = 0;
     u32 cond = 1;
     u32 condstack = 0;
 
-    u32* loopstart = code;
+    const u32* loopstart = code;
     u32 loopcount = 0;
     u32 loopcond = 1;
     u32 loopcondstack = 0;

--- a/src/AREngine.h
+++ b/src/AREngine.h
@@ -33,7 +33,7 @@ public:
     void SetCodeFile(ARCodeFile* file) { CodeFile = file; }
 
     void RunCheats();
-    void RunCheat(ARCode& arcode);
+    void RunCheat(const ARCode& arcode);
 private:
     melonDS::NDS& NDS;
     ARCodeFile* CodeFile; // AR code file - frontend is responsible for managing this

--- a/src/ARM.h
+++ b/src/ARM.h
@@ -82,7 +82,7 @@ public:
     virtual void ExecuteJIT() = 0;
 #endif
 
-    bool CheckCondition(u32 code)
+    bool CheckCondition(u32 code) const
     {
         if (code == 0xE) return true;
         if (ConditionTable[code] & (1 << (CPSR>>28))) return true;
@@ -111,7 +111,7 @@ public:
         if (v) CPSR |= 0x10000000;
     }
 
-    inline bool ModeIs(u32 mode)
+    inline bool ModeIs(u32 mode) const
     {
         u32 cm = CPSR & 0x1f;
         mode &= 0x1f;
@@ -317,7 +317,7 @@ public:
     void ICacheInvalidateAll();
 
     void CP15Write(u32 id, u32 val);
-    u32 CP15Read(u32 id);
+    u32 CP15Read(u32 id) const;
 
     u32 CP15Control;
 

--- a/src/ARMJIT_A64/ARMJIT_Compiler.h
+++ b/src/ARMJIT_A64/ARMJIT_Compiler.h
@@ -116,7 +116,7 @@ public:
 
     bool CanCompile(bool thumb, u16 kind);
 
-    bool FlagsNZNeeded()
+    bool FlagsNZNeeded() const
     {
         return CurInstr.SetFlags & 0xC;
     }
@@ -236,7 +236,7 @@ public:
         return (u8*)entry - GetRXBase();
     }
 
-    bool IsJITFault(u8* pc);
+    bool IsJITFault(const u8* pc);
     u8* RewriteMemAccess(u8* pc);
 
     void SwapCodeRegion()

--- a/src/ARMJIT_A64/ARMJIT_LoadStore.cpp
+++ b/src/ARMJIT_A64/ARMJIT_LoadStore.cpp
@@ -28,7 +28,7 @@ using namespace Arm64Gen;
 namespace melonDS
 {
 
-bool Compiler::IsJITFault(u8* pc)
+bool Compiler::IsJITFault(const u8* pc)
 {
     return (u64)pc >= (u64)GetRXBase() && (u64)pc - (u64)GetRXBase() < (JitMemMainSize + JitMemSecondarySize);
 }

--- a/src/ARMJIT_Internal.h
+++ b/src/ARMJIT_Internal.h
@@ -85,7 +85,7 @@ typedef void (*InterpreterFunc)(ARM* cpu);
 extern InterpreterFunc InterpretARM[];
 extern InterpreterFunc InterpretTHUMB[];
 
-inline bool PageContainsCode(AddressRange* range)
+inline bool PageContainsCode(const AddressRange* range)
 {
     for (int i = 0; i < 8; i++)
     {

--- a/src/ARMJIT_RegisterCache.h
+++ b/src/ARMJIT_RegisterCache.h
@@ -99,7 +99,7 @@ public:
         LiteralsLoaded &= ~(1 << reg);
     }
 
-    bool IsLiteral(int reg)
+    bool IsLiteral(int reg) const
     {
         return LiteralsLoaded & (1 << reg);
     }

--- a/src/ARMJIT_x64/ARMJIT_Compiler.cpp
+++ b/src/ARMJIT_x64/ARMJIT_Compiler.cpp
@@ -651,7 +651,7 @@ const Compiler::CompileFunc T_Comp[ARMInstrInfo::tk_Count] = {
 };
 #undef F
 
-bool Compiler::CanCompile(bool thumb, u16 kind)
+bool Compiler::CanCompile(bool thumb, u16 kind) const
 {
     return (thumb ? T_Comp[kind] : A_Comp[kind]) != NULL;
 }
@@ -667,7 +667,7 @@ void Compiler::Reset()
     LoadStorePatches.clear();
 }
 
-bool Compiler::IsJITFault(u8* addr)
+bool Compiler::IsJITFault(const u8* addr)
 {
     return (u64)addr >= (u64)ResetStart && (u64)addr < (u64)ResetStart + CodeMemSize;
 }

--- a/src/ARMJIT_x64/ARMJIT_Compiler.h
+++ b/src/ARMJIT_x64/ARMJIT_Compiler.h
@@ -94,7 +94,7 @@ public:
     void LoadReg(int reg, Gen::X64Reg nativeReg);
     void SaveReg(int reg, Gen::X64Reg nativeReg);
 
-    bool CanCompile(bool thumb, u16 kind);
+    bool CanCompile(bool thumb, u16 kind) const;
 
     typedef void (Compiler::*CompileFunc)();
 
@@ -236,7 +236,7 @@ public:
         SetCodePtr(FarCode);
     }
 
-    bool IsJITFault(u8* addr);
+    bool IsJITFault(const u8* addr);
 
     u8* RewriteMemAccess(u8* pc);
 

--- a/src/CP15.cpp
+++ b/src/CP15.cpp
@@ -668,7 +668,7 @@ void ARMv5::CP15Write(u32 id, u32 val)
         Log(LogLevel::Debug, "unknown CP15 write op %03X %08X\n", id, val);
 }
 
-u32 ARMv5::CP15Read(u32 id)
+u32 ARMv5::CP15Read(u32 id) const
 {
     //printf("CP15 read op %03X %08X\n", id, NDS::ARM9->R[15]);
 

--- a/src/DSi.cpp
+++ b/src/DSi.cpp
@@ -180,7 +180,7 @@ std::unique_ptr<NDSCart::CartCommon> DSi::EjectCart()
     return oldcart;
 }
 
-void DSi::CamInputFrame(int cam, u32* data, int width, int height, bool rgb)
+void DSi::CamInputFrame(int cam, const u32* data, int width, int height, bool rgb)
 {
     switch (cam)
     {
@@ -276,7 +276,7 @@ void DSi::SetCartInserted(bool inserted)
         SCFG_MC |= 1;
 }
 
-void DSi::DecryptModcryptArea(u32 offset, u32 size, u8* iv)
+void DSi::DecryptModcryptArea(u32 offset, u32 size, const u8* iv)
 {
     AES_ctx ctx;
     u8 key[16];
@@ -956,21 +956,21 @@ void DSi::StallNDMAs()
 }
 
 
-bool DSi::DMAsInMode(u32 cpu, u32 mode)
+bool DSi::DMAsInMode(u32 cpu, u32 mode) const
 {
     if (NDS::DMAsInMode(cpu, mode)) return true;
 
     return NDMAsInMode(cpu, NDMAModes[mode]);
 }
 
-bool DSi::DMAsRunning(u32 cpu)
+bool DSi::DMAsRunning(u32 cpu) const
 {
     if (NDS::DMAsRunning(cpu)) return true;
 
     return NDMAsRunning(cpu);
 }
 
-bool DSi::NDMAsInMode(u32 cpu, u32 mode)
+bool DSi::NDMAsInMode(u32 cpu, u32 mode) const
 {
     cpu <<= 2;
     if (NDMAs[cpu+0].IsInMode(mode)) return true;
@@ -980,7 +980,7 @@ bool DSi::NDMAsInMode(u32 cpu, u32 mode)
     return false;
 }
 
-bool DSi::NDMAsRunning(u32 cpu)
+bool DSi::NDMAsRunning(u32 cpu) const
 {
     cpu <<= 2;
     if (NDMAs[cpu+0].IsRunning()) return true;

--- a/src/DSi.h
+++ b/src/DSi.h
@@ -87,8 +87,8 @@ public:
 
     void RunNDMAs(u32 cpu);
     void StallNDMAs();
-    bool NDMAsInMode(u32 cpu, u32 mode);
-    bool NDMAsRunning(u32 cpu);
+    bool NDMAsInMode(u32 cpu, u32 mode) const;
+    bool NDMAsRunning(u32 cpu) const;
     void CheckNDMAs(u32 cpu, u32 mode);
     void StopNDMAs(u32 cpu, u32 mode);
 
@@ -138,7 +138,7 @@ public:
     DSi& operator=(DSi&&) = delete;
     void SetNDSCart(std::unique_ptr<NDSCart::CartCommon>&& cart) override;
     std::unique_ptr<NDSCart::CartCommon> EjectCart() override;
-    bool NeedsDirectBoot() override
+    bool NeedsDirectBoot() const override
     {
         // for now, DSi mode requires original BIOS/NAND
         return false;
@@ -153,9 +153,9 @@ public:
     void SetSDCard(FATStorage&& sdcard) noexcept { SDMMC.SetSDCard(std::move(sdcard)); }
     void SetSDCard(std::optional<FATStorage>&& sdcard) noexcept { SDMMC.SetSDCard(std::move(sdcard)); }
 
-    void CamInputFrame(int cam, u32* data, int width, int height, bool rgb) override;
-    bool DMAsInMode(u32 cpu, u32 mode) override;
-    bool DMAsRunning(u32 cpu) override;
+    void CamInputFrame(int cam, const u32* data, int width, int height, bool rgb) override;
+    bool DMAsInMode(u32 cpu, u32 mode) const override;
+    bool DMAsRunning(u32 cpu) const override;
     void StopDMAs(u32 cpu, u32 mode) override;
     void CheckDMAs(u32 cpu, u32 mode) override;
     u16 SCFG_Clock7;
@@ -178,7 +178,7 @@ private:
     bool FullBIOSBoot;
     void Set_SCFG_Clock9(u16 val);
     void Set_SCFG_MC(u32 val);
-    void DecryptModcryptArea(u32 offset, u32 size, u8* iv);
+    void DecryptModcryptArea(u32 offset, u32 size, const u8* iv);
     void ApplyNewRAMSize(u32 size);
 };
 

--- a/src/DSi_AES.cpp
+++ b/src/DSi_AES.cpp
@@ -235,7 +235,7 @@ void DSi_AES::ProcessBlock_CTR()
 }
 
 
-u32 DSi_AES::ReadCnt()
+u32 DSi_AES::ReadCnt() const
 {
     u32 ret = Cnt;
 

--- a/src/DSi_AES.h
+++ b/src/DSi_AES.h
@@ -54,7 +54,7 @@ public:
     void Reset();
     void DoSavestate(Savestate* file);
 
-    u32 ReadCnt();
+    u32 ReadCnt() const;
     void WriteCnt(u32 val);
     void WriteBlkCnt(u32 val);
 

--- a/src/DSi_Camera.cpp
+++ b/src/DSi_Camera.cpp
@@ -438,7 +438,7 @@ void DSi_Camera::Stop()
     Platform::Camera_Stop(Num);
 }
 
-bool DSi_Camera::IsActivated()
+bool DSi_Camera::IsActivated() const
 {
     if (StandbyCnt & (1<<14)) return false; // standby
     if (!(MiscCnt & (1<<9))) return false; // data transfer not enabled
@@ -477,7 +477,7 @@ void DSi_Camera::StartTransfer()
     Platform::Camera_CaptureFrame(Num, FrameBuffer, 640, 480, true);
 }
 
-bool DSi_Camera::TransferDone()
+bool DSi_Camera::TransferDone() const
 {
     return TransferY >= FrameHeight;
 }
@@ -590,7 +590,7 @@ void DSi_Camera::Write(u8 val, bool last)
     else      DataPos++;
 }
 
-u16 DSi_Camera::I2C_ReadReg(u16 addr)
+u16 DSi_Camera::I2C_ReadReg(u16 addr) const
 {
     switch (addr)
     {
@@ -695,7 +695,7 @@ void DSi_Camera::I2C_WriteReg(u16 addr, u16 val)
 // TODO: not sure at all what is the accessible range
 // or if there is any overlap in the address range
 
-u8 DSi_Camera::MCU_Read(u16 addr)
+u8 DSi_Camera::MCU_Read(u16 addr) const
 {
     addr &= 0x7FFF;
 
@@ -724,7 +724,7 @@ void DSi_Camera::MCU_Write(u16 addr, u8 val)
 }
 
 
-void DSi_Camera::InputFrame(u32* data, int width, int height, bool rgb)
+void DSi_Camera::InputFrame(const u32* data, int width, int height, bool rgb)
 {
     // TODO: double-buffering?
 

--- a/src/DSi_Camera.h
+++ b/src/DSi_Camera.h
@@ -38,10 +38,10 @@ public:
 
     void Reset() override;
     void Stop();
-    bool IsActivated();
+    bool IsActivated() const;
 
     void StartTransfer();
-    bool TransferDone();
+    bool TransferDone() const;
 
     // lengths in words
     int TransferScanline(u32* buffer, int maxlen);
@@ -50,7 +50,7 @@ public:
     u8 Read(bool last) override;
     void Write(u8 val, bool last) override;
 
-    void InputFrame(u32* data, int width, int height, bool rgb);
+    void InputFrame(const u32* data, int width, int height, bool rgb);
 
     u32 Num;
 
@@ -59,7 +59,7 @@ private:
     u32 RegAddr;
     u16 RegData;
 
-    u16 I2C_ReadReg(u16 addr);
+    u16 I2C_ReadReg(u16 addr) const;
     void I2C_WriteReg(u16 addr, u16 val);
 
     u16 PLLDiv;
@@ -72,7 +72,7 @@ private:
     u16 MCUAddr;
     u8 MCURegs[0x8000];
 
-    u8 MCU_Read(u16 addr);
+    u8 MCU_Read(u16 addr) const;
     void MCU_Write(u16 addr, u8 val);
 
     u16 FrameWidth, FrameHeight;
@@ -91,7 +91,9 @@ public:
     void Stop();
     void DoSavestate(Savestate* file);
 
+    const DSi_Camera* GetOuterCamera() const { return Camera0; }
     DSi_Camera* GetOuterCamera() { return Camera0; }
+    const DSi_Camera* GetInnerCamera() const { return Camera1; }
     DSi_Camera* GetInnerCamera() { return Camera1; }
 
     void IRQ(u32 param);

--- a/src/DSi_DSP.cpp
+++ b/src/DSi_DSP.cpp
@@ -72,7 +72,7 @@ void DSi_DSP::IrqSem()
     DSi.SetIRQ(0, IRQ_DSi_DSP);
 }
 
-u16 DSi_DSP::DSPRead16(u32 addr) const
+u16 DSi_DSP::DSPRead16(u32 addr)
 {
     if (!(addr & 0x40000))
     {

--- a/src/DSi_DSP.cpp
+++ b/src/DSi_DSP.cpp
@@ -34,7 +34,7 @@ const u32 DSi_DSP::DataMemoryOffset = 0x20000; // from Teakra memory_interface.h
 // NOTE: ^ IS IN DSP WORDS, NOT IN BYTES!
 
 
-u16 DSi_DSP::GetPSTS()
+u16 DSi_DSP::GetPSTS() const
 {
     u16 r = DSP_PSTS & (1<<9); // this is the only sticky bit
     //r &= ~((1<<2)|(1<<7)); // we support instant resets and wrfifo xfers
@@ -72,7 +72,7 @@ void DSi_DSP::IrqSem()
     DSi.SetIRQ(0, IRQ_DSi_DSP);
 }
 
-u16 DSi_DSP::DSPRead16(u32 addr)
+u16 DSi_DSP::DSPRead16(u32 addr) const
 {
     if (!(addr & 0x40000))
     {
@@ -182,7 +182,7 @@ void DSi_DSP::Reset()
     SNDExCnt = 0;
 }
 
-bool DSi_DSP::IsRstReleased()
+bool DSi_DSP::IsRstReleased() const
 {
     return SCFG_RST;
 }
@@ -193,12 +193,12 @@ void DSi_DSP::SetRstLine(bool release)
     DSPTimestamp = DSi.ARM9Timestamp; // only start now!
 }
 
-inline bool DSi_DSP::IsDSPCoreEnabled()
+inline bool DSi_DSP::IsDSPCoreEnabled() const
 {
     return (DSi.SCFG_Clock9 & (1<<1)) && SCFG_RST && (!(DSP_PCFG & (1<<0)));
 }
 
-inline bool DSi_DSP::IsDSPIOEnabled()
+inline bool DSi_DSP::IsDSPIOEnabled() const
 {
     return (DSi.SCFG_Clock9 & (1<<1)) && SCFG_RST;
 }

--- a/src/DSi_DSP.h
+++ b/src/DSi_DSP.h
@@ -41,7 +41,7 @@ public:
     void DSPCatchUpU32(u32 _);
 
     // SCFG_RST bit0
-    bool IsRstReleased();
+    bool IsRstReleased() const;
     void SetRstLine(bool release);
 
     // DSP_* regs (0x040043xx) (NOTE: checks SCFG_EXT)
@@ -54,7 +54,7 @@ public:
     u32 Read32(u32 addr);
     void Write32(u32 addr, u32 val);
 
-    u16 ReadSNDExCnt() { return SNDExCnt; }
+    u16 ReadSNDExCnt() const { return SNDExCnt; }
     void WriteSNDExCnt(u16 val, u16 mask);
 
     // NOTE: checks SCFG_CLK9
@@ -64,7 +64,7 @@ public:
     void IrqRep1();
     void IrqRep2();
     void IrqSem();
-    u16 DSPRead16(u32 addr);
+    u16 DSPRead16(u32 addr) const;
     void DSPWrite16(u32 addr, u16 val);
     void AudioCb(std::array<s16, 2> frame);
 
@@ -93,10 +93,10 @@ private:
 
     static const u32 DataMemoryOffset;
 
-    u16 GetPSTS();
+    u16 GetPSTS() const;
 
-    inline bool IsDSPCoreEnabled();
-    inline bool IsDSPIOEnabled();
+    inline bool IsDSPCoreEnabled() const;
+    inline bool IsDSPIOEnabled() const;
 
     bool DSPCatchUp();
 

--- a/src/DSi_DSP.h
+++ b/src/DSi_DSP.h
@@ -64,7 +64,7 @@ public:
     void IrqRep1();
     void IrqRep2();
     void IrqSem();
-    u16 DSPRead16(u32 addr) const;
+    u16 DSPRead16(u32 addr);
     void DSPWrite16(u32 addr, u16 val);
     void AudioCb(std::array<s16, 2> frame);
 

--- a/src/DSi_I2C.cpp
+++ b/src/DSi_I2C.cpp
@@ -117,20 +117,20 @@ void DSi_BPTWL::DoSavestate(Savestate* file)
 }
 
 // TODO: Needs more investigation on the other bits
-inline bool DSi_BPTWL::GetIRQMode()
+inline bool DSi_BPTWL::GetIRQMode() const
 {
     return Registers[0x12] & 0x01;
 }
 
-u8 DSi_BPTWL::GetBootFlag() { return Registers[0x70]; }
+u8 DSi_BPTWL::GetBootFlag() const { return Registers[0x70]; }
 
-bool DSi_BPTWL::GetBatteryCharging() { return Registers[0x20] >> 7; }
+bool DSi_BPTWL::GetBatteryCharging() const { return Registers[0x20] >> 7; }
 void DSi_BPTWL::SetBatteryCharging(bool charging)
 {
     Registers[0x20] = (((charging ? 0x8 : 0x0) << 4) | (Registers[0x20] & 0x0F));
 }
 
-u8 DSi_BPTWL::GetBatteryLevel() { return Registers[0x20] & 0xF; }
+u8 DSi_BPTWL::GetBatteryLevel() const { return Registers[0x20] & 0xF; }
 void DSi_BPTWL::SetBatteryLevel(u8 batteryLevel)
 {
     Registers[0x20] = ((Registers[0x20] & 0xF0) | (batteryLevel & 0x0F));
@@ -143,13 +143,13 @@ void DSi_BPTWL::SetBatteryLevel(u8 batteryLevel)
 
 }
 
-u8 DSi_BPTWL::GetVolumeLevel() { return Registers[0x40]; }
+u8 DSi_BPTWL::GetVolumeLevel() const { return Registers[0x40]; }
 void DSi_BPTWL::SetVolumeLevel(u8 volume)
 {
     Registers[0x40] = volume & 0x1F;
 }
 
-u8 DSi_BPTWL::GetBacklightLevel() { return Registers[0x41]; }
+u8 DSi_BPTWL::GetBacklightLevel() const { return Registers[0x41]; }
 void DSi_BPTWL::SetBacklightLevel(u8 backlight)
 {
     Registers[0x41] = backlight > 4 ? 4 : backlight;
@@ -246,7 +246,7 @@ void DSi_BPTWL::SetVolumeSwitchReleased(u32 key)
     VolumeSwitchRepeatTime = 0.0;
 }
 
-inline bool DSi_BPTWL::CheckVolumeSwitchKeysValid()
+inline bool DSi_BPTWL::CheckVolumeSwitchKeysValid() const
 {
     bool up = VolumeSwitchKeysDown & (1 << volumeKey_Up);
     bool down = VolumeSwitchKeysDown & (1 << volumeKey_Down);

--- a/src/DSi_I2C.h
+++ b/src/DSi_I2C.h
@@ -86,20 +86,20 @@ public:
     void Reset() override;
     void DoSavestate(Savestate* file) override;
 
-    u8 GetBootFlag();
+    u8 GetBootFlag() const;
 
-    bool GetBatteryCharging();
+    bool GetBatteryCharging() const;
     void SetBatteryCharging(bool charging);
 
-    u8 GetBatteryLevel();
+    u8 GetBatteryLevel() const;
     void SetBatteryLevel(u8 batteryLevel);
 
     // 0-31
-    u8 GetVolumeLevel();
+    u8 GetVolumeLevel() const;
     void SetVolumeLevel(u8 volume);
 
     // 0-4
-    u8 GetBacklightLevel();
+    u8 GetBacklightLevel() const;
     void SetBacklightLevel(u8 backlight);
 
     void DoHardwareReset(bool direct);
@@ -144,10 +144,10 @@ private:
     u8 Registers[0x100];
     u32 CurPos;
 
-    bool GetIRQMode();
+    bool GetIRQMode() const;
 
     void ResetButtonState();
-    bool CheckVolumeSwitchKeysValid();
+    bool CheckVolumeSwitchKeysValid() const;
 };
 
 

--- a/src/DSi_NAND.cpp
+++ b/src/DSi_NAND.cpp
@@ -365,7 +365,7 @@ bool NANDImage::ESEncrypt(u8* data, u32 len) const
     return true;
 }
 
-bool NANDImage::ESDecrypt(u8* data, u32 len)
+bool NANDImage::ESDecrypt(u8* data, u32 len) const
 {
     AES_ctx ctx;
     u8 iv[16];

--- a/src/DSi_NAND.h
+++ b/src/DSi_NAND.h
@@ -71,7 +71,7 @@ private:
     u32 ReadFATBlock(u64 addr, u32 len, u8* buf);
     u32 WriteFATBlock(u64 addr, u32 len, const u8* buf);
     bool ESEncrypt(u8* data, u32 len) const;
-    bool ESDecrypt(u8* data, u32 len);
+    bool ESDecrypt(u8* data, u32 len) const;
     Platform::FileHandle* CurFile = nullptr;
     DSiKey eMMC_CID;
     u64 ConsoleID;

--- a/src/DSi_NDMA.h
+++ b/src/DSi_NDMA.h
@@ -44,12 +44,12 @@ public:
     void Run9();
     void Run7();
 
-    bool IsInMode(u32 mode)
+    bool IsInMode(u32 mode) const
     {
         return ((mode == StartMode) && (Cnt & 0x80000000));
     }
 
-    bool IsRunning() { return Running!=0; }
+    bool IsRunning() const { return Running!=0; }
 
     void StartIfNeeded(u32 mode)
     {

--- a/src/DSi_SD.cpp
+++ b/src/DSi_SD.cpp
@@ -336,7 +336,7 @@ void DSi_SDHost::FinishRX(u32 param)
         SetIRQ(24);
 }
 
-u32 DSi_SDHost::DataRX(u8* data, u32 len)
+u32 DSi_SDHost::DataRX(const u8* data, u32 len)
 {
     if (len != BlockLen16) { Log(LogLevel::Warn, "!! BAD BLOCKLEN\n"); len = BlockLen16; }
 
@@ -440,7 +440,7 @@ u32 DSi_SDHost::DataTX(u8* data, u32 len)
     return len;
 }
 
-u32 DSi_SDHost::GetTransferrableLen(u32 len)
+u32 DSi_SDHost::GetTransferrableLen(u32 len) const
 {
     if (len > BlockLen16) len = BlockLen16; // checkme
     return len;

--- a/src/DSi_SD.h
+++ b/src/DSi_SD.h
@@ -51,9 +51,9 @@ public:
     void FinishRX(u32 param);
     void FinishTX(u32 param);
     void SendResponse(u32 val, bool last);
-    u32 DataRX(u8* data, u32 len);
+    u32 DataRX(const u8* data, u32 len);
     u32 DataTX(u8* data, u32 len);
-    u32 GetTransferrableLen(u32 len);
+    u32 GetTransferrableLen(u32 len) const;
 
     void CheckRX();
     void CheckTX();

--- a/src/DSi_SPI_TSC.cpp
+++ b/src/DSi_SPI_TSC.cpp
@@ -121,7 +121,7 @@ void DSi_TSC::SetTouchCoords(u16 x, u16 y)
     }
 }
 
-void DSi_TSC::MicInputFrame(s16* data, int samples)
+void DSi_TSC::MicInputFrame(const s16* data, int samples)
 {
     if (TSCMode == 0x00) return TSC::MicInputFrame(data, samples);
 

--- a/src/DSi_SPI_TSC.h
+++ b/src/DSi_SPI_TSC.h
@@ -40,7 +40,7 @@ public:
     void SetMode(u8 mode);
 
     void SetTouchCoords(u16 x, u16 y) override;
-    void MicInputFrame(s16* data, int samples) override;
+    void MicInputFrame(const s16* data, int samples) override;
 
     void Write(u8 val) override;
     void Release() override;

--- a/src/FATStorage.cpp
+++ b/src/FATStorage.cpp
@@ -145,12 +145,12 @@ bool FATStorage::InjectFile(const std::string& path, u8* data, u32 len)
 }
 
 
-u32 FATStorage::ReadSectors(u32 start, u32 num, u8* data)
+u32 FATStorage::ReadSectors(u32 start, u32 num, u8* data) const
 {
     return ReadSectorsInternal(File, FileSize, start, num, data);
 }
 
-u32 FATStorage::WriteSectors(u32 start, u32 num, u8* data)
+u32 FATStorage::WriteSectors(u32 start, u32 num, const u8* data)
 {
     if (ReadOnly) return 0;
     return WriteSectorsInternal(File, FileSize, start, num, data);
@@ -947,7 +947,7 @@ bool FATStorage::ImportDirectory(const std::string& sourcedir)
     return true;
 }
 
-u64 FATStorage::GetDirectorySize(fs::path sourcedir)
+u64 FATStorage::GetDirectorySize(fs::path sourcedir) const
 {
     u64 ret = 0;
     u32 csize = 0x1000; // this is an estimate

--- a/src/FATStorage.h
+++ b/src/FATStorage.h
@@ -58,8 +58,8 @@ public:
 
     bool InjectFile(const std::string& path, u8* data, u32 len);
 
-    u32 ReadSectors(u32 start, u32 num, u8* data);
-    u32 WriteSectors(u32 start, u32 num, u8* data);
+    u32 ReadSectors(u32 start, u32 num, u8* data) const;
+    u32 WriteSectors(u32 start, u32 num, const u8* data);
     [[nodiscard]] bool IsReadOnly() const noexcept { return ReadOnly; }
 
 private:
@@ -92,7 +92,7 @@ private:
     void CleanupDirectory(const std::string& sourcedir, const std::string& path, int level);
     bool ImportFile(const std::string& path, std::filesystem::path in);
     bool ImportDirectory(const std::string& sourcedir);
-    u64 GetDirectorySize(std::filesystem::path sourcedir);
+    u64 GetDirectorySize(std::filesystem::path sourcedir) const;
 
     bool Load(const std::string& filename, u64 size, const std::optional<std::string>& sourcedir);
     bool Save();

--- a/src/FIFO.h
+++ b/src/FIFO.h
@@ -74,12 +74,12 @@ public:
         return ret;
     }
 
-    T Peek()
+    T Peek() const
     {
         return Entries[ReadPos];
     }
 
-    T Peek(u32 offset)
+    T Peek(u32 offset) const
     {
         u32 pos = ReadPos + offset;
         if (pos >= NumEntries)
@@ -88,11 +88,11 @@ public:
         return Entries[pos];
     }
 
-    u32 Level() { return NumOccupied; }
-    bool IsEmpty() { return NumOccupied == 0; }
-    bool IsFull() { return NumOccupied >= NumEntries; }
+    u32 Level() const { return NumOccupied; }
+    bool IsEmpty() const { return NumOccupied == 0; }
+    bool IsFull() const { return NumOccupied >= NumEntries; }
 
-    bool CanFit(u32 num) { return ((NumOccupied + num) <= NumEntries); }
+    bool CanFit(u32 num) const { return ((NumOccupied + num) <= NumEntries); }
 
 private:
     T Entries[NumEntries] = {0};
@@ -164,12 +164,12 @@ public:
         return ret;
     }
 
-    T Peek()
+    T Peek() const
     {
         return Entries[ReadPos];
     }
 
-    T Peek(u32 offset)
+    T Peek(u32 offset) const
     {
         u32 pos = ReadPos + offset;
         if (pos >= NumEntries)
@@ -178,11 +178,11 @@ public:
         return Entries[pos];
     }
 
-    u32 Level() { return NumOccupied; }
-    bool IsEmpty() { return NumOccupied == 0; }
-    bool IsFull() { return NumOccupied >= NumEntries; }
+    u32 Level() const { return NumOccupied; }
+    bool IsEmpty() const { return NumOccupied == 0; }
+    bool IsFull() const { return NumOccupied >= NumEntries; }
 
-    bool CanFit(u32 num) { return ((NumOccupied + num) <= NumEntries); }
+    bool CanFit(u32 num) const { return ((NumOccupied + num) <= NumEntries); }
 
 private:
     u32 NumEntries;

--- a/src/GPU2D.cpp
+++ b/src/GPU2D.cpp
@@ -648,7 +648,7 @@ void Unit::CheckWindows(u32 line)
     else if (line == Win1Coords[2]) Win1Active |=  0x1;
 }
 
-void Unit::CalculateWindowMask(u32 line, u8* windowMask, u8* objWindow)
+void Unit::CalculateWindowMask(u32 line, u8* windowMask, const u8* objWindow)
 {
     for (u32 i = 0; i < 256; i++)
         windowMask[i] = WinCnt[2]; // window outside
@@ -694,7 +694,7 @@ void Unit::CalculateWindowMask(u32 line, u8* windowMask, u8* objWindow)
     }
 }
 
-void Unit::GetBGVRAM(u8*& data, u32& mask)
+void Unit::GetBGVRAM(u8*& data, u32& mask) const
 {
     if (Num == 0)
     {
@@ -708,7 +708,7 @@ void Unit::GetBGVRAM(u8*& data, u32& mask)
     }
 }
 
-void Unit::GetOBJVRAM(u8*& data, u32& mask)
+void Unit::GetOBJVRAM(u8*& data, u32& mask) const
 {
     if (Num == 0)
     {

--- a/src/GPU2D.h
+++ b/src/GPU2D.h
@@ -52,7 +52,7 @@ public:
     void Write16(u32 addr, u16 val);
     void Write32(u32 addr, u32 val);
 
-    bool UsesFIFO()
+    bool UsesFIFO() const
     {
         if (((DispCnt >> 16) & 0x3) == 3)
             return true;
@@ -72,11 +72,11 @@ public:
     u16* GetBGExtPal(u32 slot, u32 pal);
     u16* GetOBJExtPal();
 
-    void GetBGVRAM(u8*& data, u32& mask);
-    void GetOBJVRAM(u8*& data, u32& mask);
+    void GetBGVRAM(u8*& data, u32& mask) const;
+    void GetOBJVRAM(u8*& data, u32& mask) const;
 
     void UpdateMosaicCounters(u32 line);
-    void CalculateWindowMask(u32 line, u8* windowMask, u8* objWindow);
+    void CalculateWindowMask(u32 line, u8* windowMask, const u8* objWindow);
 
     u32 Num;
     bool Enabled;

--- a/src/GPU2D_Soft.cpp
+++ b/src/GPU2D_Soft.cpp
@@ -30,7 +30,7 @@ SoftRenderer::SoftRenderer(melonDS::GPU& gpu)
     // mosaic table is initialized at compile-time
 }
 
-u32 SoftRenderer::ColorComposite(int i, u32 val1, u32 val2)
+u32 SoftRenderer::ColorComposite(int i, u32 val1, u32 val2) const
 {
     u32 coloreffect = 0;
     u32 eva, evb;

--- a/src/GPU2D_Soft.h
+++ b/src/GPU2D_Soft.h
@@ -117,7 +117,7 @@ private:
 
         return rb | g | 0xFF000000;
     }
-    u32 ColorComposite(int i, u32 val1, u32 val2);
+    u32 ColorComposite(int i, u32 val1, u32 val2) const;
 
     template<u32 bgmode> void DrawScanlineBGMode(u32 line);
     void DrawScanlineBGMode6(u32 line);

--- a/src/GPU3D.cpp
+++ b/src/GPU3D.cpp
@@ -1455,7 +1455,7 @@ void GPU3D::CalculateLighting() noexcept
 }
 
 
-void GPU3D::BoxTest(u32* params) noexcept
+void GPU3D::BoxTest(const u32* params) noexcept
 {
     Vertex cube[8];
     Vertex face[10];
@@ -1588,7 +1588,7 @@ void GPU3D::VecTest(u32 param) noexcept
 
 
 
-void GPU3D::CmdFIFOWrite(CmdFIFOEntry& entry) noexcept
+void GPU3D::CmdFIFOWrite(const CmdFIFOEntry& entry) noexcept
 {
     if (CmdFIFO.IsEmpty() && !CmdPIPE.IsFull())
     {

--- a/src/GPU3D.h
+++ b/src/GPU3D.h
@@ -147,10 +147,10 @@ private:
     void SubmitPolygon() noexcept;
     void SubmitVertex() noexcept;
     void CalculateLighting() noexcept;
-    void BoxTest(u32* params) noexcept;
+    void BoxTest(const u32* params) noexcept;
     void PosTest() noexcept;
     void VecTest(u32 param) noexcept;
-    void CmdFIFOWrite(CmdFIFOEntry& entry) noexcept;
+    void CmdFIFOWrite(const CmdFIFOEntry& entry) noexcept;
     CmdFIFOEntry CmdFIFORead() noexcept;
     void FinishWork(s32 cycles) noexcept;
     void VertexPipelineSubmitCmd() noexcept

--- a/src/GPU3D_OpenGL.cpp
+++ b/src/GPU3D_OpenGL.cpp
@@ -406,7 +406,7 @@ void GLRenderer::SetRenderSettings(bool betterpolygons, int scale) noexcept
 }
 
 
-void GLRenderer::SetupPolygon(GLRenderer::RendererPolygon* rp, Polygon* polygon)
+void GLRenderer::SetupPolygon(GLRenderer::RendererPolygon* rp, Polygon* polygon) const
 {
     rp->PolyData = polygon;
 
@@ -452,7 +452,7 @@ void GLRenderer::SetupPolygon(GLRenderer::RendererPolygon* rp, Polygon* polygon)
     }
 }
 
-u32* GLRenderer::SetupVertex(Polygon* poly, int vid, Vertex* vtx, u32 vtxattr, u32* vptr)
+u32* GLRenderer::SetupVertex(const Polygon* poly, int vid, const Vertex* vtx, u32 vtxattr, u32* vptr) const
 {
     u32 z = poly->FinalZ[vid];
     u32 w = poly->FinalW[vid];
@@ -735,18 +735,18 @@ void GLRenderer::BuildPolygons(GLRenderer::RendererPolygon* polygons, int npolys
     NumEdgeIndices = eidx - EdgeIndicesOffset;
 }
 
-int GLRenderer::RenderSinglePolygon(int i)
+int GLRenderer::RenderSinglePolygon(int i) const
 {
-    RendererPolygon* rp = &PolygonList[i];
+    const RendererPolygon* rp = &PolygonList[i];
 
     glDrawElements(rp->PrimType, rp->NumIndices, GL_UNSIGNED_SHORT, (void*)(uintptr_t)(rp->IndicesOffset * 2));
 
     return 1;
 }
 
-int GLRenderer::RenderPolygonBatch(int i)
+int GLRenderer::RenderPolygonBatch(int i) const
 {
-    RendererPolygon* rp = &PolygonList[i];
+    const RendererPolygon* rp = &PolygonList[i];
     GLuint primtype = rp->PrimType;
     u32 key = rp->RenderKey;
     int numpolys = 0;
@@ -754,7 +754,7 @@ int GLRenderer::RenderPolygonBatch(int i)
 
     for (int iend = i; iend < NumFinalPolys; iend++)
     {
-        RendererPolygon* cur_rp = &PolygonList[iend];
+        const RendererPolygon* cur_rp = &PolygonList[iend];
         if (cur_rp->PrimType != primtype) break;
         if (cur_rp->RenderKey != key) break;
 
@@ -766,16 +766,16 @@ int GLRenderer::RenderPolygonBatch(int i)
     return numpolys;
 }
 
-int GLRenderer::RenderPolygonEdgeBatch(int i)
+int GLRenderer::RenderPolygonEdgeBatch(int i) const
 {
-    RendererPolygon* rp = &PolygonList[i];
+    const RendererPolygon* rp = &PolygonList[i];
     u32 key = rp->RenderKey;
     int numpolys = 0;
     u32 numindices = 0;
 
     for (int iend = i; iend < NumFinalPolys; iend++)
     {
-        RendererPolygon* cur_rp = &PolygonList[iend];
+        const RendererPolygon* cur_rp = &PolygonList[iend];
         if (cur_rp->RenderKey != key) break;
 
         numpolys++;

--- a/src/GPU3D_OpenGL.h
+++ b/src/GPU3D_OpenGL.h
@@ -80,12 +80,12 @@ private:
 
     bool BuildRenderShader(u32 flags, const char* vs, const char* fs);
     void UseRenderShader(u32 flags);
-    void SetupPolygon(RendererPolygon* rp, Polygon* polygon);
-    u32* SetupVertex(Polygon* poly, int vid, Vertex* vtx, u32 vtxattr, u32* vptr);
+    void SetupPolygon(RendererPolygon* rp, Polygon* polygon) const;
+    u32* SetupVertex(const Polygon* poly, int vid, const Vertex* vtx, u32 vtxattr, u32* vptr) const;
     void BuildPolygons(RendererPolygon* polygons, int npolys);
-    int RenderSinglePolygon(int i);
-    int RenderPolygonBatch(int i);
-    int RenderPolygonEdgeBatch(int i);
+    int RenderSinglePolygon(int i) const;
+    int RenderPolygonBatch(int i) const;
+    int RenderPolygonEdgeBatch(int i) const;
     void RenderSceneChunk(int y, int h);
 
     enum

--- a/src/GPU3D_Soft.cpp
+++ b/src/GPU3D_Soft.cpp
@@ -112,7 +112,7 @@ void SoftRenderer::SetThreaded(bool threaded) noexcept
     }
 }
 
-void SoftRenderer::TextureLookup(u32 texparam, u32 texpal, s16 s, s16 t, u16* color, u8* alpha)
+void SoftRenderer::TextureLookup(u32 texparam, u32 texpal, s16 s, s16 t, u16* color, u8* alpha) const
 {
     u32 vramaddr = (texparam & 0xFFFF) << 3;
 
@@ -388,7 +388,7 @@ bool DepthTest_LessThan_FrontFacing(s32 dstz, s32 z, u32 dstattr)
     return false;
 }
 
-u32 SoftRenderer::AlphaBlend(u32 srccolor, u32 dstcolor, u32 alpha) noexcept
+u32 SoftRenderer::AlphaBlend(u32 srccolor, u32 dstcolor, u32 alpha) const noexcept
 {
     u32 dstalpha = dstcolor >> 24;
 
@@ -418,7 +418,7 @@ u32 SoftRenderer::AlphaBlend(u32 srccolor, u32 dstcolor, u32 alpha) noexcept
     return srcR | (srcG << 8) | (srcB << 16) | (dstalpha << 24);
 }
 
-u32 SoftRenderer::RenderPixel(Polygon* polygon, u8 vr, u8 vg, u8 vb, s16 s, s16 t)
+u32 SoftRenderer::RenderPixel(const Polygon* polygon, u8 vr, u8 vg, u8 vb, s16 s, s16 t) const
 {
     u8 r, g, b, a;
 
@@ -565,7 +565,7 @@ void SoftRenderer::PlotTranslucentPixel(u32 pixeladdr, u32 color, u32 z, u32 pol
     AttrBuffer[pixeladdr] = attr;
 }
 
-void SoftRenderer::SetupPolygonLeftEdge(SoftRenderer::RendererPolygon* rp, s32 y)
+void SoftRenderer::SetupPolygonLeftEdge(SoftRenderer::RendererPolygon* rp, s32 y) const
 {
     Polygon* polygon = rp->PolyData;
 
@@ -592,7 +592,7 @@ void SoftRenderer::SetupPolygonLeftEdge(SoftRenderer::RendererPolygon* rp, s32 y
                               polygon->FinalW[rp->CurVL], polygon->FinalW[rp->NextVL], y);
 }
 
-void SoftRenderer::SetupPolygonRightEdge(SoftRenderer::RendererPolygon* rp, s32 y)
+void SoftRenderer::SetupPolygonRightEdge(SoftRenderer::RendererPolygon* rp, s32 y) const
 {
     Polygon* polygon = rp->PolyData;
 
@@ -619,7 +619,7 @@ void SoftRenderer::SetupPolygonRightEdge(SoftRenderer::RendererPolygon* rp, s32 
                               polygon->FinalW[rp->CurVR], polygon->FinalW[rp->NextVR], y);
 }
 
-void SoftRenderer::SetupPolygon(SoftRenderer::RendererPolygon* rp, Polygon* polygon)
+void SoftRenderer::SetupPolygon(SoftRenderer::RendererPolygon* rp, Polygon* polygon) const
 {
     u32 nverts = polygon->NumVertices;
 
@@ -1375,7 +1375,7 @@ void SoftRenderer::RenderScanline(s32 y, int npolys)
     }
 }
 
-u32 SoftRenderer::CalculateFogDensity(u32 pixeladdr)
+u32 SoftRenderer::CalculateFogDensity(u32 pixeladdr) const
 {
     u32 z = DepthBuffer[pixeladdr];
     u32 densityid, densityfrac;

--- a/src/GPU3D_Soft.h
+++ b/src/GPU3D_Soft.h
@@ -429,16 +429,16 @@ private:
     };
 
     template <typename T>
-    inline T ReadVRAM_Texture(u32 addr)
+    inline T ReadVRAM_Texture(u32 addr) const
     {
         return *(T*)&GPU.VRAMFlat_Texture[addr & 0x7FFFF];
     }
     template <typename T>
-    inline T ReadVRAM_TexPal(u32 addr)
+    inline T ReadVRAM_TexPal(u32 addr) const
     {
         return *(T*)&GPU.VRAMFlat_TexPal[addr & 0x1FFFF];
     }
-    u32 AlphaBlend(u32 srccolor, u32 dstcolor, u32 alpha) noexcept;
+    u32 AlphaBlend(u32 srccolor, u32 dstcolor, u32 alpha) const noexcept;
 
     struct RendererPolygon
     {
@@ -454,16 +454,16 @@ private:
 
     melonDS::GPU& GPU;
     RendererPolygon PolygonList[2048];
-    void TextureLookup(u32 texparam, u32 texpal, s16 s, s16 t, u16* color, u8* alpha);
-    u32 RenderPixel(Polygon* polygon, u8 vr, u8 vg, u8 vb, s16 s, s16 t);
+    void TextureLookup(u32 texparam, u32 texpal, s16 s, s16 t, u16* color, u8* alpha) const;
+    u32 RenderPixel(const Polygon* polygon, u8 vr, u8 vg, u8 vb, s16 s, s16 t) const;
     void PlotTranslucentPixel(u32 pixeladdr, u32 color, u32 z, u32 polyattr, u32 shadow);
-    void SetupPolygonLeftEdge(RendererPolygon* rp, s32 y);
-    void SetupPolygonRightEdge(RendererPolygon* rp, s32 y);
-    void SetupPolygon(RendererPolygon* rp, Polygon* polygon);
+    void SetupPolygonLeftEdge(RendererPolygon* rp, s32 y) const;
+    void SetupPolygonRightEdge(RendererPolygon* rp, s32 y) const;
+    void SetupPolygon(RendererPolygon* rp, Polygon* polygon) const;
     void RenderShadowMaskScanline(RendererPolygon* rp, s32 y);
     void RenderPolygonScanline(RendererPolygon* rp, s32 y);
     void RenderScanline(s32 y, int npolys);
-    u32 CalculateFogDensity(u32 pixeladdr);
+    u32 CalculateFogDensity(u32 pixeladdr) const;
     void ScanlineFinalPass(s32 y);
     void ClearBuffers();
     void RenderPolygons(bool threaded, Polygon** polygons, int npolys);

--- a/src/JitBlock.h
+++ b/src/JitBlock.h
@@ -46,12 +46,12 @@ public:
 
     JitBlockEntry EntryPoint;
 
-    u32* AddressRanges()
-    { return &Data[0]; }
-    u32* AddressMasks()
-    { return &Data[NumAddresses]; }
-    u32* Literals()
-    { return &Data[NumAddresses * 2]; }
+    const u32* AddressRanges() const { return &Data[0]; }
+    u32* AddressRanges() { return &Data[0]; }
+    const u32* AddressMasks() const { return &Data[NumAddresses]; }
+    u32* AddressMasks() { return &Data[NumAddresses]; }
+    const u32* Literals() const { return &Data[NumAddresses * 2]; }
+    u32* Literals() { return &Data[NumAddresses * 2]; }
 
 private:
     TinyVector<u32> Data;

--- a/src/NDS.cpp
+++ b/src/NDS.cpp
@@ -256,7 +256,7 @@ void NDS::InitTimings()
     // handled later: GBA slot, wifi
 }
 
-bool NDS::NeedsDirectBoot()
+bool NDS::NeedsDirectBoot() const
 {
     if (ConsoleType == 1)
     {
@@ -1145,7 +1145,7 @@ void NDS::SetKeyMask(u32 mask)
     CheckKeyIRQ(1, oldkey, KeyInput);
 }
 
-bool NDS::IsLidClosed()
+bool NDS::IsLidClosed() const
 {
     if (KeyInput & (1<<23)) return true;
     return false;
@@ -1338,7 +1338,7 @@ void NDS::ClearIRQ2(u32 irq)
     UpdateIRQ(1);
 }
 
-bool NDS::HaltInterrupted(u32 cpu)
+bool NDS::HaltInterrupted(u32 cpu) const
 {
     if (cpu == 0)
     {
@@ -1409,7 +1409,7 @@ void NDS::EnterSleepMode()
     ARM7.Halt(2);
 }
 
-u32 NDS::GetPC(u32 cpu)
+u32 NDS::GetPC(u32 cpu) const
 {
     return cpu ? ARM7.R[15] : ARM9.R[15];
 }
@@ -1637,7 +1637,7 @@ void NDS::TimerStart(u32 id, u16 cnt)
 
 
 
-bool NDS::DMAsInMode(u32 cpu, u32 mode)
+bool NDS::DMAsInMode(u32 cpu, u32 mode) const
 {
     cpu <<= 2;
     if (DMAs[cpu+0].IsInMode(mode)) return true;
@@ -1648,7 +1648,7 @@ bool NDS::DMAsInMode(u32 cpu, u32 mode)
     return false;
 }
 
-bool NDS::DMAsRunning(u32 cpu)
+bool NDS::DMAsRunning(u32 cpu) const
 {
     cpu <<= 2;
     if (DMAs[cpu+0].IsRunning()) return true;

--- a/src/NDS.h
+++ b/src/NDS.h
@@ -325,7 +325,7 @@ public:
     Firmware& GetFirmware() { return SPI.GetFirmwareMem()->GetFirmware(); }
     void SetFirmware(Firmware&& firmware) { SPI.GetFirmwareMem()->SetFirmware(std::move(firmware)); }
 
-    virtual bool NeedsDirectBoot();
+    virtual bool NeedsDirectBoot() const;
     void SetupDirectBoot(const std::string& romname);
     virtual void SetupDirectBoot();
 
@@ -361,10 +361,10 @@ public:
 
     void SetKeyMask(u32 mask);
 
-    bool IsLidClosed();
+    bool IsLidClosed() const;
     void SetLidClosed(bool closed);
 
-    virtual void CamInputFrame(int cam, u32* data, int width, int height, bool rgb) {}
+    virtual void CamInputFrame(int cam, const u32* data, int width, int height, bool rgb) {}
     void MicInputFrame(s16* data, int samples);
 
     void RegisterEventFunc(u32 id, u32 funcid, EventFunc func);
@@ -383,20 +383,20 @@ public:
     void ClearIRQ(u32 cpu, u32 irq);
     void SetIRQ2(u32 irq);
     void ClearIRQ2(u32 irq);
-    bool HaltInterrupted(u32 cpu);
+    bool HaltInterrupted(u32 cpu) const;
     void StopCPU(u32 cpu, u32 mask);
     void ResumeCPU(u32 cpu, u32 mask);
     void GXFIFOStall();
     void GXFIFOUnstall();
 
-    u32 GetPC(u32 cpu);
+    u32 GetPC(u32 cpu) const;
     u64 GetSysClockCycles(int num);
     void NocashPrint(u32 cpu, u32 addr);
 
     void MonitorARM9Jump(u32 addr);
 
-    virtual bool DMAsInMode(u32 cpu, u32 mode);
-    virtual bool DMAsRunning(u32 cpu);
+    virtual bool DMAsInMode(u32 cpu, u32 mode) const;
+    virtual bool DMAsRunning(u32 cpu) const;
     virtual void CheckDMAs(u32 cpu, u32 mode);
     virtual void StopDMAs(u32 cpu, u32 mode);
 

--- a/src/NDSCart.cpp
+++ b/src/NDSCart.cpp
@@ -48,7 +48,7 @@ constexpr u32 ByteSwap(u32 val)
     return (val >> 24) | ((val >> 8) & 0xFF00) | ((val << 8) & 0xFF0000) | (val << 24);
 }
 
-void NDSCartSlot::Key1_Encrypt(u32* data) noexcept
+void NDSCartSlot::Key1_Encrypt(u32* data) const noexcept
 {
     u32 y = data[0];
     u32 x = data[1];
@@ -69,7 +69,7 @@ void NDSCartSlot::Key1_Encrypt(u32* data) noexcept
     data[1] = y ^ Key1_KeyBuf[0x11];
 }
 
-void NDSCartSlot::Key1_Decrypt(u32* data) noexcept
+void NDSCartSlot::Key1_Decrypt(u32* data) const noexcept
 {
     u32 y = data[0];
     u32 x = data[1];
@@ -109,7 +109,7 @@ void NDSCartSlot::Key1_ApplyKeycode(u32* keycode, u32 mod) noexcept
     }
 }
 
-void NDSCartSlot::Key1_LoadKeyBuf(bool dsi, u8 *bios, u32 biosLength) noexcept
+void NDSCartSlot::Key1_LoadKeyBuf(bool dsi, const u8 *bios, u32 biosLength) noexcept
 {
     if (!NDS.IsLoadedARM7BIOSBuiltIn())
     {
@@ -136,7 +136,7 @@ void NDSCartSlot::Key1_LoadKeyBuf(bool dsi, u8 *bios, u32 biosLength) noexcept
     }
 }
 
-void NDSCartSlot::Key1_InitKeycode(bool dsi, u32 idcode, u32 level, u32 mod, u8 *bios, u32 biosLength) noexcept
+void NDSCartSlot::Key1_InitKeycode(bool dsi, u32 idcode, u32 level, u32 mod, const u8 *bios, u32 biosLength) noexcept
 {
     Key1_LoadKeyBuf(dsi, bios, biosLength);
 
@@ -152,7 +152,7 @@ void NDSCartSlot::Key1_InitKeycode(bool dsi, u32 idcode, u32 level, u32 mod, u8 
 }
 
 
-void NDSCartSlot::Key2_Encrypt(u8* data, u32 len) noexcept
+void NDSCartSlot::Key2_Encrypt(const u8* data, u32 len) noexcept
 {
     for (u32 i = 0; i < len; i++)
     {
@@ -232,7 +232,7 @@ void CartCommon::DoSavestate(Savestate* file)
     file->Bool32(&DSiMode);
 }
 
-int CartCommon::ROMCommandStart(NDS& nds, NDSCartSlot& cartslot, u8* cmd, u8* data, u32 len)
+int CartCommon::ROMCommandStart(NDS& nds, NDSCartSlot& cartslot, const u8* cmd, u8* data, u32 len)
 {
     if (CmdEncMode == 0)
     {
@@ -345,7 +345,7 @@ int CartCommon::ROMCommandStart(NDS& nds, NDSCartSlot& cartslot, u8* cmd, u8* da
     return 0;
 }
 
-void CartCommon::ROMCommandFinish(u8* cmd, u8* data, u32 len)
+void CartCommon::ROMCommandFinish(const u8* cmd, u8* data, u32 len)
 {
 }
 
@@ -354,7 +354,7 @@ u8 CartCommon::SPIWrite(u8 val, u32 pos, bool last)
     return 0xFF;
 }
 
-void CartCommon::ReadROM(u32 addr, u32 len, u8* data, u32 offset)
+void CartCommon::ReadROM(u32 addr, u32 len, u8* data, u32 offset) const
 {
     if (addr >= ROMLength) return;
     if ((addr+len) > ROMLength)
@@ -477,7 +477,7 @@ void CartRetail::SetSaveMemory(const u8* savedata, u32 savelen)
     Platform::WriteNDSSave(savedata, len, 0, len);
 }
 
-int CartRetail::ROMCommandStart(NDS& nds, NDSCart::NDSCartSlot& cartslot, u8* cmd, u8* data, u32 len)
+int CartRetail::ROMCommandStart(NDS& nds, NDSCart::NDSCartSlot& cartslot, const u8* cmd, u8* data, u32 len)
 {
     if (CmdEncMode != 2) return CartCommon::ROMCommandStart(nds, cartslot, cmd, data, len);
 
@@ -537,7 +537,7 @@ u8 CartRetail::SPIWrite(u8 val, u32 pos, bool last)
     }
 }
 
-void CartRetail::ReadROM_B7(u32 addr, u32 len, u8* data, u32 offset)
+void CartRetail::ReadROM_B7(u32 addr, u32 len, u8* data, u32 offset) const
 {
     addr &= (ROMLength-1);
 
@@ -875,7 +875,7 @@ void CartRetailNAND::SetSaveMemory(const u8* savedata, u32 savelen)
     BuildSRAMID();
 }
 
-int CartRetailNAND::ROMCommandStart(NDS& nds, NDSCart::NDSCartSlot& cartslot, u8* cmd, u8* data, u32 len)
+int CartRetailNAND::ROMCommandStart(NDS& nds, NDSCart::NDSCartSlot& cartslot, const u8* cmd, u8* data, u32 len)
 {
     if (CmdEncMode != 2) return CartCommon::ROMCommandStart(nds, cartslot, cmd, data, len);
 
@@ -1011,7 +1011,7 @@ int CartRetailNAND::ROMCommandStart(NDS& nds, NDSCart::NDSCartSlot& cartslot, u8
     }
 }
 
-void CartRetailNAND::ROMCommandFinish(u8* cmd, u8* data, u32 len)
+void CartRetailNAND::ROMCommandFinish(const u8* cmd, u8* data, u32 len)
 {
     if (CmdEncMode != 2) return CartCommon::ROMCommandFinish(cmd, data, len);
 
@@ -1206,7 +1206,7 @@ void CartHomebrew::SetupDirectBoot(const std::string& romname, NDS& nds)
     }
 }
 
-int CartHomebrew::ROMCommandStart(NDS& nds, NDSCart::NDSCartSlot& cartslot, u8* cmd, u8* data, u32 len)
+int CartHomebrew::ROMCommandStart(NDS& nds, NDSCart::NDSCartSlot& cartslot, const u8* cmd, u8* data, u32 len)
 {
     if (CmdEncMode != 2) return CartCommon::ROMCommandStart(nds, cartslot, cmd, data, len);
 
@@ -1243,7 +1243,7 @@ int CartHomebrew::ROMCommandStart(NDS& nds, NDSCart::NDSCartSlot& cartslot, u8* 
     }
 }
 
-void CartHomebrew::ROMCommandFinish(u8* cmd, u8* data, u32 len)
+void CartHomebrew::ROMCommandFinish(const u8* cmd, u8* data, u32 len)
 {
     if (CmdEncMode != 2) return CartCommon::ROMCommandFinish(cmd, data, len);
 
@@ -1263,7 +1263,7 @@ void CartHomebrew::ROMCommandFinish(u8* cmd, u8* data, u32 len)
     }
 }
 
-void CartHomebrew::ApplyDLDIPatchAt(u8* binary, u32 dldioffset, const u8* patch, u32 patchlen, bool readonly)
+void CartHomebrew::ApplyDLDIPatchAt(u8* binary, u32 dldioffset, const u8* patch, u32 patchlen, bool readonly) const
 {
     if (patch[0x0D] > binary[dldioffset+0x0F])
     {
@@ -1394,7 +1394,7 @@ void CartHomebrew::ApplyDLDIPatch(const u8* patch, u32 patchlen, bool readonly)
     }
 }
 
-void CartHomebrew::ReadROM_B7(u32 addr, u32 len, u8* data, u32 offset)
+void CartHomebrew::ReadROM_B7(u32 addr, u32 len, u8* data, u32 offset) const
 {
     // TODO: how strict should this be for homebrew?
 

--- a/src/NDSCart.h
+++ b/src/NDSCart.h
@@ -83,8 +83,8 @@ public:
     virtual void DoSavestate(Savestate* file);
 
 
-    virtual int ROMCommandStart(NDS& nds, NDSCart::NDSCartSlot& cartslot, u8* cmd, u8* data, u32 len);
-    virtual void ROMCommandFinish(u8* cmd, u8* data, u32 len);
+    virtual int ROMCommandStart(NDS& nds, NDSCart::NDSCartSlot& cartslot, const u8* cmd, u8* data, u32 len);
+    virtual void ROMCommandFinish(const u8* cmd, u8* data, u32 len);
 
     virtual u8 SPIWrite(u8 val, u32 pos, bool last);
 
@@ -103,7 +103,7 @@ public:
     [[nodiscard]] const u8* GetROM() const { return ROM.get(); }
     [[nodiscard]] u32 GetROMLength() const { return ROMLength; }
 protected:
-    void ReadROM(u32 addr, u32 len, u8* data, u32 offset);
+    void ReadROM(u32 addr, u32 len, u8* data, u32 offset) const;
 
     std::unique_ptr<u8[]> ROM = nullptr;
     u32 ROMLength = 0;
@@ -152,7 +152,7 @@ public:
 
     void SetSaveMemory(const u8* savedata, u32 savelen) override;
 
-    int ROMCommandStart(NDS& nds, NDSCart::NDSCartSlot& cartslot, u8* cmd, u8* data, u32 len) override;
+    int ROMCommandStart(NDS& nds, NDSCart::NDSCartSlot& cartslot, const u8* cmd, u8* data, u32 len) override;
 
     u8 SPIWrite(u8 val, u32 pos, bool last) override;
 
@@ -161,7 +161,7 @@ public:
     u32 GetSaveMemoryLength() const override { return SRAMLength; }
 
 protected:
-    void ReadROM_B7(u32 addr, u32 len, u8* data, u32 offset);
+    void ReadROM_B7(u32 addr, u32 len, u8* data, u32 offset) const;
 
     u8 SRAMWrite_EEPROMTiny(u8 val, u32 pos, bool last);
     u8 SRAMWrite_EEPROM(u8 val, u32 pos, bool last);
@@ -191,8 +191,8 @@ public:
 
     void SetSaveMemory(const u8* savedata, u32 savelen) override;
 
-    int ROMCommandStart(NDS& nds, NDSCart::NDSCartSlot& cartslot, u8* cmd, u8* data, u32 len) override;
-    void ROMCommandFinish(u8* cmd, u8* data, u32 len) override;
+    int ROMCommandStart(NDS& nds, NDSCart::NDSCartSlot& cartslot, const u8* cmd, u8* data, u32 len) override;
+    void ROMCommandFinish(const u8* cmd, u8* data, u32 len) override;
 
     u8 SPIWrite(u8 val, u32 pos, bool last) override;
 
@@ -247,8 +247,8 @@ public:
     void Reset() override;
     void SetupDirectBoot(const std::string& romname, NDS& nds) override;
 
-    int ROMCommandStart(NDS& nds, NDSCart::NDSCartSlot& cartslot, u8* cmd, u8* data, u32 len) override;
-    void ROMCommandFinish(u8* cmd, u8* data, u32 len) override;
+    int ROMCommandStart(NDS& nds, NDSCart::NDSCartSlot& cartslot, const u8* cmd, u8* data, u32 len) override;
+    void ROMCommandFinish(const u8* cmd, u8* data, u32 len) override;
 
     [[nodiscard]] const std::optional<FATStorage>& GetSDCard() const noexcept { return SD; }
     void SetSDCard(FATStorage&& sdcard) noexcept { SD = std::move(sdcard); }
@@ -261,9 +261,9 @@ public:
     }
 
 private:
-    void ApplyDLDIPatchAt(u8* binary, u32 dldioffset, const u8* patch, u32 patchlen, bool readonly);
+    void ApplyDLDIPatchAt(u8* binary, u32 dldioffset, const u8* patch, u32 patchlen, bool readonly) const;
     void ApplyDLDIPatch(const u8* patch, u32 patchlen, bool readonly);
-    void ReadROM_B7(u32 addr, u32 len, u8* data, u32 offset);
+    void ReadROM_B7(u32 addr, u32 len, u8* data, u32 offset) const;
 
     std::optional<FATStorage> SD {};
 };
@@ -354,12 +354,12 @@ private:
     u64 Key2_X = 0;
     u64 Key2_Y = 0;
 
-    void Key1_Encrypt(u32* data) noexcept;
-    void Key1_Decrypt(u32* data) noexcept;
+    void Key1_Encrypt(u32* data) const noexcept;
+    void Key1_Decrypt(u32* data) const noexcept;
     void Key1_ApplyKeycode(u32* keycode, u32 mod) noexcept;
-    void Key1_LoadKeyBuf(bool dsi, u8 *bios, u32 biosLength) noexcept;
-    void Key1_InitKeycode(bool dsi, u32 idcode, u32 level, u32 mod, u8 *bios, u32 biosLength) noexcept;
-    void Key2_Encrypt(u8* data, u32 len) noexcept;
+    void Key1_LoadKeyBuf(bool dsi, const u8 *bios, u32 biosLength) noexcept;
+    void Key1_InitKeycode(bool dsi, u32 idcode, u32 level, u32 mod, const u8 *bios, u32 biosLength) noexcept;
+    void Key2_Encrypt(const u8* data, u32 len) noexcept;
     void ROMEndTransfer(u32 param) noexcept;
     void ROMPrepareData(u32 param) noexcept;
     void AdvanceROMTransfer() noexcept;

--- a/src/NonStupidBitfield.h
+++ b/src/NonStupidBitfield.h
@@ -42,7 +42,7 @@ struct NonStupidBitField
         NonStupidBitField<Size>& BitField;
         u32 Idx;
 
-        operator bool()
+        operator bool() const
         {
             return BitField.Data[Idx >> 6] & (1ULL << (Idx & 0x3F));
         }
@@ -62,13 +62,13 @@ struct NonStupidBitField
         u32 BitIdx;
         u64 RemainingBits;
 
-        u32 operator*() { return DataIdx * 64 + BitIdx; }
+        u32 operator*() const { return DataIdx * 64 + BitIdx; }
 
-        bool operator==(const Iterator& other)
+        bool operator==(const Iterator& other) const
         {
             return other.DataIdx == DataIdx;
         }
-        bool operator!=(const Iterator& other)
+        bool operator!=(const Iterator& other) const
         {
             return other.DataIdx != DataIdx;
         }

--- a/src/RTC.cpp
+++ b/src/RTC.cpp
@@ -86,17 +86,17 @@ void RTC::DoSavestate(Savestate* file)
 }
 
 
-u8 RTC::BCD(u8 val)
+u8 RTC::BCD(u8 val) const
 {
     return (val % 10) | ((val / 10) << 4);
 }
 
-u8 RTC::FromBCD(u8 val)
+u8 RTC::FromBCD(u8 val) const
 {
     return (val & 0xF) + ((val >> 4) * 10);
 }
 
-u8 RTC::BCDIncrement(u8 val)
+u8 RTC::BCDIncrement(u8 val) const
 {
     val++;
     if ((val & 0x0F) >= 0x0A)
@@ -106,7 +106,7 @@ u8 RTC::BCDIncrement(u8 val)
     return val;
 }
 
-u8 RTC::BCDSanitize(u8 val, u8 vmin, u8 vmax)
+u8 RTC::BCDSanitize(u8 val, u8 vmin, u8 vmax) const
 {
     if (val < vmin || val > vmax)
         val = vmin;
@@ -119,12 +119,12 @@ u8 RTC::BCDSanitize(u8 val, u8 vmin, u8 vmax)
 }
 
 
-void RTC::GetState(StateData& state)
+void RTC::GetState(StateData& state) const
 {
     memcpy(&state, &State, sizeof(State));
 }
 
-void RTC::SetState(StateData& state)
+void RTC::SetState(const StateData& state)
 {
     memcpy(&State, &state, sizeof(State));
 
@@ -134,7 +134,7 @@ void RTC::SetState(StateData& state)
         WriteDateTime(i+1, State.DateTime[i]);
 }
 
-void RTC::GetDateTime(int& year, int& month, int& day, int& hour, int& minute, int& second)
+void RTC::GetDateTime(int& year, int& month, int& day, int& hour, int& minute, int& second) const
 {
     year = FromBCD(State.DateTime[0]);
     year += 2000;
@@ -374,7 +374,7 @@ void RTC::ProcessIRQ(int type) // 0=minute carry 1=periodic 2=status reg write
 }
 
 
-u8 RTC::DaysInMonth()
+u8 RTC::DaysInMonth() const
 {
     u8 numdays;
 

--- a/src/RTC.h
+++ b/src/RTC.h
@@ -55,9 +55,9 @@ public:
 
     void DoSavestate(Savestate* file);
 
-    void GetState(StateData& state);
-    void SetState(StateData& state);
-    void GetDateTime(int& year, int& month, int& day, int& hour, int& minute, int& second);
+    void GetState(StateData& state) const;
+    void SetState(const StateData& state);
+    void GetDateTime(int& year, int& month, int& day, int& hour, int& minute, int& second) const;
     void SetDateTime(int year, int month, int day, int hour, int minute, int second);
 
     void ClockTimer(u32 param);
@@ -87,16 +87,16 @@ private:
     void ResetState();
     void ScheduleTimer(bool first);
 
-    u8 BCD(u8 val);
-    u8 FromBCD(u8 val);
-    u8 BCDIncrement(u8 val);
-    u8 BCDSanitize(u8 val, u8 vmin, u8 vmax);
+    u8 BCD(u8 val) const;
+    u8 FromBCD(u8 val) const;
+    u8 BCDIncrement(u8 val) const;
+    u8 BCDSanitize(u8 val, u8 vmin, u8 vmax) const;
 
     void SetIRQ(u8 irq);
     void ClearIRQ(u8 irq);
     void ProcessIRQ(int type);
 
-    u8 DaysInMonth();
+    u8 DaysInMonth() const;
     void CountYear();
     void CountMonth();
     void CheckEndOfMonth();

--- a/src/SPI.cpp
+++ b/src/SPI.cpp
@@ -57,7 +57,7 @@ u16 CRC16(const u8* data, u32 len, u32 start)
 
 
 
-bool FirmwareMem::VerifyCRC16(u32 start, u32 offset, u32 len, u32 crcoffset)
+bool FirmwareMem::VerifyCRC16(u32 start, u32 offset, u32 len, u32 crcoffset) const
 {
     u16 crc_stored =  *(u16*)&FirmwareData.Buffer()[crcoffset];
     u16 crc_calced = CRC16(&FirmwareData.Buffer()[offset], len, start);
@@ -154,7 +154,7 @@ void FirmwareMem::SetupDirectBoot()
     }
 }
 
-bool FirmwareMem::IsLoadedFirmwareBuiltIn()
+bool FirmwareMem::IsLoadedFirmwareBuiltIn() const
 {
     return FirmwareData.GetHeader().Identifier == GENERATED_FIRMWARE_IDENTIFIER;
 }
@@ -308,7 +308,7 @@ void PowerMan::DoSavestate(Savestate* file)
     file->VarArray(RegMasks, 8); // is that needed??
 }
 
-bool PowerMan::GetBatteryLevelOkay() { return !Registers[1]; }
+bool PowerMan::GetBatteryLevelOkay() const { return !Registers[1]; }
 void PowerMan::SetBatteryLevelOkay(bool okay) { Registers[1] = okay ? 0x00 : 0x01; }
 
 void PowerMan::Write(u8 val)
@@ -404,7 +404,7 @@ void TSC::SetTouchCoords(u16 x, u16 y)
     NDS.KeyInput &= ~(1 << (16+6));
 }
 
-void TSC::MicInputFrame(s16* data, int samples)
+void TSC::MicInputFrame(const s16* data, int samples)
 {
     if (!data)
     {
@@ -549,7 +549,7 @@ void SPIHost::TransferDone(u32 param)
         NDS.SetIRQ(1, IRQ_SPI);
 }
 
-u8 SPIHost::ReadData()
+u8 SPIHost::ReadData() const
 {
     if (!(Cnt & (1<<15))) return 0;
     if (Cnt & (1<<7)) return 0; // checkme

--- a/src/SPI.h
+++ b/src/SPI.h
@@ -51,7 +51,7 @@ public:
     virtual void Reset() = 0;
     virtual void DoSavestate(Savestate* file) = 0;
 
-    virtual u8 Read() { return Data; }
+    virtual u8 Read() const { return Data; }
     virtual void Write(u8 val) = 0;
     virtual void Release() { Hold = false; DataPos = 0; }
 
@@ -76,7 +76,7 @@ public:
     Firmware& GetFirmware() noexcept { return FirmwareData; }
     [[nodiscard]] const Firmware& GetFirmware() const noexcept { return FirmwareData; }
     void SetFirmware(Firmware&& firmware) { FirmwareData = std::move(firmware); }
-    bool IsLoadedFirmwareBuiltIn();
+    bool IsLoadedFirmwareBuiltIn() const;
 
     void Write(u8 val) override;
     void Release() override;
@@ -89,7 +89,7 @@ private:
     u8 StatusReg;
     u32 Addr;
 
-    bool VerifyCRC16(u32 start, u32 offset, u32 len, u32 crcoffset);
+    bool VerifyCRC16(u32 start, u32 offset, u32 len, u32 crcoffset) const;
 };
 
 class PowerMan : public SPIDevice
@@ -100,7 +100,7 @@ public:
     void Reset() override;
     void DoSavestate(Savestate* file) override;
 
-    bool GetBatteryLevelOkay();
+    bool GetBatteryLevelOkay() const;
     void SetBatteryLevelOkay(bool okay);
 
     void Write(u8 val) override;
@@ -121,7 +121,7 @@ public:
     virtual void DoSavestate(Savestate* file) override;
 
     virtual void SetTouchCoords(u16 x, u16 y);
-    virtual void MicInputFrame(s16* data, int samples);
+    virtual void MicInputFrame(const s16* data, int samples);
 
     virtual void Write(u8 val) override;
 
@@ -148,16 +148,18 @@ public:
     FirmwareMem* GetFirmwareMem() { return (FirmwareMem*)Devices[SPIDevice_FirmwareMem]; }
     const FirmwareMem* GetFirmwareMem() const { return (FirmwareMem*)Devices[SPIDevice_FirmwareMem]; }
     PowerMan* GetPowerMan() { return (PowerMan*)Devices[SPIDevice_PowerMan]; }
+    const PowerMan* GetPowerMan() const { return (PowerMan*)Devices[SPIDevice_PowerMan]; }
     TSC* GetTSC() { return (TSC*)Devices[SPIDevice_TSC]; }
+    const TSC* GetTSC() const { return (TSC*)Devices[SPIDevice_TSC]; }
 
     const Firmware& GetFirmware() const { return GetFirmwareMem()->GetFirmware(); }
     Firmware& GetFirmware() { return GetFirmwareMem()->GetFirmware(); }
     void SetFirmware(Firmware&& firmware) { GetFirmwareMem()->SetFirmware(std::move(firmware)); }
 
-    u16 ReadCnt() { return Cnt; }
+    u16 ReadCnt() const { return Cnt; }
     void WriteCnt(u16 val);
 
-    u8 ReadData();
+    u8 ReadData() const;
     void WriteData(u8 val);
 
     void TransferDone(u32 param);

--- a/src/SPU.cpp
+++ b/src/SPU.cpp
@@ -956,7 +956,7 @@ void SPU::InitOutput()
     Platform::Mutex_Unlock(AudioLock);
 }
 
-int SPU::GetOutputSize()
+int SPU::GetOutputSize() const
 {
     Platform::Mutex_Lock(AudioLock);
 

--- a/src/SPU.h
+++ b/src/SPU.h
@@ -237,7 +237,7 @@ public:
     void TrimOutput();
     void DrainOutput();
     void InitOutput();
-    int GetOutputSize();
+    int GetOutputSize() const;
     void Sync(bool wait);
     int ReadOutput(s16* data, int samples);
     void TransferOutput();

--- a/src/TinyVector.h
+++ b/src/TinyVector.h
@@ -97,7 +97,7 @@ struct __attribute__((packed)) TinyVector
             Data[i] = Data[i + 1];*/
     }
 
-    int Find(T needle)
+    int Find(T needle) const
     {
         for (int i = 0; i < Length; i++)
         {
@@ -121,6 +121,12 @@ struct __attribute__((packed)) TinyVector
     }
 
     T& operator[](int index)
+    {
+        assert(index >= 0 && index < Length);
+        return Data[index];
+    }
+
+    const T& operator[](int index) const
     {
         assert(index >= 0 && index < Length);
         return Data[index];

--- a/src/Wifi.cpp
+++ b/src/Wifi.cpp
@@ -78,12 +78,12 @@ const u8 Wifi::MPAckMAC[6]   = {0x03, 0x09, 0xBF, 0x00, 0x00, 0x03};
 // * TX errors (if applicable)
 
 
-bool MACEqual(u8* a, const u8* b)
+bool MACEqual(const u8* a, const u8* b)
 {
     return (*(u32*)&a[0] == *(u32*)&b[0]) && (*(u16*)&a[4] == *(u16*)&b[4]);
 }
 
-bool MACIsBroadcast(u8* a)
+bool MACIsBroadcast(const u8* a)
 {
     return (*(u32*)&a[0] == 0xFFFFFFFF) && (*(u16*)&a[4] == 0xFFFF);
 }
@@ -440,14 +440,14 @@ void Wifi::PowerDown()
 }
 
 
-int Wifi::PreambleLen(int rate)
+int Wifi::PreambleLen(int rate) const
 {
     if (rate == 1) return 192;
     if (IOPORT(W_Preamble) & 0x0004) return 96;
     return 192;
 }
 
-u32 Wifi::NumClients(u16 bitmask)
+u32 Wifi::NumClients(u16 bitmask) const
 {
     u32 ret = 0;
     for (int i = 1; i < 16; i++)
@@ -457,7 +457,7 @@ u32 Wifi::NumClients(u16 bitmask)
     return ret;
 }
 
-void Wifi::IncrementTXCount(TXSlot* slot)
+void Wifi::IncrementTXCount(const TXSlot* slot)
 {
     u8 cnt = RAM[slot->Addr + 0x4];
     if (cnt < 0xFF) cnt++;
@@ -477,7 +477,7 @@ void Wifi::ReportMPReplyErrors(u16 clientfail)
     }
 }
 
-void Wifi::TXSendFrame(TXSlot* slot, int num)
+void Wifi::TXSendFrame(const TXSlot* slot, int num)
 {
     u32 noseqno = 0;
 
@@ -2258,12 +2258,12 @@ void Wifi::Write(u32 addr, u16 val)
 }
 
 
-u8* Wifi::GetMAC()
+const u8* Wifi::GetMAC() const
 {
     return (u8*)&IOPORT(W_MACAddr0);
 }
 
-u8* Wifi::GetBSSID()
+const u8* Wifi::GetBSSID() const
 {
     return (u8*)&IOPORT(W_BSSID0);
 }

--- a/src/Wifi.h
+++ b/src/Wifi.h
@@ -169,8 +169,8 @@ public:
     u16 Read(u32 addr);
     void Write(u32 addr, u16 val);
 
-    u8* GetMAC();
-    u8* GetBSSID();
+    const u8* GetMAC() const;
+    const u8* GetBSSID() const;
 
 private:
     melonDS::NDS& NDS;
@@ -261,12 +261,12 @@ private:
     void SetStatus(u32 status);
     void PowerDown();
 
-    int PreambleLen(int rate);
-    u32 NumClients(u16 bitmask);
-    void IncrementTXCount(TXSlot* slot);
+    int PreambleLen(int rate) const;
+    u32 NumClients(u16 bitmask) const;
+    void IncrementTXCount(const TXSlot* slot);
     void ReportMPReplyErrors(u16 clientfail);
 
-    void TXSendFrame(TXSlot* slot, int num);
+    void TXSendFrame(const TXSlot* slot, int num);
     void StartTX_LocN(int nslot, int loc);
     void StartTX_Cmd();
     void StartTX_Beacon();

--- a/src/WifiAP.cpp
+++ b/src/WifiAP.cpp
@@ -66,8 +66,8 @@ const u8 WifiAP::APMac[6] = {0x00, 0xF0, 0x77, 0x77, 0x77, 0x77};
 #define PALIGN_4(p, base)  while (PLEN(p,base) & 0x3) *p++ = 0xFF;
 
 
-bool MACEqual(u8* a, const u8* b);
-bool MACIsBroadcast(u8* a);
+bool MACEqual(const u8* a, const u8* b);
+bool MACIsBroadcast(const u8* a);
 
 
 WifiAP::WifiAP(Wifi* client) : Client(client)
@@ -107,7 +107,7 @@ void WifiAP::MSTimer()
 }
 
 
-int WifiAP::HandleManagementFrame(u8* data, int len)
+int WifiAP::HandleManagementFrame(const u8* data, int len)
 {
     // TODO: perfect this
     // noting that frames sent pre-auth/assoc don't have a proper BSSID
@@ -258,7 +258,7 @@ int WifiAP::HandleManagementFrame(u8* data, int len)
 }
 
 
-int WifiAP::SendPacket(u8* data, int len)
+int WifiAP::SendPacket(const u8* data, int len)
 {
     data += 12;
 

--- a/src/WifiAP.h
+++ b/src/WifiAP.h
@@ -38,7 +38,7 @@ public:
     void MSTimer();
 
     // packet format: 12-byte TX header + original 802.11 frame
-    int SendPacket(u8* data, int len);
+    int SendPacket(const u8* data, int len);
     int RecvPacket(u8* data);
 
 private:
@@ -60,7 +60,7 @@ private:
     // 0=disconnected 1=authenticated 2=associated
     int ClientStatus;
 
-    int HandleManagementFrame(u8* data, int len);
+    int HandleManagementFrame(const u8* data, int len);
 };
 
 }


### PR DESCRIPTION
- This will make it easier to use `NDS` objects in `const` contexts (e.g. `const` parameters or methods)