### PR TITLE
Fix an incorrect use of `std::move`

### DIFF
--- a/src/GBACart.cpp
+++ b/src/GBACart.cpp
@@ -755,24 +755,6 @@ std::unique_ptr<CartCommon> ParseROM(std::unique_ptr<u8[]>&& romdata, u32 romlen
 
     auto [cartrom, cartromsize] = PadToPowerOf2(std::move(romdata), romlen);
 
-    std::unique_ptr<u8[]> cartsram;
-    try
-    {
-        cartsram = std::move(sramdata) ? std::make_unique<u8[]>(sramlen) : nullptr;
-    }
-    catch (const std::bad_alloc& e)
-    {
-        Log(LogLevel::Error, "GBACart: failed to allocate memory for ROM (%d bytes)\n", cartromsize);
-
-        return nullptr;
-    }
-
-    if (cartsram)
-    {
-        memset(cartsram.get(), 0, sramlen);
-        memcpy(cartsram.get(), sramdata.get(), sramlen);
-    }
-
     char gamecode[5] = { '\0' };
     memcpy(&gamecode, cartrom.get() + 0xAC, 4);
 
@@ -790,9 +772,9 @@ std::unique_ptr<CartCommon> ParseROM(std::unique_ptr<u8[]>&& romdata, u32 romlen
 
     std::unique_ptr<CartCommon> cart;
     if (solarsensor)
-        cart = std::make_unique<CartGameSolarSensor>(std::move(cartrom), cartromsize, std::move(cartsram), sramlen);
+        cart = std::make_unique<CartGameSolarSensor>(std::move(cartrom), cartromsize, std::move(sramdata), sramlen);
     else
-        cart = std::make_unique<CartGame>(std::move(cartrom), cartromsize, std::move(cartsram), sramlen);
+        cart = std::make_unique<CartGame>(std::move(cartrom), cartromsize, std::move(sramdata), sramlen);
 
     cart->Reset();
 


### PR DESCRIPTION
- When I adapted `GBACart::ParseROM` to use `unique_ptr` instead of a plain pointer, I forgot to remove the code that copied the SRAM data
- That code was made unnecessary because of the move