### PR TITLE
Don't reset the VRAM cache if saving a state

### DIFF
--- a/src/GPU.cpp
+++ b/src/GPU.cpp
@@ -275,7 +275,8 @@ void GPU::DoSavestate(Savestate* file) noexcept
     GPU2D_B.DoSavestate(file);
     GPU3D.DoSavestate(file);
 
-    ResetVRAMCache();
+    if (!file->Saving)
+        ResetVRAMCache();
 }
 
 void GPU::AssignFramebuffers() noexcept


### PR DESCRIPTION
This fixes a flickering bug in melonDS DS. https://github.com/JesseTG/melonds-ds/issues/142