### PR TITLE
Add interrupt instruction for games to print to terminal

### DIFF
--- a/src/ARMInterpreter.cpp
+++ b/src/ARMInterpreter.cpp
@@ -278,6 +278,20 @@ void A_SVC(ARM* cpu)
 
 void T_SVC(ARM* cpu)
 {
+    // Print from game. Execute `svc 0xFC` with the null-terminated string address in `r0`.
+    if ((cpu->CurInstr & 0xFF) == 0xFC)
+    {
+        u32 addr = cpu->R[0];
+        for (;;)
+        {
+            u32 c;
+            cpu->DataRead8(addr++, &c);
+            if (!c) break;
+            printf("%c", c);
+        }
+        return;
+    }
+
     u32 oldcpsr = cpu->CPSR;
     cpu->CPSR &= ~0xBF;
     cpu->CPSR |= 0x93;


### PR DESCRIPTION
If the game executes `svc 0xFC`, the contents of the null-terminated string addressed in register `r0` will be printed to the terminal.

For consistency, this is the same mechanism that is used in Desmume ([source](https://github.com/TASEmulators/desmume/blob/b06537cf51b5ad5dae70378e9fb995b9a4dcafc0/desmume/src/thumb_instructions.cpp#L1018)).