### PR TITLE
Encapsulate both network implementations into objects

### DIFF
--- a/src/frontend/qt_sdl/LAN_PCap.cpp
+++ b/src/frontend/qt_sdl/LAN_PCap.cpp
@@ -387,7 +387,7 @@ LAN_PCap::LAN_PCap(const PCap& pcap, const AdapterData& data, pcap_t* adapter) n
 
 LAN_PCap::~LAN_PCap() noexcept
 {
-    if (PCapAdapter)
+    if (PCapAdapter && pcap_close)
     {
         pcap_close(PCapAdapter);
         PCapAdapter = nullptr;

--- a/src/frontend/qt_sdl/LAN_PCap.cpp
+++ b/src/frontend/qt_sdl/LAN_PCap.cpp
@@ -50,23 +50,7 @@ using Platform::LogLevel;
 #define PCAP_OPENFLAG_PROMISCUOUS 1
 #endif
 
-
-#define DECL_PCAP_FUNC(ret, name, args, args2) \
-    typedef ret (*type_##name) args; \
-    type_##name ptr_##name = NULL; \
-    ret name args { return ptr_##name args2; }
-
-DECL_PCAP_FUNC(int, pcap_findalldevs, (pcap_if_t** alldevs, char* errbuf), (alldevs,errbuf))
-DECL_PCAP_FUNC(void, pcap_freealldevs, (pcap_if_t* alldevs), (alldevs))
-DECL_PCAP_FUNC(pcap_t*, pcap_open_live, (const char* src, int snaplen, int flags, int readtimeout, char* errbuf), (src,snaplen,flags,readtimeout,errbuf))
-DECL_PCAP_FUNC(void, pcap_close, (pcap_t* dev), (dev))
-DECL_PCAP_FUNC(int, pcap_setnonblock, (pcap_t* dev, int nonblock, char* errbuf), (dev,nonblock,errbuf))
-DECL_PCAP_FUNC(int, pcap_sendpacket, (pcap_t* dev, const u_char* data, int len), (dev,data,len))
-DECL_PCAP_FUNC(int, pcap_dispatch, (pcap_t* dev, int num, pcap_handler callback, u_char* data), (dev,num,callback,data))
-DECL_PCAP_FUNC(const u_char*, pcap_next, (pcap_t* dev, struct pcap_pkthdr* hdr), (dev,hdr))
-
-
-namespace LAN_PCap
+namespace melonDS
 {
 
 const char* PCapLibNames[] =
@@ -85,23 +69,11 @@ const char* PCapLibNames[] =
     NULL
 };
 
-AdapterData* Adapters = NULL;
-int NumAdapters = 0;
-
-Platform::DynamicLibrary* PCapLib = NULL;
-pcap_t* PCapAdapter = NULL;
-AdapterData* PCapAdapterData;
-
-u8 PacketBuffer[2048];
-int PacketLen;
-volatile int RXNum;
-
-
 #define LOAD_PCAP_FUNC(sym) \
-    ptr_##sym = (type_##sym)DynamicLibrary_LoadFunction(lib, #sym); \
-    if (!ptr_##sym) return false;
+    sym = (sym##_t)DynamicLibrary_LoadFunction(lib, #sym); \
+    if (!sym) return false;
 
-bool TryLoadPCap(Platform::DynamicLibrary *lib)
+bool PCap::TryLoadPCap(Platform::DynamicLibrary *lib) noexcept
 {
     LOAD_PCAP_FUNC(pcap_findalldevs)
     LOAD_PCAP_FUNC(pcap_freealldevs)
@@ -110,129 +82,107 @@ bool TryLoadPCap(Platform::DynamicLibrary *lib)
     LOAD_PCAP_FUNC(pcap_setnonblock)
     LOAD_PCAP_FUNC(pcap_sendpacket)
     LOAD_PCAP_FUNC(pcap_dispatch)
-    LOAD_PCAP_FUNC(pcap_next)
 
+    PCapLib = lib;
     return true;
 }
 
-bool Init(bool open_adapter)
+std::optional<PCap> PCap::New() noexcept
 {
-    PCapAdapter = NULL;
-    PacketLen = 0;
-    RXNum = 0;
-
-    NumAdapters = 0;
+    PCap pcap;
 
     // TODO: how to deal with cases where an adapter is unplugged or changes config??
-    if (!PCapLib)
+
+    for (int i = 0; PCapLibNames[i]; i++)
     {
-        PCapLib = NULL;
+        Platform::DynamicLibrary* lib = Platform::DynamicLibrary_Load(PCapLibNames[i]);
+        if (!lib) continue;
 
-        for (int i = 0; PCapLibNames[i]; i++)
+        if (!pcap.TryLoadPCap(lib))
         {
-            Platform::DynamicLibrary* lib = Platform::DynamicLibrary_Load(PCapLibNames[i]);
-            if (!lib) continue;
-
-            if (!TryLoadPCap(lib))
-            {
-                Platform::DynamicLibrary_Unload(lib);
-                continue;
-            }
-
-            Log(LogLevel::Info, "PCap: lib %s, init successful\n", PCapLibNames[i]);
-            PCapLib = lib;
-            break;
+            Platform::DynamicLibrary_Unload(lib);
+            continue;
         }
 
-        if (PCapLib == NULL)
-        {
-            Log(LogLevel::Error, "PCap: init failed\n");
-            return false;
-        }
+        Log(LogLevel::Info, "PCap: lib %s, init successful\n", PCapLibNames[i]);
+        break;
     }
 
-    char errbuf[PCAP_ERRBUF_SIZE];
-    int ret;
+    if (pcap.PCapLib == nullptr)
+    {
+        Log(LogLevel::Error, "PCap: init failed\n");
+        return std::nullopt;
+    }
 
-    pcap_if_t* alldevs;
-    ret = pcap_findalldevs(&alldevs, errbuf);
-    if (ret < 0 || alldevs == NULL)
+    char errbuf[PCAP_ERRBUF_SIZE] {};
+    if (pcap.pcap_findalldevs(&pcap.AllDevices, errbuf) < 0 || pcap.AllDevices == nullptr)
     {
         Log(LogLevel::Warn, "PCap: no devices available\n");
-        return false;
+        return std::nullopt;
     }
 
-    pcap_if_t* dev = alldevs;
-    while (dev) { NumAdapters++; dev = dev->next; }
-
-    Adapters = new AdapterData[NumAdapters];
-    memset(Adapters, 0, sizeof(AdapterData)*NumAdapters);
-
-    AdapterData* adata = &Adapters[0];
-    dev = alldevs;
-    while (dev)
+    for (pcap_if_t* dev = pcap.AllDevices; dev != nullptr; dev = dev->next)
     {
-        adata->Internal = dev;
+        AdapterData adata {};
+        adata.Internal = dev;
 
 #ifdef __WIN32__
         // hax
         int len = strlen(dev->name);
         len -= 12; if (len > 127) len = 127;
-        strncpy(adata->DeviceName, &dev->name[12], len);
-        adata->DeviceName[len] = '\0';
+        strncpy(adata.DeviceName, &dev->name[12], len);
+        adata.DeviceName[len] = '\0';
 #else
-        strncpy(adata->DeviceName, dev->name, 127);
-        adata->DeviceName[127] = '\0';
+        strncpy(adata.DeviceName, dev->name, 127);
+        adata.DeviceName[127] = '\0';
 
-        strncpy(adata->FriendlyName, adata->DeviceName, 127);
-        adata->FriendlyName[127] = '\0';
+        strncpy(adata.FriendlyName, adata.DeviceName, 127);
+        adata.FriendlyName[127] = '\0';
 #endif // __WIN32__
 
-        dev = dev->next;
-        adata++;
+        pcap.Adapters.push_back(adata);
     }
 
 #ifdef __WIN32__
 
     ULONG bufsize = 16384;
     IP_ADAPTER_ADDRESSES* buf = (IP_ADAPTER_ADDRESSES*)HeapAlloc(GetProcessHeap(), 0, bufsize);
-    ULONG uret = GetAdaptersAddresses(AF_INET, 0, NULL, buf, &bufsize);
+    ULONG uret = GetAdaptersAddresses(AF_INET, 0, nullptr, buf, &bufsize);
     if (uret == ERROR_BUFFER_OVERFLOW)
     {
         HeapFree(GetProcessHeap(), 0, buf);
         buf = (IP_ADAPTER_ADDRESSES*)HeapAlloc(GetProcessHeap(), 0, bufsize);
-        uret = GetAdaptersAddresses(AF_INET, 0, NULL, buf, &bufsize);
+        uret = GetAdaptersAddresses(AF_INET, 0, nullptr, buf, &bufsize);
     }
     if (uret != ERROR_SUCCESS)
     {
         Log(LogLevel::Error, "GetAdaptersAddresses() shat itself: %08X\n", uret);
-        return false;
+        return std::nullopt;
     }
 
-    for (int i = 0; i < NumAdapters; i++)
+    for (AdapterData& adata : pcap.Adapters)
     {
-        adata = &Adapters[i];
         IP_ADAPTER_ADDRESSES* addr = buf;
         while (addr)
         {
-            if (strcmp(addr->AdapterName, adata->DeviceName))
+            if (strcmp(addr->AdapterName, adata.DeviceName))
             {
                 addr = addr->Next;
                 continue;
             }
 
-            WideCharToMultiByte(CP_UTF8, 0, addr->FriendlyName, 127, adata->FriendlyName, 127, NULL, NULL);
-            adata->FriendlyName[127] = '\0';
+            WideCharToMultiByte(CP_UTF8, 0, addr->FriendlyName, 127, adata.FriendlyName, 127, nullptr, nullptr);
+            adata.FriendlyName[127] = '\0';
 
-            WideCharToMultiByte(CP_UTF8, 0, addr->Description, 127, adata->Description, 127, NULL, NULL);
-            adata->Description[127] = '\0';
+            WideCharToMultiByte(CP_UTF8, 0, addr->Description, 127, adata.Description, 127, nullptr, nullptr);
+            adata.Description[127] = '\0';
 
             if (addr->PhysicalAddressLength != 6)
             {
                 Log(LogLevel::Warn, "weird MAC addr length %d for %s\n", addr->PhysicalAddressLength, addr->AdapterName);
             }
             else
-                memcpy(adata->MAC, addr->PhysicalAddress, 6);
+                memcpy(adata.MAC, addr->PhysicalAddress, 6);
 
             IP_ADAPTER_UNICAST_ADDRESS* ipaddr = addr->FirstUnicastAddress;
             while (ipaddr)
@@ -241,7 +191,7 @@ bool Init(bool open_adapter)
                 if (sa->sa_family == AF_INET)
                 {
                     struct in_addr sa4 = ((sockaddr_in*)sa)->sin_addr;
-                    memcpy(adata->IP_v4, &sa4, 4);
+                    memcpy(adata.IP_v4, &sa4, 4);
                 }
 
                 ipaddr = ipaddr->Next;
@@ -259,6 +209,7 @@ bool Init(bool open_adapter)
     if (getifaddrs(&addrs) != 0)
     {
         Log(LogLevel::Error, "getifaddrs() shat itself :(\n");
+        pcap.pcap_freealldevs(alldevs);
         return false;
     }
 
@@ -287,7 +238,7 @@ bool Init(bool open_adapter)
                 struct sockaddr_in* sa = (sockaddr_in*)curaddr->ifa_addr;
                 memcpy(adata->IP_v4, &sa->sin_addr, 4);
             }
-            #ifdef __linux__
+#ifdef __linux__
             else if (af == AF_PACKET)
             {
                 struct sockaddr_ll* sa = (sockaddr_ll*)curaddr->ifa_addr;
@@ -296,7 +247,7 @@ bool Init(bool open_adapter)
                 else
                     memcpy(adata->MAC, sa->sll_addr, 6);
             }
-            #else
+#else
             else if (af == AF_LINK)
             {
                 struct sockaddr_dl* sa = (sockaddr_dl*)curaddr->ifa_addr;
@@ -305,7 +256,7 @@ bool Init(bool open_adapter)
                 else
                     memcpy(adata->MAC, LLADDR(sa), 6);
             }
-            #endif
+#endif
             curaddr = curaddr->ifa_next;
         }
     }
@@ -314,67 +265,140 @@ bool Init(bool open_adapter)
 
 #endif // __WIN32__
 
-    if (!open_adapter) return true;
-    if (PCapAdapter) pcap_close(PCapAdapter);
-
-    // open pcap device
-    PCapAdapterData = &Adapters[0];
-    for (int i = 0; i < NumAdapters; i++)
-    {
-        if (!strncmp(Adapters[i].DeviceName, Config::LANDevice.c_str(), 128))
-            PCapAdapterData = &Adapters[i];
-    }
-
-    dev = (pcap_if_t*)PCapAdapterData->Internal;
-    PCapAdapter = pcap_open_live(dev->name, 2048, PCAP_OPENFLAG_PROMISCUOUS, 1, errbuf);
-    if (!PCapAdapter)
-    {
-        Log(LogLevel::Error, "PCap: failed to open adapter %s\n", errbuf);
-        return false;
-    }
-
-    pcap_freealldevs(alldevs);
-
-    if (pcap_setnonblock(PCapAdapter, 1, errbuf) < 0)
-    {
-        Log(LogLevel::Error, "PCap: failed to set nonblocking mode\n");
-        pcap_close(PCapAdapter); PCapAdapter = NULL;
-        return false;
-    }
-
-    return true;
+    return std::make_optional(std::move(pcap));
 }
 
-void DeInit()
+PCap::PCap(PCap&& other) noexcept :
+    Adapters(std::move(other.Adapters)),
+    PCapLib(other.PCapLib),
+    AllDevices(other.AllDevices),
+    pcap_findalldevs(other.pcap_findalldevs),
+    pcap_freealldevs(other.pcap_freealldevs),
+    pcap_open_live(other.pcap_open_live),
+    pcap_close(other.pcap_close),
+    pcap_setnonblock(other.pcap_setnonblock),
+    pcap_sendpacket(other.pcap_sendpacket),
+    pcap_dispatch(other.pcap_dispatch)
+{
+    other.PCapLib = nullptr;
+    other.AllDevices = nullptr;
+    other.pcap_close = nullptr;
+    other.pcap_dispatch = nullptr;
+    other.pcap_findalldevs = nullptr;
+    other.pcap_freealldevs = nullptr;
+    other.pcap_open_live = nullptr;
+    other.pcap_sendpacket = nullptr;
+    other.pcap_setnonblock = nullptr;
+}
+
+PCap& PCap::operator=(PCap&& other) noexcept
+{
+    if (this != &other)
+    {
+        Adapters = std::move(other.Adapters);
+        if (AllDevices)
+        {
+            pcap_freealldevs(AllDevices);
+        }
+        if (PCapLib)
+        {
+            Platform::DynamicLibrary_Unload(PCapLib);
+        }
+        PCapLib = other.PCapLib;
+        AllDevices = other.AllDevices;
+        pcap_close = other.pcap_close;
+        pcap_dispatch = other.pcap_dispatch;
+        pcap_findalldevs = other.pcap_findalldevs;
+        pcap_freealldevs = other.pcap_freealldevs;
+        pcap_open_live = other.pcap_open_live;
+        pcap_sendpacket = other.pcap_sendpacket;
+        pcap_setnonblock = other.pcap_setnonblock;
+
+        other.pcap_close = nullptr;
+        other.pcap_dispatch = nullptr;
+        other.pcap_findalldevs = nullptr;
+        other.pcap_freealldevs = nullptr;
+        other.pcap_open_live = nullptr;
+        other.pcap_sendpacket = nullptr;
+        other.pcap_setnonblock = nullptr;
+        other.PCapLib = nullptr;
+        other.AllDevices = nullptr;
+    }
+
+    return *this;
+}
+
+PCap::~PCap() noexcept
 {
     if (PCapLib)
     {
-        if (PCapAdapter)
+        if (AllDevices)
         {
-            pcap_close(PCapAdapter);
-            PCapAdapter = NULL;
+            pcap_freealldevs(AllDevices);
+            AllDevices = nullptr;
         }
 
         Platform::DynamicLibrary_Unload(PCapLib);
-        PCapLib = NULL;
+        PCapLib = nullptr;
     }
 }
 
 
-void RXCallback(u_char* blarg, const struct pcap_pkthdr* header, const u_char* data)
+std::optional<LAN_PCap> PCap::OpenAdapter(const AdapterData& landevice) noexcept
 {
-    while (RXNum > 0);
+    char errbuf[PCAP_ERRBUF_SIZE] {};
+
+    // open pcap device
+    pcap_t* adapter = pcap_open_live(landevice.Internal->name, 2048, PCAP_OPENFLAG_PROMISCUOUS, 1, errbuf);
+    if (!adapter)
+    {
+        Log(LogLevel::Error, "PCap: failed to open adapter %s\n", errbuf);
+        return std::nullopt;
+    }
+
+    if (pcap_setnonblock(adapter, 1, errbuf) < 0)
+    {
+        Log(LogLevel::Error, "PCap: failed to set nonblocking mode\n");
+        pcap_close(adapter);
+        return std::nullopt;
+    }
+
+    return LAN_PCap(*this, landevice, adapter);
+}
+
+LAN_PCap::LAN_PCap(const PCap& pcap, const AdapterData& data, pcap_t* adapter) noexcept :
+    pcap_close(pcap.pcap_close),
+    pcap_sendpacket(pcap.pcap_sendpacket),
+    pcap_dispatch(pcap.pcap_dispatch),
+    PCapAdapter(adapter),
+    PCapAdapterData(data)
+{
+}
+
+LAN_PCap::~LAN_PCap() noexcept
+{
+    if (PCapAdapter)
+    {
+        pcap_close(PCapAdapter);
+        PCapAdapter = nullptr;
+    }
+}
+
+void LAN_PCap::RXCallback(u_char* userdata, const struct pcap_pkthdr* header, const u_char* data) noexcept
+{
+    LAN_PCap* lan = (LAN_PCap*)userdata;
+    while (lan->RXNum > 0);
 
     if (header->len > 2048-64) return;
 
-    PacketLen = header->len;
-    memcpy(PacketBuffer, data, PacketLen);
-    RXNum = 1;
+    lan->PacketLen = header->len;
+    memcpy(lan->PacketBuffer, data, lan->PacketLen);
+    lan->RXNum = 1;
 }
 
-int SendPacket(u8* data, int len)
+int LAN_PCap::SendPacket(u8* data, int len)
 {
-    if (PCapAdapter == NULL)
+    if (PCapAdapter == nullptr)
         return 0;
 
     if (len > 2048)
@@ -388,9 +412,9 @@ int SendPacket(u8* data, int len)
     return len;
 }
 
-int RecvPacket(u8* data)
+int LAN_PCap::RecvPacket(u8* data)
 {
-    if (PCapAdapter == NULL)
+    if (PCapAdapter == nullptr)
         return 0;
 
     int ret = 0;
@@ -401,7 +425,7 @@ int RecvPacket(u8* data)
         RXNum = 0;
     }
 
-    pcap_dispatch(PCapAdapter, 1, RXCallback, NULL);
+    pcap_dispatch(PCapAdapter, 1, RXCallback, reinterpret_cast<u_char*>(this));
     return ret;
 }
 

--- a/src/frontend/qt_sdl/LAN_PCap.cpp
+++ b/src/frontend/qt_sdl/LAN_PCap.cpp
@@ -384,6 +384,50 @@ LAN_PCap::~LAN_PCap() noexcept
     }
 }
 
+LAN_PCap::LAN_PCap(LAN_PCap&& other) noexcept :
+    pcap_close(other.pcap_close),
+    pcap_sendpacket(other.pcap_sendpacket),
+    pcap_dispatch(other.pcap_dispatch),
+    PacketLen(other.PacketLen),
+    RXNum(other.RXNum),
+    PCapAdapter(other.PCapAdapter),
+    PCapAdapterData(other.PCapAdapterData)
+{
+    other.PCapAdapter = nullptr;
+    other.pcap_close = nullptr;
+    other.pcap_dispatch = nullptr;
+    other.pcap_sendpacket = nullptr;
+    other.PCapAdapterData = {};
+}
+
+LAN_PCap& LAN_PCap::operator=(LAN_PCap&& other) noexcept
+{
+    if (this != &other)
+    {
+        if (PCapAdapter)
+        {
+            pcap_close(PCapAdapter);
+            PCapAdapter = nullptr;
+        }
+
+        pcap_close = other.pcap_close;
+        pcap_sendpacket = other.pcap_sendpacket;
+        pcap_dispatch = other.pcap_dispatch;
+        PacketLen = other.PacketLen;
+        RXNum = other.RXNum;
+        PCapAdapter = other.PCapAdapter;
+        PCapAdapterData = other.PCapAdapterData;
+
+        other.pcap_close = nullptr;
+        other.pcap_dispatch = nullptr;
+        other.pcap_sendpacket = nullptr;
+        other.PCapAdapter = nullptr;
+        other.PCapAdapterData = {};
+    }
+
+    return *this;
+}
+
 void LAN_PCap::RXCallback(u_char* userdata, const struct pcap_pkthdr* header, const u_char* data) noexcept
 {
     LAN_PCap* lan = (LAN_PCap*)userdata;

--- a/src/frontend/qt_sdl/LAN_PCap.cpp
+++ b/src/frontend/qt_sdl/LAN_PCap.cpp
@@ -343,6 +343,16 @@ PCap::~PCap() noexcept
     }
 }
 
+std::optional<LAN_PCap> PCap::OpenAdapter(std::string_view landevice) noexcept
+{
+    for (const AdapterData& adata : Adapters)
+    {
+        if (strncmp(landevice.data(), adata.DeviceName, 128) == 0)
+            return OpenAdapter(adata);
+    }
+
+    return std::nullopt;
+}
 
 std::optional<LAN_PCap> PCap::OpenAdapter(const AdapterData& landevice) noexcept
 {

--- a/src/frontend/qt_sdl/LAN_PCap.h
+++ b/src/frontend/qt_sdl/LAN_PCap.h
@@ -72,7 +72,7 @@ public:
     std::optional<LAN_PCap> OpenAdapter(std::string_view landevice) noexcept;
     std::optional<LAN_PCap> OpenAdapter(const AdapterData& landevice) noexcept;
 private:
-    PCap() noexcept;
+    PCap() noexcept = default;
     bool TryLoadPCap(Platform::DynamicLibrary *lib) noexcept;
     friend class LAN_PCap;
     std::vector<AdapterData> Adapters {};

--- a/src/frontend/qt_sdl/LAN_PCap.h
+++ b/src/frontend/qt_sdl/LAN_PCap.h
@@ -21,10 +21,15 @@
 
 #include "types.h"
 
-namespace LAN_PCap
-{
+#include <optional>
+#include <vector>
 
-using namespace melonDS;
+#include <pcap/pcap.h>
+
+namespace melonDS
+{
+namespace Platform { struct DynamicLibrary; }
+
 struct AdapterData
 {
     char DeviceName[128];
@@ -34,19 +39,82 @@ struct AdapterData
     u8 MAC[6];
     u8 IP_v4[4];
 
-    void* Internal;
+    pcap_if_t* Internal;
 };
 
+using pcap_findalldevs_t = int (*)(pcap_if_t** alldevs, char* errbuf);
+using pcap_freealldevs_t = void (*)(pcap_if_t* alldevs);
+using pcap_open_live_t = pcap_t* (*)(const char* src, int snaplen, int flags, int readtimeout, char* errbuf);
+using pcap_close_t = void (*)(pcap_t* dev);
+using pcap_setnonblock_t = int (*)(pcap_t* dev, int nonblock, char* errbuf);
+using pcap_sendpacket_t = int (*)(pcap_t* dev, const u_char* data, int len);
+using pcap_dispatch_t = int (*)(pcap_t* dev, int num, pcap_handler callback, u_char* data);
+using pcap_next_t = const u_char* (*)(pcap_t* dev, struct pcap_pkthdr* hdr);
 
-extern AdapterData* Adapters;
-extern int NumAdapters;
+class LAN_PCap;
 
+#define DECL_PCAP_FUNC(ret, name, args, args2) \
+    typedef ret (*type_##name) args; \
+    type_##name ptr_##name = NULL; \
+    ret name args { return ptr_##name args2; }
 
-bool Init(bool open_adapter);
-void DeInit();
+class PCap
+{
+public:
+    static std::optional<PCap> New() noexcept;
+    ~PCap() noexcept;
+    PCap(const PCap&) = delete;
+    PCap& operator=(const PCap&) = delete;
+    PCap(PCap&&) noexcept;
+    PCap& operator=(PCap&&) noexcept;
 
-int SendPacket(u8* data, int len);
-int RecvPacket(u8* data);
+    [[nodiscard]] const std::vector<AdapterData>& GetAdapters() const noexcept { return Adapters; }
+    std::optional<LAN_PCap> OpenAdapter(std::string_view landevice) noexcept;
+    std::optional<LAN_PCap> OpenAdapter(const AdapterData& landevice) noexcept;
+private:
+    PCap() noexcept;
+    bool TryLoadPCap(Platform::DynamicLibrary *lib) noexcept;
+    friend class LAN_PCap;
+    std::vector<AdapterData> Adapters {};
+    Platform::DynamicLibrary* PCapLib = nullptr;
+    pcap_if_t* AllDevices = nullptr;
+
+    pcap_findalldevs_t pcap_findalldevs = nullptr;
+    pcap_freealldevs_t pcap_freealldevs = nullptr;
+    pcap_open_live_t pcap_open_live = nullptr;
+    pcap_close_t pcap_close = nullptr;
+    pcap_setnonblock_t pcap_setnonblock = nullptr;
+    pcap_sendpacket_t pcap_sendpacket = nullptr;
+    pcap_dispatch_t pcap_dispatch = nullptr;
+};
+
+class LAN_PCap
+{
+public:
+    ~LAN_PCap() noexcept;
+    LAN_PCap(const LAN_PCap&) = delete;
+    LAN_PCap& operator=(const LAN_PCap&) = delete;
+    LAN_PCap(LAN_PCap&&) noexcept;
+    LAN_PCap& operator=(LAN_PCap&&) noexcept;
+    int SendPacket(u8* data, int len);
+    int RecvPacket(u8* data);
+private:
+    friend class PCap;
+    LAN_PCap(const PCap& pcap, const AdapterData& data, pcap_t* adapter) noexcept;
+    static void RXCallback(u_char* blarg, const struct pcap_pkthdr* header, const u_char* data) noexcept;
+
+    pcap_close_t pcap_close = nullptr;
+    pcap_sendpacket_t pcap_sendpacket = nullptr;
+    pcap_dispatch_t pcap_dispatch = nullptr;
+
+    u8 PacketBuffer[2048] {};
+    int PacketLen = 0;
+    volatile int RXNum = 0;
+    pcap_t* PCapAdapter = nullptr;
+    AdapterData PCapAdapterData;
+};
+
+#undef DECL_PCAP_FUNC
 
 }
 

--- a/src/frontend/qt_sdl/LAN_PCap.h
+++ b/src/frontend/qt_sdl/LAN_PCap.h
@@ -98,6 +98,7 @@ public:
     LAN_PCap& operator=(LAN_PCap&&) noexcept;
     int SendPacket(u8* data, int len);
     int RecvPacket(u8* data);
+    [[nodiscard]] const AdapterData& GetAdapterData() const noexcept { return PCapAdapterData; }
 private:
     friend class PCap;
     LAN_PCap(const PCap& pcap, const AdapterData& data, pcap_t* adapter) noexcept;

--- a/src/frontend/qt_sdl/LAN_Socket.cpp
+++ b/src/frontend/qt_sdl/LAN_Socket.cpp
@@ -511,9 +511,9 @@ int LAN_Socket::RecvPacket(u8* data)
     {
         u32 timeout = 0;
         PollListSize = 0;
-        slirp_pollfds_fill(Ctx, &timeout, SlirpCbAddPoll, nullptr);
+        slirp_pollfds_fill(Ctx, &timeout, SlirpCbAddPoll, this);
         int res = poll(PollList, PollListSize, timeout);
-        slirp_pollfds_poll(Ctx, res<0, SlirpCbGetREvents, nullptr);
+        slirp_pollfds_poll(Ctx, res<0, SlirpCbGetREvents, this);
     }
 
     if (!RXBuffer.IsEmpty())

--- a/src/frontend/qt_sdl/LAN_Socket.cpp
+++ b/src/frontend/qt_sdl/LAN_Socket.cpp
@@ -111,7 +111,7 @@ ssize_t LAN_Socket::SlirpCbSendPacket(const void* buf, size_t len, void* opaque)
     return len;
 }
 
-void SlirpCbGuestError(const char* msg, void* opaque) noexcept
+void LAN_Socket::SlirpCbGuestError(const char* msg, void* opaque) noexcept
 {
     Log(LogLevel::Error, "SLIRP: error: %s\n", msg);
 }
@@ -180,7 +180,7 @@ void SlirpCbNotify(void* opaque)
     Log(LogLevel::Debug, "Slirp: notify???\n");
 }
 
-SlirpCb LAN_Socket::cb =
+const SlirpCb LAN_Socket::cb =
 {
     .send_packet = SlirpCbSendPacket,
     .guest_error = SlirpCbGuestError,

--- a/src/frontend/qt_sdl/LAN_Socket.h
+++ b/src/frontend/qt_sdl/LAN_Socket.h
@@ -24,6 +24,7 @@
 #else
 #include <netinet/in.h>
 #include <arpa/inet.h>
+#include <sys/poll.h>
 #endif
 
 #include "FIFO.h"

--- a/src/frontend/qt_sdl/LAN_Socket.h
+++ b/src/frontend/qt_sdl/LAN_Socket.h
@@ -49,7 +49,7 @@ public:
     int RecvPacket(u8* data);
 private:
     static constexpr int PollListMax = 64;
-    static SlirpCb cb;
+    const static SlirpCb cb;
     static ssize_t SlirpCbSendPacket(const void* buf, size_t len, void* opaque) noexcept;
     static void SlirpCbGuestError(const char* msg, void* opaque) noexcept;
     static int SlirpCbAddPoll(int fd, int events, void* opaque) noexcept;

--- a/src/frontend/qt_sdl/LAN_Socket.h
+++ b/src/frontend/qt_sdl/LAN_Socket.h
@@ -19,21 +19,50 @@
 #ifndef LAN_SOCKET_H
 #define LAN_SOCKET_H
 
+#ifdef _WIN32
+#include <winsock2.h>
+#else
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#endif
+
+#include "FIFO.h"
 #include "types.h"
 
-namespace LAN_Socket
+struct Slirp;
+struct SlirpCb;
+
+namespace melonDS
 {
-using namespace melonDS;
+class LAN_Socket
+{
+public:
+    LAN_Socket() noexcept;
+    ~LAN_Socket() noexcept;
+    LAN_Socket(const LAN_Socket&) = delete;
+    LAN_Socket& operator=(const LAN_Socket&) = delete;
+    // Can't move this because the Slirp ctx has a pointer to this object
+    LAN_Socket(LAN_Socket&&) = delete;
+    LAN_Socket& operator=(LAN_Socket&&) = delete;
 
-//
+    int SendPacket(u8* data, int len);
+    int RecvPacket(u8* data);
+private:
+    static constexpr int PollListMax = 64;
+    static SlirpCb cb;
+    static ssize_t SlirpCbSendPacket(const void* buf, size_t len, void* opaque) noexcept;
+    static void SlirpCbGuestError(const char* msg, void* opaque) noexcept;
+    static int SlirpCbAddPoll(int fd, int events, void* opaque) noexcept;
+    static int SlirpCbGetREvents(int idx, void* opaque) noexcept;
+    void RXEnqueue(const void* buf, int len) noexcept;
+    void HandleDNSFrame(u8* data, int len) noexcept;
 
-
-bool Init();
-void DeInit();
-
-int SendPacket(u8* data, int len);
-int RecvPacket(u8* data);
-
+    pollfd PollList[PollListMax] {};
+    int PollListSize = 0;
+    FIFO<u32, (0x8000 >> 2)> RXBuffer {};
+    u32 IPv4ID = 0;
+    Slirp* Ctx = nullptr;
+};
 }
 
 #endif // LAN_SOCKET_H

--- a/src/frontend/qt_sdl/Platform.cpp
+++ b/src/frontend/qt_sdl/Platform.cpp
@@ -571,11 +571,11 @@ bool LAN_Init()
 {
     if (Config::DirectLAN)
     {
-        std::optional<melonDS::PCap> pcap = PCap::New();
-        if (!pcap)
+        PCap = PCap::New();
+        if (!PCap)
             return false;
 
-        std::optional<LAN_PCap> lan = pcap->OpenAdapter(Config::LANDevice);
+        std::optional<LAN_PCap> lan = PCap->OpenAdapter(Config::LANDevice);
         if (!lan)
             return false;
 
@@ -583,6 +583,7 @@ bool LAN_Init()
     }
     else
     {
+        PCap = std::nullopt;
         Lan.emplace<LAN_Socket>();
     }
 

--- a/src/frontend/qt_sdl/WifiSettingsDialog.cpp
+++ b/src/frontend/qt_sdl/WifiSettingsDialog.cpp
@@ -129,12 +129,12 @@ void WifiSettingsDialog::on_cbxDirectAdapter_currentIndexChanged(int sel)
     LAN_PCap::AdapterData* adapter = &LAN_PCap::Adapters[sel];
     char tmp[64];
 
-    sprintf(tmp, "%02X:%02X:%02X:%02X:%02X:%02X",
+    snprintf(tmp, sizeof(tmp), "%02X:%02X:%02X:%02X:%02X:%02X",
             adapter->MAC[0], adapter->MAC[1], adapter->MAC[2],
             adapter->MAC[3], adapter->MAC[4], adapter->MAC[5]);
     ui->lblAdapterMAC->setText(QString(tmp));
 
-    sprintf(tmp, "%d.%d.%d.%d",
+    snprintf(tmp, sizeof(tmp), "%d.%d.%d.%d",
             adapter->IP_v4[0], adapter->IP_v4[1],
             adapter->IP_v4[2], adapter->IP_v4[3]);
     ui->lblAdapterIP->setText(QString(tmp));

--- a/src/frontend/qt_sdl/WifiSettingsDialog.h
+++ b/src/frontend/qt_sdl/WifiSettingsDialog.h
@@ -20,6 +20,7 @@
 #define WIFISETTINGSDIALOG_H
 
 #include <QDialog>
+#include "LAN_PCap.h"
 
 namespace Ui { class WifiSettingsDialog; }
 class WifiSettingsDialog;
@@ -61,8 +62,7 @@ private slots:
 
 private:
     Ui::WifiSettingsDialog* ui;
-
-    bool haspcap;
+    std::optional<melonDS::PCap> pcap;
 
     void updateAdapterControls();
 };


### PR DESCRIPTION
This PR wraps `LAN_Socket` and `LAN_PCap` in an object-oriented interface to simplify management of their resources. Instead of having to ensure that frontends call `Init()` and `DeInit()` in the right order, they just have to hang on to their `LAN_Socket` or `LAN_PCap` objects until they're done.

Although these classes are part of the frontend, [I build them into melonDS DS](https://github.com/JesseTG/melonds-ds/blob/main/src/libretro/CMakeLists.txt#L135-L148). [Rafael does so](https://github.com/rafaelvcaetano/melonDS-android-lib/blob/a26a30f19a1d0317af82ebf8074740a61cf3584b/src/android/CMakeLists.txt#L5-L6) in his Android port, too.