### PR TITLE
Simplify the SRAM's representation in  `NDSCartArgs`

### DIFF
--- a/src/NDSCart.cpp
+++ b/src/NDSCart.cpp
@@ -404,7 +404,11 @@ CartRetail::CartRetail(std::unique_ptr<u8[]>&& rom, u32 len, u32 chipid, bool ba
         { // Copy in what we can, truncate the rest.
             SRAM = std::make_unique<u8[]>(SRAMLength);
             memset(SRAM.get(), 0xFF, SRAMLength);
-            memcpy(SRAM.get(), sram.get(), std::min(sramlen, SRAMLength));
+
+            if (sram)
+            { // If we have anything to copy, that is.
+                memcpy(SRAM.get(), sram.get(), std::min(sramlen, SRAMLength));
+            }
         }
     }
 

--- a/src/NDSCart.cpp
+++ b/src/NDSCart.cpp
@@ -1642,7 +1642,8 @@ std::unique_ptr<CartCommon> ParseROM(std::unique_ptr<u8[]>&& romdata, u32 romlen
     }
 
     std::unique_ptr<CartCommon> cart;
-    auto [sram, sramlen] = args ? std::move(*args->SRAM) : std::make_pair(nullptr, 0);
+    std::unique_ptr<u8[]> sram = args ? std::move(args->SRAM) : nullptr;
+    u32 sramlen = args ? args->SRAMLength : 0;
     if (homebrew)
         cart = std::make_unique<CartHomebrew>(std::move(cartrom), cartromsize, cartid, romparams, args ? std::move(args->SDCard) : std::nullopt);
     else if (cartid & 0x08000000)

--- a/src/NDSCart.h
+++ b/src/NDSCart.h
@@ -61,9 +61,14 @@ struct NDSCartArgs
     std::optional<FATStorageArgs> SDCard = std::nullopt;
 
     /// Save RAM to load into the cartridge.
-    /// If \c nullopt, then the cart's SRAM buffer will be empty.
+    /// If \c nullptr, then the cart's SRAM buffer will be empty.
     /// Ignored for homebrew ROMs.
-    std::optional<std::pair<std::unique_ptr<u8[]>, u32>> SRAM = std::nullopt;
+    std::unique_ptr<u8[]> SRAM = nullptr;
+
+    /// The length of the buffer in SRAM.
+    /// If 0, then the cart's SRAM buffer will be empty.
+    /// Ignored for homebrew ROMs.
+    u32 SRAMLength = 0;
 };
 
 // CartCommon -- base code shared by all cart types

--- a/src/frontend/qt_sdl/ROMManager.cpp
+++ b/src/frontend/qt_sdl/ROMManager.cpp
@@ -1316,8 +1316,8 @@ bool LoadROM(EmuThread* emuthread, QStringList filepath, bool reset)
         // the ROM is homebrew or not.
         // So this is the card we *would* load if the ROM were homebrew.
         .SDCard = GetDLDISDCardArgs(),
-
-        .SRAM = std::make_pair(std::move(savedata), savelen),
+        .SRAM = std::move(savedata),
+        .SRAMLength = savelen,
     };
 
     auto cart = NDSCart::ParseROM(std::move(filedata), filelen, std::move(cartargs));


### PR DESCRIPTION
When all you have is a hammer, everything looks like a nail...

I overthought this one. I could've just checked `args && args->SRAM`, but then some other poor bastard might make this mistake. Don't mix `pair`, `optional`, and `unique_ptr` all at once, kids.

This PR resolves a crash in melonDS DS that occurs when loading a game without any available save data. It doesn't occur in upstream melonDS because it uses a different constructor overload than I do.