### PR TITLE
Fix 0px tall polygon aa

### DIFF
--- a/src/GPU3D_Soft.cpp
+++ b/src/GPU3D_Soft.cpp
@@ -1036,6 +1036,14 @@ void SoftRenderer::RenderPolygonScanline(const GPU& gpu, RendererPolygon* rp, s3
         }
     }
 
+    // quick hack to fix a minor bug.
+    // for some reason 0 pixel tall polygons have broken aa.
+    if (polygon->YBottom == polygon->YTop)
+    {
+        l_edgecov = 0;
+        r_edgecov = 0;
+    }
+
     // interpolate attributes along Y
 
     s32 rl = interp_start->Interpolate(vlcur->FinalColor[0], vlnext->FinalColor[0]);


### PR DESCRIPTION
For some reason 0 pixel tall polygons have their coverage set to 0?
Not sure.
Maybe they're treated as if their edges are swapped for some erroneous reason?
There's probably a better fix for this but this was quick and easy.
Only thing I've found that triggers this noticeably in a bit of brief testing is the big screens in gen 4 pokemon centers (depending on where you stand)