### PR TITLE
Fix generic icon when using Wayland

### DIFF
--- a/src/frontend/qt_sdl/main.cpp
+++ b/src/frontend/qt_sdl/main.cpp
@@ -3474,12 +3474,11 @@ void emuStop()
 MelonApplication::MelonApplication(int& argc, char** argv)
     : QApplication(argc, argv)
 {
-#ifndef __APPLE__
+#if !defined(Q_OS_APPLE)
     setWindowIcon(QIcon(":/melon-icon"));
-#endif
-
-#ifdef !defined(__APPLE__) && !defined(__WIN32__)
-    setDesktopFileName(QString("net.kuribo64.melonDS"));
+    #if defined(Q_OS_UNIX)
+        setDesktopFileName(QString("net.kuribo64.melonDS"));
+    #endif
 #endif
 }
 

--- a/src/frontend/qt_sdl/main.cpp
+++ b/src/frontend/qt_sdl/main.cpp
@@ -3477,6 +3477,10 @@ MelonApplication::MelonApplication(int& argc, char** argv)
 #ifndef __APPLE__
     setWindowIcon(QIcon(":/melon-icon"));
 #endif
+
+#ifdef !defined(__APPLE__) && !defined(__WIN32__)
+    setDesktopFileName(QString("net.kuribo64.melonDS"));
+#endif
 }
 
 bool MelonApplication::event(QEvent *event)


### PR DESCRIPTION
When using melonDS on Wayland (Plasma in my case) the program icon was not set correctly such that the generic Wayland icon was used instead of melonDS own icon. The reason for that is that the used method `setWindowIcon` does not work on Wayland anymore for setting app icons. Instead applications should make use of `setDesktopFileName` which provides the graphical shell the name of the associated desktop file from which the referenced icon is taken for the taskbar and the window border.

I've tested the commit on Linux using Plasma on Wayland and Plasma on X11; in either case both icons (window border / window decorations and taskbar) were set correctly.

Regarding the used flags I'm unsure if there exists a better fitting flag (like e.g. `__UNIX__`), but I think it should cover the relevant platforms.

What's worth noting is, that despite the icon shouldn't work at all without my commit on Wayland (with Plasma) in the taskbar and the window border, the icon was only broken in the window border and not in the taskbar. Other applications with the same issue (using only `setWindowIcon`) had broken icons in the taskbar **and** the window border.

The newly added method eventually raises the required version of Qt5 to version 5.7 in which the method `setDesktopFileName` was added.