### PR TITLE
Support GBA .sav file with appended .rtc

### DIFF
--- a/src/GBACart.cpp
+++ b/src/GBACart.cpp
@@ -193,6 +193,7 @@ void CartGame::SetupSave(u32 type)
         SRAMType = S_FLASH512K;
         break;
     case 128*1024:
+    case (128*1024 + 0x10): // mGBA .sav file with appended real time clock data
         SRAMType = S_FLASH1M;
         break;
     case 0:

--- a/src/GBACart.cpp
+++ b/src/GBACart.cpp
@@ -193,7 +193,7 @@ void CartGame::SetupSave(u32 type)
         SRAMType = S_FLASH512K;
         break;
     case 128*1024:
-    case (128*1024 + 0x10): // mGBA .sav file with appended real time clock data
+    case (128*1024 + 0x10): // .sav file with appended real time clock data (ex: emulator mGBA)
         SRAMType = S_FLASH1M;
         break;
     case 0:


### PR DESCRIPTION
mGBA generates GBA .sav files with a length 128KB + 0x10.
The extra 0x10 contains real time clock data (which is used in games such as Pokemon Emerald).

Currently, using such .sav results in the warning `!! BAD GBA SAVE LENGTH 131088`. The .sav is ignored which prevent interactions between DS and GBA games.

With this PR, .sav with length 128KB + 0x10 can be loaded properly. After a GBA<->DS interaction, the resulting modified GBA .sav stays 128KB + 0x10: the extra 0x10 remains unmodified.

This was tested playing Pokemon Platinum and migrating Pokemons from Pokemon Emerald.
 