### PR TITLE
Apply some quick hotfixes

### DIFF
--- a/src/DSi_NAND.cpp
+++ b/src/DSi_NAND.cpp
@@ -122,7 +122,8 @@ NANDImage::NANDImage(NANDImage&& other) noexcept :
     ConsoleID(other.ConsoleID),
     FATIV(other.FATIV),
     FATKey(other.FATKey),
-    ESKey(other.ESKey)
+    ESKey(other.ESKey),
+    Length(other.Length)
 {
     other.CurFile = nullptr;
 }
@@ -140,6 +141,7 @@ NANDImage& NANDImage::operator=(NANDImage&& other) noexcept
         FATIV = other.FATIV;
         FATKey = other.FATKey;
         ESKey = other.ESKey;
+        Length = other.Length;
 
         other.CurFile = nullptr;
     }

--- a/src/FATStorage.cpp
+++ b/src/FATStorage.cpp
@@ -32,10 +32,7 @@ using namespace Platform;
 using std::string;
 
 FATStorage::FATStorage(const std::string& filename, u64 size, bool readonly, const std::optional<string>& sourcedir) :
-    FilePath(filename),
-    FileSize(size),
-    ReadOnly(readonly),
-    SourceDir(sourcedir)
+    FATStorage(FATStorageArgs { filename, size, readonly, sourcedir })
 {
     Load(filename, size, sourcedir);
 
@@ -55,7 +52,7 @@ FATStorage::FATStorage(FATStorageArgs&& args) noexcept :
 {
     Load(FilePath, FileSize, SourceDir);
 
-    File = nullptr;
+    File = Platform::OpenLocalFile(FilePath, FileMode::ReadWriteExisting);
 }
 
 FATStorage::FATStorage(FATStorage&& other) noexcept

--- a/src/FATStorage.cpp
+++ b/src/FATStorage.cpp
@@ -34,9 +34,6 @@ using std::string;
 FATStorage::FATStorage(const std::string& filename, u64 size, bool readonly, const std::optional<string>& sourcedir) :
     FATStorage(FATStorageArgs { filename, size, readonly, sourcedir })
 {
-    Load(filename, size, sourcedir);
-
-    File = Platform::OpenLocalFile(FilePath, FileMode::ReadWriteExisting);
 }
 
 FATStorage::FATStorage(const FATStorageArgs& args) noexcept :

--- a/src/FATStorage.h
+++ b/src/FATStorage.h
@@ -48,8 +48,8 @@ class FATStorage
 {
 public:
     FATStorage(const std::string& filename, u64 size, bool readonly, const std::optional<std::string>& sourcedir = std::nullopt);
-    FATStorage(const FATStorageArgs& args) noexcept;
-    FATStorage(FATStorageArgs&& args) noexcept;
+    explicit FATStorage(const FATStorageArgs& args) noexcept;
+    explicit FATStorage(FATStorageArgs&& args) noexcept;
     FATStorage(FATStorage&& other) noexcept;
     FATStorage(const FATStorage& other) = delete;
     FATStorage& operator=(const FATStorage& other) = delete;

--- a/src/NDSCart.cpp
+++ b/src/NDSCart.cpp
@@ -1657,9 +1657,15 @@ std::unique_ptr<CartCommon> ParseROM(std::unique_ptr<u8[]>&& romdata, u32 romlen
     std::unique_ptr<u8[]> sram = args ? std::move(args->SRAM) : nullptr;
     u32 sramlen = args ? args->SRAMLength : 0;
     if (homebrew)
-        cart = std::make_unique<CartHomebrew>(std::move(cartrom), cartromsize, cartid, romparams, args ? std::move(args->SDCard) : std::nullopt);
+    {
+        std::optional<FATStorage> sdcard = args && args->SDCard ? std::make_optional<FATStorage>(std::move(*args->SDCard)) : std::nullopt;
+        cart = std::make_unique<CartHomebrew>(std::move(cartrom), cartromsize, cartid, romparams, std::move(sdcard));
+    }
     else if (gametitle[0] == 0 && !strncmp("SD/TF-NDS", gametitle + 1, 9) && gamecode == 0x414D5341)
-        cart = std::make_unique<CartR4>(std::move(cartrom), cartromsize, cartid, romparams, CartR4TypeR4, CartR4LanguageEnglish, args ? std::move(args->SDCard) : std::nullopt);
+    {
+        std::optional<FATStorage> sdcard = args && args->SDCard ? std::make_optional<FATStorage>(std::move(*args->SDCard)) : std::nullopt;
+        cart = std::make_unique<CartR4>(std::move(cartrom), cartromsize, cartid, romparams, CartR4TypeR4, CartR4LanguageEnglish, std::move(sdcard));
+    }
     else if (cartid & 0x08000000)
         cart = std::make_unique<CartRetailNAND>(std::move(cartrom), cartromsize, cartid, romparams, std::move(sram), sramlen);
     else if (irversion != 0)


### PR DESCRIPTION
- Set `NANDImage::Length` in the move constructor/assignment
- Make `FATStorage`'s constructors `explicit`
- Delegate to one of `FATStorage`'s constructors