### PR TITLE
Fix DSiWare detection

### DIFF
--- a/src/NDS_Header.h
+++ b/src/NDS_Header.h
@@ -39,6 +39,8 @@ enum RegionMask : u32
     RegionFree = 0xFFFFFFFF,
 };
 
+constexpr u32 DSiWareTitleIDHigh = 0x00030004;
+
 // Consult GBATEK for info on what these are
 struct NDSHeader
 {
@@ -198,8 +200,9 @@ struct NDSHeader
 
     u8 HeaderSignature[128]; // RSA-SHA1 across 0x000..0xDFF
 
-    /// @return \c true if this header represents a DSi title
-    /// (either a physical cartridge or a DSiWare title).
+    /// @return \c true if this header represents a title
+    /// that is DSi-exclusive (including DSiWare)
+    /// or DSi-enhanced (including cartridges).
     [[nodiscard]] bool IsDSi() const { return (UnitCode & 0x02) != 0; }
     [[nodiscard]] u32 GameCodeAsU32() const {
         return (u32)GameCode[3] << 24 |
@@ -213,7 +216,7 @@ struct NDSHeader
     }
 
     /// @return \c true if this header represents a DSiWare title.
-    [[nodiscard]] bool IsDSiWare() const { return IsDSi() && DSiRegionStart == 0; }
+    [[nodiscard]] bool IsDSiWare() const { return IsDSi() && DSiTitleIDHigh == DSiWareTitleIDHigh; }
 };
 
 static_assert(sizeof(NDSHeader) == 4096, "NDSHeader is not 4096 bytes!");


### PR DESCRIPTION
- According to GBATek, all DSiWare games have a high title ID of 0x00030004
- Some homebrew apps set the Unitcode bits to DSi mode to enable support of DSi features
- Fixes a bug in [melonDS DS](https://github.com/JesseTG/melonds-ds/issues/160) where homebrew is incorrectly detected as DSiWare