### PR TITLE
Check for write permissions for some key files

### DIFF
--- a/src/Platform.h
+++ b/src/Platform.h
@@ -137,6 +137,11 @@ enum FileMode : unsigned {
     Text = 0b01'00'00,
 
     /**
+     * Opens a file in append mode.
+     */
+    Append = 0b10'00'00,
+
+    /**
      * Opens a file for reading and writing.
      * Equivalent to <tt>Read | Write</tt>.
      */

--- a/src/Platform.h
+++ b/src/Platform.h
@@ -210,6 +210,9 @@ bool LocalFileExists(const std::string& name);
 // Warning: Also creates the file if not present!
 bool CheckFileWritable(const std::string& filepath);
 
+// Same as above (CheckFileWritable()) but for local files.
+bool CheckLocalFileWritable(const std::string& filepath);
+
 /** Close a file opened with \c OpenFile.
  * @returns \c true if the file was closed successfully, false otherwise.
  * @post \c file is no longer valid and should not be used.

--- a/src/Platform.h
+++ b/src/Platform.h
@@ -206,6 +206,10 @@ FileHandle* OpenLocalFile(const std::string& path, FileMode mode);
 bool FileExists(const std::string& name);
 bool LocalFileExists(const std::string& name);
 
+// Returns true if we have permission to write to the file.
+// Warning: Also creates the file if not present!
+bool CheckFileWritable(const std::string& filepath);
+
 /** Close a file opened with \c OpenFile.
  * @returns \c true if the file was closed successfully, false otherwise.
  * @post \c file is no longer valid and should not be used.

--- a/src/frontend/qt_sdl/Config.cpp
+++ b/src/frontend/qt_sdl/Config.cpp
@@ -376,7 +376,7 @@ ConfigEntry ConfigFile[] =
 };
 
 
-void LoadFile(int inst)
+bool LoadFile(int inst, int actualinst)
 {
     Platform::FileHandle* f;
     if (inst > 0)
@@ -384,11 +384,17 @@ void LoadFile(int inst)
         char name[100] = {0};
         snprintf(name, 99, kUniqueConfigFile, inst+1);
         f = Platform::OpenLocalFile(name, Platform::FileMode::ReadText);
+
+        if (!Platform::CheckLocalFileWritable(name)) return false;
     }
     else
+    {
         f = Platform::OpenLocalFile(kConfigFile, Platform::FileMode::ReadText);
 
-    if (!f) return;
+        if (actualinst == 0 && !Platform::CheckLocalFileWritable(kConfigFile)) return false;
+    }
+
+    if (!f) return true;
 
     char linebuf[1024];
     char entryname[32];
@@ -423,9 +429,10 @@ void LoadFile(int inst)
     }
 
     CloseFile(f);
+    return true;
 }
 
-void Load()
+bool Load()
 {
 
     for (ConfigEntry* entry = &ConfigFile[0]; entry->Value; entry++)
@@ -438,12 +445,14 @@ void Load()
         case 3: *(int64_t*)entry->Value = std::get<int64_t>(entry->Default); break;
         }
     }
-
-    LoadFile(0);
-
+    
     int inst = Platform::InstanceID();
+
+    bool ret = LoadFile(0, inst);
     if (inst > 0)
-        LoadFile(inst);
+        ret = LoadFile(inst, inst);
+
+    return ret;
 }
 
 void Save()

--- a/src/frontend/qt_sdl/Config.h
+++ b/src/frontend/qt_sdl/Config.h
@@ -203,7 +203,7 @@ extern bool GdbARM7BreakOnStartup;
 extern bool GdbARM9BreakOnStartup;
 
 
-void Load();
+bool Load();
 void Save();
 
 }

--- a/src/frontend/qt_sdl/EmuSettingsDialog.cpp
+++ b/src/frontend/qt_sdl/EmuSettingsDialog.cpp
@@ -380,6 +380,12 @@ void EmuSettingsDialog::on_btnFirmwareBrowse_clicked()
 
     if (file.isEmpty()) return;
 
+    if (!Platform::CheckFileWritable(file.toStdString()))
+    {
+        QMessageBox::critical(this, "melonDS", "Unable to write to firmware file.\nPlease check file/folder write permissions.");
+        return;
+    }
+
     updateLastBIOSFolder(file);
 
     ui->txtFirmwarePath->setText(file);
@@ -436,6 +442,12 @@ void EmuSettingsDialog::on_btnDLDISDBrowse_clicked()
 
     if (file.isEmpty()) return;
 
+    if (!Platform::CheckFileWritable(file.toStdString()))
+    {
+        QMessageBox::critical(this, "melonDS", "Unable to write to DLDI SD image.\nPlease check file/folder write permissions.");
+        return;
+    }
+
     updateLastBIOSFolder(file);
 
     ui->txtDLDISDPath->setText(file);
@@ -468,6 +480,13 @@ void EmuSettingsDialog::on_btnDSiFirmwareBrowse_clicked()
 
     if (file.isEmpty()) return;
 
+    if (!Platform::CheckFileWritable(file.toStdString()))
+    {
+        QMessageBox::critical(this, "melonDS", "Unable to write to DSi firmware file.\nPlease check file/folder write permissions.");
+        return;
+    }
+
+
     updateLastBIOSFolder(file);
 
     ui->txtDSiFirmwarePath->setText(file);
@@ -481,6 +500,13 @@ void EmuSettingsDialog::on_btnDSiNANDBrowse_clicked()
                                                 "NAND files (*.bin *.mmc *.rom);;Any file (*.*)");
 
     if (file.isEmpty()) return;
+
+    if (!Platform::CheckFileWritable(file.toStdString()))
+    {
+        QMessageBox::critical(this, "melonDS", "Unable to write to DSi NAND image.\nPlease check file/folder write permissions.");
+        return;
+    }
+
 
     updateLastBIOSFolder(file);
 
@@ -509,6 +535,12 @@ void EmuSettingsDialog::on_btnDSiSDBrowse_clicked()
                                                 "Image files (*.bin *.rom *.img *.sd *.dmg);;Any file (*.*)");
 
     if (file.isEmpty()) return;
+
+    if (!Platform::CheckFileWritable(file.toStdString()))
+    {
+        QMessageBox::critical(this, "melonDS", "Unable to write to DSi SD image.\nPlease check file/folder write permissions.");
+        return;
+    }
 
     updateLastBIOSFolder(file);
 

--- a/src/frontend/qt_sdl/PathSettingsDialog.cpp
+++ b/src/frontend/qt_sdl/PathSettingsDialog.cpp
@@ -19,6 +19,7 @@
 #include <stdio.h>
 #include <QFileDialog>
 #include <QMessageBox>
+#include <QTemporaryFile>
 
 #include "types.h"
 #include "Config.h"
@@ -37,6 +38,7 @@ extern bool RunningSomething;
 
 bool PathSettingsDialog::needsReset = false;
 
+constexpr char errordialog[] = "melonDS cannot write to that directory.";
 
 PathSettingsDialog::PathSettingsDialog(QWidget* parent) : QDialog(parent), ui(new Ui::PathSettingsDialog)
 {
@@ -101,6 +103,12 @@ void PathSettingsDialog::on_btnSaveFileBrowse_clicked()
                                                      QString::fromStdString(EmuDirectory));
 
     if (dir.isEmpty()) return;
+    
+    if (!QTemporaryFile(dir).open())
+    {
+        QMessageBox::critical(this, "melonDS", errordialog);
+        return;
+    }
 
     ui->txtSaveFilePath->setText(dir);
 }
@@ -112,6 +120,12 @@ void PathSettingsDialog::on_btnSavestateBrowse_clicked()
                                                      QString::fromStdString(EmuDirectory));
 
     if (dir.isEmpty()) return;
+    
+    if (!QTemporaryFile(dir).open())
+    {
+        QMessageBox::critical(this, "melonDS", errordialog);
+        return;
+    }
 
     ui->txtSavestatePath->setText(dir);
 }
@@ -123,6 +137,12 @@ void PathSettingsDialog::on_btnCheatFileBrowse_clicked()
                                                      QString::fromStdString(EmuDirectory));
 
     if (dir.isEmpty()) return;
+    
+    if (!QTemporaryFile(dir).open())
+    {
+        QMessageBox::critical(this, "melonDS", errordialog);
+        return;
+    }
 
     ui->txtCheatFilePath->setText(dir);
 }

--- a/src/frontend/qt_sdl/Platform.cpp
+++ b/src/frontend/qt_sdl/Platform.cpp
@@ -334,8 +334,12 @@ bool LocalFileExists(const std::string& name)
 bool CheckFileWritable(const std::string& filepath)
 {
     FileHandle* file = Platform::OpenFile(filepath.c_str(), FileMode::Append);
-
-    return (file != nullptr);
+    if (file)
+    {
+        Platform::CloseFile(file);
+        return true;
+    }
+    else return false;
 }
 
 bool FileSeek(FileHandle* file, s64 offset, FileSeekOrigin origin)

--- a/src/frontend/qt_sdl/Platform.cpp
+++ b/src/frontend/qt_sdl/Platform.cpp
@@ -342,6 +342,17 @@ bool CheckFileWritable(const std::string& filepath)
     else return false;
 }
 
+bool CheckLocalFileWritable(const std::string& name)
+{
+    FileHandle* file = Platform::OpenLocalFile(name.c_str(), FileMode::Append);
+    if (file)
+    {
+        Platform::CloseFile(file);
+        return true;
+    }
+    else return false;
+}
+
 bool FileSeek(FileHandle* file, s64 offset, FileSeekOrigin origin)
 {
     int stdorigin;

--- a/src/frontend/qt_sdl/Platform.cpp
+++ b/src/frontend/qt_sdl/Platform.cpp
@@ -331,6 +331,13 @@ bool LocalFileExists(const std::string& name)
     return true;
 }
 
+bool CheckFileWritable(const std::string& filepath)
+{
+    FileHandle* file = Platform::OpenFile(filepath.c_str(), FileMode::Append);
+
+    return (file != nullptr);
+}
+
 bool FileSeek(FileHandle* file, s64 offset, FileSeekOrigin origin)
 {
     int stdorigin;

--- a/src/frontend/qt_sdl/Platform.cpp
+++ b/src/frontend/qt_sdl/Platform.cpp
@@ -217,6 +217,10 @@ std::string InstanceFileSuffix()
 
 constexpr char AccessMode(FileMode mode, bool file_exists)
 {
+
+    if (mode & FileMode::Append)
+        return  'a';
+
     if (!(mode & FileMode::Write))
         // If we're only opening the file for reading...
         return 'r';
@@ -255,7 +259,7 @@ static std::string GetModeString(FileMode mode, bool file_exists)
 
 FileHandle* OpenFile(const std::string& path, FileMode mode)
 {
-    if ((mode & FileMode::ReadWrite) == FileMode::None)
+    if ((mode & (FileMode::ReadWrite | FileMode::Append)) == FileMode::None)
     { // If we aren't reading or writing, then we can't open the file
         Log(LogLevel::Error, "Attempted to open \"%s\" in neither read nor write mode (FileMode 0x%x)\n", path.c_str(), mode);
         return nullptr;

--- a/src/frontend/qt_sdl/ROMManager.cpp
+++ b/src/frontend/qt_sdl/ROMManager.cpp
@@ -1281,7 +1281,7 @@ char* GetSavErrorString(std::string& filepath, bool gba)
 {
     std::string console = gba ? "GBA" : "DS";
     std::string err1 = "Unable to write to ";
-    std::string err2 = " save.\nEnsure the save file/directory can be written to.\n\nAttempted to Access:\n";
+    std::string err2 = " save.\nPlease check file/folder write permissions.\n\nAttempted to Access:\n";
 
     err1 += console + err2 + filepath;
 

--- a/src/frontend/qt_sdl/ROMManager.cpp
+++ b/src/frontend/qt_sdl/ROMManager.cpp
@@ -1299,12 +1299,15 @@ u8 LoadROM(EmuThread* emuthread, QStringList filepath, bool reset)
     std::string origsav = savname;
     savname += Platform::InstanceFileSuffix();
 
-    FileHandle* sav = Platform::OpenFile(savname, FileMode::Append);
-    if (sav) CloseFile(sav);
-    else return 2; // sav write perm error
+    FileHandle* sav = Platform::OpenFile(savname, FileMode::Read);
+    if (!sav)
+    {
+        if (!Platform::CheckFileWritable(origsav)) return 2; // sav write error
 
-    sav = Platform::OpenFile(savname, FileMode::Read);
-    if (!sav) sav = Platform::OpenFile(origsav, FileMode::Read);
+        sav = Platform::OpenFile(origsav, FileMode::Read);
+    }
+    else if (!Platform::CheckFileWritable(savname)) return 2; // sav write error
+
     if (sav)
     {
         savelen = (u32)Platform::FileLength(sav);

--- a/src/frontend/qt_sdl/ROMManager.cpp
+++ b/src/frontend/qt_sdl/ROMManager.cpp
@@ -211,6 +211,9 @@ QString VerifyDSFirmware()
     f = Platform::OpenLocalFile(Config::FirmwarePath, FileMode::Read);
     if (!f) return "DS firmware was not found or could not be accessed. Check your emu settings.";
 
+    if (!Platform::CheckFileWritable(Config::FirmwarePath))
+        return "DS firmware is unable to be written to.\nPlease check file/folder write permissions.";
+
     len = FileLength(f);
     if (len == 0x20000)
     {
@@ -238,6 +241,9 @@ QString VerifyDSiFirmware()
     f = Platform::OpenLocalFile(Config::DSiFirmwarePath, FileMode::Read);
     if (!f) return "DSi firmware was not found or could not be accessed. Check your emu settings.";
 
+    if (!Platform::CheckFileWritable(Config::FirmwarePath))
+        return "DSi firmware is unable to be written to.\nPlease check file/folder write permissions.";
+
     len = FileLength(f);
     if (len != 0x20000)
     {
@@ -259,6 +265,9 @@ QString VerifyDSiNAND()
 
     f = Platform::OpenLocalFile(Config::DSiNANDPath, FileMode::ReadWriteExisting);
     if (!f) return "DSi NAND was not found or could not be accessed. Check your emu settings.";
+
+    if (!Platform::CheckFileWritable(Config::FirmwarePath))
+        return "DSi NAND is unable to be written to.\nPlease check file/folder write permissions.";
 
     // TODO: some basic checks
     // check that it has the nocash footer, and all

--- a/src/frontend/qt_sdl/ROMManager.cpp
+++ b/src/frontend/qt_sdl/ROMManager.cpp
@@ -1286,7 +1286,7 @@ bool LoadROMData(const QStringList& filepath, std::unique_ptr<u8[]>& filedata, u
         return false;
 }
 
-char* GetSavErrorString(std::string& filepath, bool gba)
+QString GetSavErrorString(std::string& filepath, bool gba)
 {
     std::string console = gba ? "GBA" : "DS";
     std::string err1 = "Unable to write to ";
@@ -1294,7 +1294,7 @@ char* GetSavErrorString(std::string& filepath, bool gba)
 
     err1 += console + err2 + filepath;
 
-    return (char*)err1.c_str();
+    return QString::fromStdString(err1);
 }
 
 bool LoadROM(QMainWindow* mainWindow, EmuThread* emuthread, QStringList filepath, bool reset)

--- a/src/frontend/qt_sdl/ROMManager.cpp
+++ b/src/frontend/qt_sdl/ROMManager.cpp
@@ -1421,7 +1421,14 @@ bool LoadGBAROM(NDS& nds, QStringList filepath)
     savname += Platform::InstanceFileSuffix();
 
     FileHandle* sav = Platform::OpenFile(savname, FileMode::Read);
-    if (!sav) sav = Platform::OpenFile(origsav, FileMode::Read);
+    if (!sav)
+    {
+        if (!Platform::CheckFileWritable(origsav)) return 2; // sav write error
+
+        sav = Platform::OpenFile(origsav, FileMode::Read);
+    }
+    else if (!Platform::CheckFileWritable(savname)) return 2; // sav write error
+
     if (sav)
     {
         savelen = (u32)FileLength(sav);

--- a/src/frontend/qt_sdl/ROMManager.cpp
+++ b/src/frontend/qt_sdl/ROMManager.cpp
@@ -1277,6 +1277,17 @@ bool LoadROMData(const QStringList& filepath, std::unique_ptr<u8[]>& filedata, u
         return false;
 }
 
+char* GetSavErrorString(std::string& filepath, bool gba)
+{
+    std::string console = gba ? "GBA" : "DS";
+    std::string err1 = "Unable to write to ";
+    std::string err2 = " save.\nEnsure the save file/directory can be written to.\n\nAttempted to Access:\n";
+
+    err1 += console + err2 + filepath;
+
+    return (char*)err1.c_str();
+}
+
 bool LoadROM(QMainWindow* mainWindow, EmuThread* emuthread, QStringList filepath, bool reset)
 {
     unique_ptr<u8[]> filedata = nullptr;
@@ -1308,7 +1319,7 @@ bool LoadROM(QMainWindow* mainWindow, EmuThread* emuthread, QStringList filepath
     {
         if (!Platform::CheckFileWritable(origsav))
         {
-            QMessageBox::critical(mainWindow, "melonDS", "Unable to write to DS save.\nCheck file/folder's write perms.");
+            QMessageBox::critical(mainWindow, "melonDS", GetSavErrorString(origsav, false));
             return false;
         }
 
@@ -1316,7 +1327,7 @@ bool LoadROM(QMainWindow* mainWindow, EmuThread* emuthread, QStringList filepath
     }
     else if (!Platform::CheckFileWritable(savname))
     {
-        QMessageBox::critical(mainWindow, "melonDS", "Unable to write to DS save.\nCheck file/folder's write perms.");
+        QMessageBox::critical(mainWindow, "melonDS", GetSavErrorString(savname, false));
         return false;
     }
 
@@ -1450,7 +1461,7 @@ bool LoadGBAROM(QMainWindow* mainWindow, NDS& nds, QStringList filepath)
     {
         if (!Platform::CheckFileWritable(origsav))
         {
-            QMessageBox::critical(mainWindow, "melonDS", "Unable to write to GBA save.\nEnsure save file/directory can be written to.");
+            QMessageBox::critical(mainWindow, "melonDS", GetSavErrorString(origsav, true));
             return false;
         }
 
@@ -1458,7 +1469,7 @@ bool LoadGBAROM(QMainWindow* mainWindow, NDS& nds, QStringList filepath)
     }
     else if (!Platform::CheckFileWritable(savname))
     {
-        QMessageBox::critical(mainWindow, "melonDS", "Unable to write to GBA save.\nEnsure save file/directory can be written to.");
+        QMessageBox::critical(mainWindow, "melonDS", GetSavErrorString(savname, true));
         return false;
     }
 

--- a/src/frontend/qt_sdl/ROMManager.h
+++ b/src/frontend/qt_sdl/ROMManager.h
@@ -23,6 +23,7 @@
 #include "SaveManager.h"
 #include "AREngine.h"
 #include "DSi_NAND.h"
+#include <QMainWindow>
 
 #include "MemConstants.h"
 #include <optional>
@@ -72,12 +73,12 @@ std::optional<Firmware> LoadFirmware(int type) noexcept;
 std::optional<DSi_NAND::NANDImage> LoadNAND(const std::array<u8, DSiBIOSSize>& arm7ibios) noexcept;
 
 /// Inserts a ROM into the emulated console.
-u8 LoadROM(EmuThread*, QStringList filepath, bool reset);
+bool LoadROM(QMainWindow* mainWindow, EmuThread*, QStringList filepath, bool reset);
 void EjectCart(NDS& nds);
 bool CartInserted();
 QString CartLabel();
 
-bool LoadGBAROM(NDS& nds, QStringList filepath);
+bool LoadGBAROM(QMainWindow* mainWindow, NDS& nds, QStringList filepath);
 void LoadGBAAddon(NDS& nds, int type);
 void EjectGBACart(NDS& nds);
 bool GBACartInserted();

--- a/src/frontend/qt_sdl/ROMManager.h
+++ b/src/frontend/qt_sdl/ROMManager.h
@@ -72,7 +72,7 @@ std::optional<Firmware> LoadFirmware(int type) noexcept;
 std::optional<DSi_NAND::NANDImage> LoadNAND(const std::array<u8, DSiBIOSSize>& arm7ibios) noexcept;
 
 /// Inserts a ROM into the emulated console.
-bool LoadROM(EmuThread*, QStringList filepath, bool reset);
+u8 LoadROM(EmuThread*, QStringList filepath, bool reset);
 void EjectCart(NDS& nds);
 bool CartInserted();
 QString CartLabel();

--- a/src/frontend/qt_sdl/Window.cpp
+++ b/src/frontend/qt_sdl/Window.cpp
@@ -865,12 +865,8 @@ void MainWindow::dropEvent(QDropEvent* event)
 
     if (isNdsRom)
     {
-        u8 error = ROMManager::LoadROM(emuThread, file, true);
-        if (error)
+        if (!ROMManager::LoadROM(mainWindow, emuThread, file, true))
         {
-            // TODO: better error reporting?
-            if (error == 1) QMessageBox::critical(this, "melonDS", "Failed to load the DS ROM.");
-            else if (error == 2) QMessageBox:: critical (this, "melonDS", "Unable to write DS save.\nCheck write perms.");
             emuThread->emuUnpause();
             return;
         }
@@ -888,10 +884,8 @@ void MainWindow::dropEvent(QDropEvent* event)
     }
     else if (isGbaRom)
     {
-        if (!ROMManager::LoadGBAROM(*emuThread->NDS, file))
+        if (!ROMManager::LoadGBAROM(mainWindow, *emuThread->NDS, file))
         {
-            // TODO: better error reporting?
-            QMessageBox::critical(this, "melonDS", "Failed to load the GBA ROM.");
             emuThread->emuUnpause();
             return;
         }
@@ -954,12 +948,7 @@ bool MainWindow::preloadROMs(QStringList file, QStringList gbafile, bool boot)
     bool gbaloaded = false;
     if (!gbafile.isEmpty())
     {
-        if (!ROMManager::LoadGBAROM(*emuThread->NDS, gbafile))
-        {
-            // TODO: better error reporting?
-            QMessageBox::critical(this, "melonDS", "Failed to load the GBA ROM.");
-            return false;
-        }
+        if (!ROMManager::LoadGBAROM(mainWindow, *emuThread->NDS, gbafile)) return false;
 
         gbaloaded = true;
     }
@@ -967,14 +956,8 @@ bool MainWindow::preloadROMs(QStringList file, QStringList gbafile, bool boot)
     bool ndsloaded = false;
     if (!file.isEmpty())
     {
-        u8 error = ROMManager::LoadROM(emuThread, file, true);
-        if (error)
-        {
-            // TODO: better error reporting?
-            if (error == 1) QMessageBox::critical(this, "melonDS", "Failed to load the DS ROM.");
-            else if (error == 2) QMessageBox:: critical (this, "melonDS", "Unable to write DS save.\nCheck write perms.");
-            return false;
-        }
+        if (!ROMManager::LoadROM(mainWindow, emuThread, file, true)) return false;
+        
         recentFileList.removeAll(file.join("|"));
         recentFileList.prepend(file.join("|"));
         updateRecentFilesMenu();
@@ -1178,12 +1161,8 @@ void MainWindow::onOpenFile()
         return;
     }
     
-    u8 error = ROMManager::LoadROM(emuThread, file, true);
-    if (error)
+    if (!ROMManager::LoadROM(mainWindow, emuThread, file, true))
     {
-        // TODO: better error reporting?
-            if (error == 1) QMessageBox::critical(this, "melonDS", "Failed to load the DS ROM.");
-            else if (error == 2) QMessageBox:: critical (this, "melonDS", "Unable to write DS save.\nCheck write perms.");
         emuThread->emuUnpause();
         return;
     }
@@ -1279,12 +1258,8 @@ void MainWindow::onClickRecentFile()
         return;
     }
     
-    u8 error = ROMManager::LoadROM(emuThread, file, true);
-    if (error)
+    if (!ROMManager::LoadROM(mainWindow, emuThread, file, true))
     {
-        // TODO: better error reporting?
-            if (error == 1) QMessageBox::critical(this, "melonDS", "Failed to load the DS ROM.");
-            else if (error == 2) QMessageBox:: critical (this, "melonDS", "Unable to write DS save.\nCheck write perms.");
         emuThread->emuUnpause();
         return;
     }
@@ -1334,12 +1309,8 @@ void MainWindow::onInsertCart()
         return;
     }
 
-    u8 error = ROMManager::LoadROM(emuThread, file, false);
-    if (error)
+    if (!ROMManager::LoadROM(mainWindow, emuThread, file, false))
     {
-        // TODO: better error reporting?
-        if (error == 1) QMessageBox::critical(this, "melonDS", "Failed to load the ROM.");
-        else if (error = 2) QMessageBox::critical(this, "melonDS", "Unable to write DS save.\nCheck write perms.");
         emuThread->emuUnpause();
         return;
     }
@@ -1371,10 +1342,8 @@ void MainWindow::onInsertGBACart()
         return;
     }
 
-    if (!ROMManager::LoadGBAROM(*emuThread->NDS, file))
+    if (!ROMManager::LoadGBAROM(mainWindow, *emuThread->NDS, file))
     {
-        // TODO: better error reporting?
-        QMessageBox::critical(this, "melonDS", "Failed to load the ROM.");
         emuThread->emuUnpause();
         return;
     }

--- a/src/frontend/qt_sdl/Window.cpp
+++ b/src/frontend/qt_sdl/Window.cpp
@@ -865,10 +865,12 @@ void MainWindow::dropEvent(QDropEvent* event)
 
     if (isNdsRom)
     {
-        if (!ROMManager::LoadROM(emuThread, file, true))
+        u8 error = ROMManager::LoadROM(emuThread, file, true);
+        if (error)
         {
             // TODO: better error reporting?
-            QMessageBox::critical(this, "melonDS", "Failed to load the DS ROM.");
+            if (error == 1) QMessageBox::critical(this, "melonDS", "Failed to load the DS ROM.");
+            else if (error == 2) QMessageBox:: critical (this, "melonDS", "Unable to write DS save.\nCheck write perms.");
             emuThread->emuUnpause();
             return;
         }
@@ -965,10 +967,12 @@ bool MainWindow::preloadROMs(QStringList file, QStringList gbafile, bool boot)
     bool ndsloaded = false;
     if (!file.isEmpty())
     {
-        if (!ROMManager::LoadROM(emuThread, file, true))
+        u8 error = ROMManager::LoadROM(emuThread, file, true);
+        if (error)
         {
             // TODO: better error reporting?
-            QMessageBox::critical(this, "melonDS", "Failed to load the ROM.");
+            if (error == 1) QMessageBox::critical(this, "melonDS", "Failed to load the DS ROM.");
+            else if (error == 2) QMessageBox:: critical (this, "melonDS", "Unable to write DS save.\nCheck write perms.");
             return false;
         }
         recentFileList.removeAll(file.join("|"));
@@ -1173,11 +1177,13 @@ void MainWindow::onOpenFile()
         emuThread->emuUnpause();
         return;
     }
-
-    if (!ROMManager::LoadROM(emuThread, file, true))
+    
+    u8 error = ROMManager::LoadROM(emuThread, file, true);
+    if (error)
     {
         // TODO: better error reporting?
-        QMessageBox::critical(this, "melonDS", "Failed to load the ROM.");
+            if (error == 1) QMessageBox::critical(this, "melonDS", "Failed to load the DS ROM.");
+            else if (error == 2) QMessageBox:: critical (this, "melonDS", "Unable to write DS save.\nCheck write perms.");
         emuThread->emuUnpause();
         return;
     }
@@ -1272,11 +1278,13 @@ void MainWindow::onClickRecentFile()
         emuThread->emuUnpause();
         return;
     }
-
-    if (!ROMManager::LoadROM(emuThread, file, true))
+    
+    u8 error = ROMManager::LoadROM(emuThread, file, true);
+    if (error)
     {
         // TODO: better error reporting?
-        QMessageBox::critical(this, "melonDS", "Failed to load the ROM.");
+            if (error == 1) QMessageBox::critical(this, "melonDS", "Failed to load the DS ROM.");
+            else if (error == 2) QMessageBox:: critical (this, "melonDS", "Unable to write DS save.\nCheck write perms.");
         emuThread->emuUnpause();
         return;
     }
@@ -1326,10 +1334,12 @@ void MainWindow::onInsertCart()
         return;
     }
 
-    if (!ROMManager::LoadROM(emuThread, file, false))
+    u8 error = ROMManager::LoadROM(emuThread, file, false);
+    if (error)
     {
         // TODO: better error reporting?
-        QMessageBox::critical(this, "melonDS", "Failed to load the ROM.");
+        if (error == 1) QMessageBox::critical(this, "melonDS", "Failed to load the ROM.");
+        else if (error = 2) QMessageBox::critical(this, "melonDS", "Unable to write DS save.\nCheck write perms.");
         emuThread->emuUnpause();
         return;
     }

--- a/src/frontend/qt_sdl/main.cpp
+++ b/src/frontend/qt_sdl/main.cpp
@@ -331,7 +331,7 @@ int main(int argc, char** argv)
     SDL_InitSubSystem(SDL_INIT_VIDEO);
     SDL_EnableScreenSaver(); SDL_DisableScreenSaver();
 
-    Config::Load();
+    if (!Config::Load()) QMessageBox::critical(NULL, "melonDS", "Unable to write to config.\nPlease check the write permissions of the folder you placed melonDS in.");
 
 #define SANITIZE(var, min, max)  { var = std::clamp(var, min, max); }
     SANITIZE(Config::ConsoleType, 0, 1);


### PR DESCRIPTION
Adds checks on:
Setting a file/directory for: SD+NAND images, firmware, save/savestates/cheat directories.
Loading a rom for: GBA/NDS .sav files, firmware, NAND. (should probably add a check for SD images just to be consistent...)
Launching melonDS for: Config file.

Tested to work on Windows 10, needs testing for Linux, and macOS.