### PR TITLE
WIP - Revamp SW Renderer to Support Timings, and Obscure Scanline Glitches

### DIFF
--- a/src/GPU3D.cpp
+++ b/src/GPU3D.cpp
@@ -781,16 +781,16 @@ bool GPU3D::DoTimings(s32 cycles, bool odd)
     if (odd)
     {
         RasterTimingCounterOdd += cycles;
-        if ((RasterTimingCounterOdd + RasterTimingCounterPrev) < RasterTimingCap) return 0;
+        if ((RasterTimingCounterOdd + RasterTimingCounterPrev) < RasterTimingCap) return false;
     }
     else
     {
         RasterTimingCounterEven += cycles;
-        if ((RasterTimingCounterEven + RasterTimingCounterPrev) < RasterTimingCap) return 0;
+        if ((RasterTimingCounterEven + RasterTimingCounterPrev) < RasterTimingCap) return false;
     }
 
     DispCnt |= (1<<12);
-    return 1;
+    return true;
 }
 
 void GPU3D::EndScanline(bool odd)
@@ -805,7 +805,7 @@ void GPU3D::EndScanline(bool odd)
         // seems to display the lowest scanline buffer count reached during the current frame.
         // we also caps it to 46 here, because this reg does that too for some reason.
         if (RDLines > RDLinesMin) RDLines = RDLinesMin;
-        if (RDLines < RDLinesMin) RDLinesMin = RDLines;
+        else if (RDLines < RDLinesMin) RDLinesMin = RDLines;
         RasterTimingCounterOdd = 0;
         RasterTimingCounterEven = 0;
     }

--- a/src/GPU3D.cpp
+++ b/src/GPU3D.cpp
@@ -221,6 +221,12 @@ void GPU3D::Reset() noexcept
     DispCnt = 0;
     AlphaRefVal = 0;
     AlphaRef = 0;
+    
+    RDLines = 46;
+    RDLinesMin = 46;
+    RasterTimingCounterPrev = 0;
+    RasterTimingCounterOdd = 0;
+    RasterTimingCounterEven = 0;
 
     memset(ToonTable, 0, sizeof(ToonTable));
     memset(EdgeTable, 0, sizeof(EdgeTable));
@@ -770,7 +776,40 @@ void GPU3D::StallPolygonPipeline(s32 delay, s32 nonstalldelay) noexcept
     }
 }
 
+bool GPU3D::DoTimings(s32 cycles, bool odd)
+{
+    if (odd)
+    {
+        RasterTimingCounterOdd += cycles;
+        if ((RasterTimingCounterOdd + RasterTimingCounterPrev) < RasterTimingCap) return 0;
+    }
+    else
+    {
+        RasterTimingCounterEven += cycles;
+        if ((RasterTimingCounterEven + RasterTimingCounterPrev) < RasterTimingCap) return 0;
+    }
 
+    DispCnt |= (1<<12);
+    return 1;
+}
+
+void GPU3D::EndScanline(bool odd)
+{
+    if (!odd)
+    {
+        RasterTimingCounterPrev += std::max(RasterTimingCounterOdd, RasterTimingCounterEven);
+        RasterTimingCounterPrev -= PerScanlineRecup; // wip
+        if (RasterTimingCounterPrev < 0) RasterTimingCounterPrev = 0;
+        // calc is wrong, seems to round up...?
+        RDLines = (RasterTimingCap - RasterTimingCounterPrev) / PerScanlineTiming;
+        // seems to display the lowest scanline buffer count reached during the current frame.
+        // we also caps it to 46 here, because this reg does that too for some reason.
+        if (RDLines > RDLinesMin) RDLines = RDLinesMin;
+        if (RDLines < RDLinesMin) RDLinesMin = RDLines;
+        RasterTimingCounterOdd = 0;
+        RasterTimingCounterEven = 0;
+    }
+}
 
 template<int comp, s32 plane, bool attribs>
 void ClipSegment(Vertex* outbuf, Vertex* vin, Vertex* vout)
@@ -2369,6 +2408,10 @@ void GPU3D::CheckFIFODMA() noexcept
 
 void GPU3D::VCount144() noexcept
 {
+    RDLinesMin = 46;
+    RasterTimingCounterPrev = 0;
+    RasterTimingCounterOdd = 0;
+    RasterTimingCounterEven = 0;
     CurrentRenderer->VCount144();
 }
 
@@ -2612,7 +2655,7 @@ u16 GPU3D::Read16(u32 addr) noexcept
         return DispCnt;
 
     case 0x04000320:
-        return 46; // TODO, eventually
+        return RDLines; // IT IS TIME
 
     case 0x04000600:
         {
@@ -2656,7 +2699,7 @@ u32 GPU3D::Read32(u32 addr) noexcept
         return DispCnt;
 
     case 0x04000320:
-        return 46; // TODO, eventually
+        return RDLines; // IT IS TIME
 
     case 0x04000600:
         {

--- a/src/GPU3D.h
+++ b/src/GPU3D.h
@@ -32,12 +32,12 @@ class GPU;
 
 // numbers based on 339 poly 64-172 horiz. line poly
 static constexpr int RasterTimingCap = 51116;
-static constexpr int PerPolyTiming = 12;
-static constexpr int PerScanlineTiming = 1064;
-static constexpr int PerScanlineRecup = 2010;//1910; 
+static constexpr int PerPolyTiming = 12; // should be correct for *most* line polygons
+static constexpr int PerPixelTiming = 1; // does not apply to the first 4 pixels in a polygon (per scanline?)
+static constexpr int PerScanlineTiming = 1064;// approximate currently, used to calc RDLines
+static constexpr int PerScanlineRecup = 2112; // seems to check out?
 //static constexpr int EmptyPolyScanline;
 //static constexpr int FirstPixelTiming;
-static constexpr int PerPixelTiming = 1;
 
 struct Vertex
 {

--- a/src/GPU3D.h
+++ b/src/GPU3D.h
@@ -25,9 +25,19 @@
 #include "Savestate.h"
 #include "FIFO.h"
 
+
 namespace melonDS
 {
 class GPU;
+
+// numbers based on 339 poly 64-172 horiz. line poly
+static constexpr int RasterTimingCap = 51116;
+static constexpr int PerPolyTiming = 12;
+static constexpr int PerScanlineTiming = 1064;
+static constexpr int PerScanlineRecup = 2010;//1910; 
+//static constexpr int EmptyPolyScanline;
+//static constexpr int FirstPixelTiming;
+static constexpr int PerPixelTiming = 1;
 
 struct Vertex
 {
@@ -114,6 +124,9 @@ public:
 
     void WriteToGXFIFO(u32 val) noexcept;
 
+    bool DoTimings(s32 cycles, bool odd);
+    void EndScanline(bool odd);
+
     [[nodiscard]] bool IsRendererAccelerated() const noexcept;
     [[nodiscard]] Renderer3D& GetCurrentRenderer() noexcept { return *CurrentRenderer; }
     [[nodiscard]] const Renderer3D& GetCurrentRenderer() const noexcept { return *CurrentRenderer; }
@@ -126,6 +139,7 @@ public:
     void Write16(u32 addr, u16 val) noexcept;
     void Write32(u32 addr, u32 val) noexcept;
     void Blit() noexcept;
+
 private:
     melonDS::NDS& NDS;
     typedef union
@@ -242,6 +256,11 @@ public:
     bool RenderingEnabled = false;
 
     u32 DispCnt = 0;
+    u32 RDLines = 0;
+    u32 RDLinesMin = 0;
+    s32 RasterTimingCounterPrev = 0;
+    s32 RasterTimingCounterOdd = 0;
+    s32 RasterTimingCounterEven = 0;
     u8 AlphaRefVal = 0;
     u8 AlphaRef = 0;
 

--- a/src/GPU3D.h
+++ b/src/GPU3D.h
@@ -116,9 +116,6 @@ public:
 
     void WriteToGXFIFO(u32 val) noexcept;
 
-    bool DoTimings(s32 cycles, bool odd);
-    void EndScanline(bool odd);
-
     [[nodiscard]] bool IsRendererAccelerated() const noexcept;
     [[nodiscard]] Renderer3D& GetCurrentRenderer() noexcept { return *CurrentRenderer; }
     [[nodiscard]] const Renderer3D& GetCurrentRenderer() const noexcept { return *CurrentRenderer; }
@@ -250,9 +247,6 @@ public:
     u32 DispCnt = 0;
     u32 RDLines = 0;
     u32 RDLinesMin = 0;
-    s32 RasterTimingCounterPrev = 0;
-    s32 RasterTimingCounterOdd = 0;
-    s32 RasterTimingCounterEven = 0;
     u8 AlphaRefVal = 0;
     u8 AlphaRef = 0;
 
@@ -342,7 +336,7 @@ public:
     static constexpr int RasterTimingCap = 51116*Frac;
     static constexpr int PerScanlineTiming = 1064*Frac; // approximate currently, used to calc RDLines. TEMPORARY UNTIL ACCURATE "FRAMEBUFFER" CAN BE IMPLEMENTED
     static constexpr int PerScanlineRecup = 2112*Frac; // seems to check out?
-
+    static constexpr int PerRightSlope = 1*Frac;
     static constexpr int PerPolyTiming = 12*Frac; // should be correct for *most* line polygons and polygons with vertical slopes
     static constexpr int PerPixelTiming = 1*Frac; // does not apply to the first 4 pixels in a polygon (per scanline?)
     static constexpr int EmptyPolyScanline = 4*Frac - 14; // seems to be slightly under 4?

--- a/src/GPU3D.h
+++ b/src/GPU3D.h
@@ -30,14 +30,6 @@ namespace melonDS
 {
 class GPU;
 
-// numbers based on 339 poly 64-172 horiz. line poly
-static constexpr int RasterTimingCap = 51116;
-static constexpr int PerPolyTiming = 12; // should be correct for *most* line polygons
-static constexpr int PerPixelTiming = 1; // does not apply to the first 4 pixels in a polygon (per scanline?)
-static constexpr int PerScanlineTiming = 1064;// approximate currently, used to calc RDLines
-static constexpr int PerScanlineRecup = 2112; // seems to check out?
-//static constexpr int EmptyPolyScanline;
-//static constexpr int FirstPixelTiming;
 
 struct Vertex
 {
@@ -344,6 +336,17 @@ public:
     u32 FlushAttributes = 0;
     u32 ScrolledLine[256];
 };
+
+    // numbers based on 339 poly 64-172 horiz. line poly
+    static constexpr int Frac = 481; // add a fractional component if pixels is not enough precision
+    static constexpr int RasterTimingCap = 51116*Frac;
+    static constexpr int PerScanlineTiming = 1064*Frac; // approximate currently, used to calc RDLines. TEMPORARY UNTIL ACCURATE "FRAMEBUFFER" CAN BE IMPLEMENTED
+    static constexpr int PerScanlineRecup = 2112*Frac; // seems to check out?
+
+    static constexpr int PerPolyTiming = 12*Frac; // should be correct for *most* line polygons and polygons with vertical slopes
+    static constexpr int PerPixelTiming = 1*Frac; // does not apply to the first 4 pixels in a polygon (per scanline?)
+    static constexpr int EmptyPolyScanline = 4*Frac - 14; // seems to be slightly under 4?
+    //static constexpr int FirstPixelTiming;
 
 class Renderer3D
 {

--- a/src/GPU3D_Soft.h
+++ b/src/GPU3D_Soft.h
@@ -461,7 +461,7 @@ private:
     void SetupPolygonRightEdge(RendererPolygon* rp, s32 y);
     void SetupPolygon(RendererPolygon* rp, Polygon* polygon);
     void RenderShadowMaskScanline(RendererPolygon* rp, s32 y);
-    void RenderPolygonScanline(RendererPolygon* rp, s32 y);
+    void RenderPolygonScanline(RendererPolygon* rp, s32 y, bool odd);
     void RenderScanline(s32 y, int npolys);
     u32 CalculateFogDensity(u32 pixeladdr);
     void ScanlineFinalPass(s32 y);
@@ -476,14 +476,17 @@ private:
     // TODO: check if the hardware can accidentally plot pixels
     // offscreen in that border
 
-    static constexpr int ScanlineWidth = 258;
-    static constexpr int NumScanlines = 194;
+    static constexpr int ScanlineWidth = 256;
+    static constexpr int NumScanlines = 192;
+    static constexpr int NumScanlinesRDLines = 192;
+    static constexpr int RDLinesBufferSize = ScanlineWidth * NumScanlinesRDLines;
     static constexpr int BufferSize = ScanlineWidth * NumScanlines;
     static constexpr int FirstPixelOffset = ScanlineWidth + 1;
 
-    u32 ColorBuffer[BufferSize * 2];
-    u32 DepthBuffer[BufferSize * 2];
-    u32 AttrBuffer[BufferSize * 2];
+    u32 ColorBuffer[RDLinesBufferSize * 2];
+    u32 DepthBuffer[RDLinesBufferSize * 2];
+    u32 AttrBuffer[RDLinesBufferSize * 2];
+    u32 FinalBuffer[BufferSize * 2];
 
     // attribute buffer:
     // bit0-3: edge flags (left/right/top/bottom)

--- a/src/GPU3D_Soft.h
+++ b/src/GPU3D_Soft.h
@@ -460,8 +460,10 @@ private:
     void SetupPolygonLeftEdge(RendererPolygon* rp, s32 y);
     void SetupPolygonRightEdge(RendererPolygon* rp, s32 y);
     void SetupPolygon(RendererPolygon* rp, Polygon* polygon);
+    bool Step(RendererPolygon* rp, bool abortscanline);
+    void CheckSlope(RendererPolygon* rp, s32 y);
     void RenderShadowMaskScanline(RendererPolygon* rp, s32 y);
-    void RenderPolygonScanline(RendererPolygon* rp, s32 y, bool odd);
+    bool RenderPolygonScanline(RendererPolygon* rp, s32 y, bool odd);
     void RenderScanline(s32 y, int npolys);
     u32 CalculateFogDensity(u32 pixeladdr);
     void ScanlineFinalPass(s32 y);

--- a/src/GPU3D_Soft.h
+++ b/src/GPU3D_Soft.h
@@ -476,9 +476,9 @@ private:
     // TODO: check if the hardware can accidentally plot pixels
     // offscreen in that border
 
-    static constexpr int ScanlineWidth = 256;
-    static constexpr int NumScanlines = 192;
-    static constexpr int NumScanlinesRDLines = 192;
+    static constexpr int ScanlineWidth = 258;
+    static constexpr int NumScanlines = 194;
+    static constexpr int NumScanlinesRDLines = 194;
     static constexpr int RDLinesBufferSize = ScanlineWidth * NumScanlinesRDLines;
     static constexpr int BufferSize = ScanlineWidth * NumScanlines;
     static constexpr int FirstPixelOffset = ScanlineWidth + 1;


### PR DESCRIPTION
This PR is a WIP effort to do a light revamp of the software renderer to support rasterization timings, and some niche glitches with the 3D GPU.

This should allow for, in the future:
Proper emulation of the Rendered Line Count register, and bit 12 of the 3D Display Control register.
Proper emulation of obscure scanline glitches, such as scanlines being delayed 48 scanlines and mayyybe the bug where the rasterizer completely breaks.
Weird edge marking quirks.

Benefits: Homebrew development, currently no emulators implement an approximation of rasterizer timings.

Todo:
better understanding of timings including: right slopes, translucency, the top 50 scanlines, etc.
better emulation of glitchy behavior.

Current performance hit: about 10% in 3d rendering heavy scenarios?
...Not ideal. Hopefully can be improved somehow, or otherwise made optional.