### PR TITLE
Fix a couple glitchy quads

### DIFF
--- a/src/GPU3D.cpp
+++ b/src/GPU3D.cpp
@@ -1246,7 +1246,7 @@ void GPU3D::SubmitPolygon() noexcept
     {
         Vertex* vtx = poly->Vertices[i];
 
-        if (vtx->FinalPosition[1] < ytop || (vtx->FinalPosition[1] == ytop && vtx->FinalPosition[0] < xtop))
+        if (vtx->FinalPosition[1] < ytop)
         {
             xtop = vtx->FinalPosition[0];
             ytop = vtx->FinalPosition[1];


### PR DESCRIPTION
Fixes some buggy quads rendering improperly.
The correct tie breaker for two points with the same y is to render the earlier vertex, rather than the leftmost one.
Doesn't seem to break anything from testing, and I don't think it should, since the only thing this impacts is Xtop (unused?), YTop (should be identical), and VTop (only used for determining which vertex to start rendering a polygon at)
I left the bottom check unchanged because i couldn't find any similar incorrect behavior with it, and I figured no reason to change what isn't broken.

Example of fix:
![image](https://github.com/melonDS-emu/melonDS/assets/102590697/e0c522cf-8f2b-4b4f-9718-bb2ab8c141b2)
