### PR TITLE
Default zero dot display register to the 24 bit integer limit

### DIFF
--- a/src/GPU3D.cpp
+++ b/src/GPU3D.cpp
@@ -191,7 +191,7 @@ void GPU3D::Reset() noexcept
 
     CmdStallQueue.Clear();
 
-    ZeroDotWLimit = 0; // CHECKME
+    ZeroDotWLimit = 0xFFFFFF;
 
     GXStat = 0;
 

--- a/src/GPU3D.h
+++ b/src/GPU3D.h
@@ -197,7 +197,7 @@ public:
 
     FIFO<CmdFIFOEntry, 64> CmdStallQueue {};
 
-    u32 ZeroDotWLimit = 0;
+    u32 ZeroDotWLimit = 0xFFFFFF;
 
     u32 GXStat = 0;
 


### PR DESCRIPTION
fixes: https://github.com/melonDS-emu/melonDS/issues/1143
fixes a fail on one of Striker's line test roms

tested via this test rom installed to nand as DSiware on a new3DS: [testdepth.zip](https://github.com/melonDS-emu/melonDS/files/14103323/testdepth.zip)

default behavior appears to be that it renders all the way up to the 24 bit integer limit (at which point it overflows to 0)