### PR TITLE
Add `alignas` specifiers to some arrays based on how they're accessed

### DIFF
--- a/src/GPU.h
+++ b/src/GPU.h
@@ -536,18 +536,18 @@ public:
     u8 VRAMCNT[9] {};
     u8 VRAMSTAT = 0;
 
-    u8 Palette[2*1024] {};
-    u8 OAM[2*1024] {};
+    alignas(u64) u8 Palette[2*1024] {};
+    alignas(u64) u8 OAM[2*1024] {};
 
-    u8 VRAM_A[128*1024] {};
-    u8 VRAM_B[128*1024] {};
-    u8 VRAM_C[128*1024] {};
-    u8 VRAM_D[128*1024] {};
-    u8 VRAM_E[ 64*1024] {};
-    u8 VRAM_F[ 16*1024] {};
-    u8 VRAM_G[ 16*1024] {};
-    u8 VRAM_H[ 32*1024] {};
-    u8 VRAM_I[ 16*1024] {};
+    alignas(u64) u8 VRAM_A[128*1024] {};
+    alignas(u64) u8 VRAM_B[128*1024] {};
+    alignas(u64) u8 VRAM_C[128*1024] {};
+    alignas(u64) u8 VRAM_D[128*1024] {};
+    alignas(u64) u8 VRAM_E[ 64*1024] {};
+    alignas(u64) u8 VRAM_F[ 16*1024] {};
+    alignas(u64) u8 VRAM_G[ 16*1024] {};
+    alignas(u64) u8 VRAM_H[ 32*1024] {};
+    alignas(u64) u8 VRAM_I[ 16*1024] {};
 
     u8* const VRAM[9]     = {VRAM_A,  VRAM_B,  VRAM_C,  VRAM_D,  VRAM_E, VRAM_F, VRAM_G, VRAM_H, VRAM_I};
     u32 const VRAMMask[9] = {0x1FFFF, 0x1FFFF, 0x1FFFF, 0x1FFFF, 0xFFFF, 0x3FFF, 0x3FFF, 0x7FFF, 0x3FFF};
@@ -596,14 +596,14 @@ public:
     u8 VRAMFlat_AOBJ[256*1024] {};
     u8 VRAMFlat_BOBJ[128*1024] {};
 
-    u8 VRAMFlat_ABGExtPal[32*1024] {};
-    u8 VRAMFlat_BBGExtPal[32*1024] {};
+    alignas(u16) u8 VRAMFlat_ABGExtPal[32*1024] {};
+    alignas(u16) u8 VRAMFlat_BBGExtPal[32*1024] {};
 
-    u8 VRAMFlat_AOBJExtPal[8*1024] {};
-    u8 VRAMFlat_BOBJExtPal[8*1024] {};
+    alignas(u16) u8 VRAMFlat_AOBJExtPal[8*1024] {};
+    alignas(u16) u8 VRAMFlat_BOBJExtPal[8*1024] {};
 
-    u8 VRAMFlat_Texture[512*1024] {};
-    u8 VRAMFlat_TexPal[128*1024] {};
+    alignas(u64) u8 VRAMFlat_Texture[512*1024] {};
+    alignas(u64) u8 VRAMFlat_TexPal[128*1024] {};
 private:
     void ResetVRAMCache() noexcept;
     void AssignFramebuffers() noexcept;

--- a/src/NDS.h
+++ b/src/NDS.h
@@ -489,12 +489,12 @@ private:
     FIFO<u32, 16> IPCFIFO9; // FIFO in which the ARM9 writes
     FIFO<u32, 16> IPCFIFO7;
     u16 DivCnt;
-    u32 DivNumerator[2];
-    u32 DivDenominator[2];
-    u32 DivQuotient[2];
-    u32 DivRemainder[2];
+    alignas(u64) u32 DivNumerator[2];
+    alignas(u64) u32 DivDenominator[2];
+    alignas(u64) u32 DivQuotient[2];
+    alignas(u64) u32 DivRemainder[2];
     u16 SqrtCnt;
-    u32 SqrtVal[2];
+    alignas(u64) u32 SqrtVal[2];
     u32 SqrtRes;
     u16 KeyCnt[2];
     bool Running;

--- a/src/NDS.h
+++ b/src/NDS.h
@@ -259,8 +259,8 @@ public: // TODO: Encapsulate the rest of these members
     u16 PowerControl9;
 
     u16 ExMemCnt[2];
-    u8 ROMSeed0[2*8];
-    u8 ROMSeed1[2*8];
+    alignas(u32) u8 ROMSeed0[2*8];
+    alignas(u32) u8 ROMSeed1[2*8];
 
 protected:
     // These BIOS arrays should be declared *before* the component objects (JIT, SPI, etc.)


### PR DESCRIPTION
This oughta pacify UBSan a little.