### PR TITLE
Fix an instance of undefined behavior

### DIFF
--- a/src/GBACart.cpp
+++ b/src/GBACart.cpp
@@ -758,7 +758,7 @@ std::unique_ptr<CartCommon> ParseROM(std::unique_ptr<u8[]>&& romdata, u32 romlen
     std::unique_ptr<u8[]> cartsram;
     try
     {
-        cartsram = sramdata ? std::make_unique<u8[]>(sramlen) : nullptr;
+        cartsram = std::move(sramdata) ? std::make_unique<u8[]>(sramlen) : nullptr;
     }
     catch (const std::bad_alloc& e)
     {


### PR DESCRIPTION
I'd forgotten to use `std::move` on a movable reference. This caused a crash on Linux.