### PR TITLE
[FIX] fix malloc on OpenBSD targets

### DIFF
--- a/src/frontend/duckstation/gl/context.cpp
+++ b/src/frontend/duckstation/gl/context.cpp
@@ -3,11 +3,7 @@
 #include "loader.h"
 #include <cstdlib>
 #include <cstring>
-#ifdef __APPLE__
 #include <stdlib.h>
-#else
-#include <malloc.h>
-#endif
 Log_SetChannel(GL::Context);
 
 #if defined(_WIN32)


### PR DESCRIPTION
over on the [ports@ mailing lists](https://marc.info/?t=170813350900001&r=1&w=2), It was requested to push this patch upstream to fix building on OpenBSD targets.

TL;DR:

OpenBSD doesn't have `malloc.h`, our `malloc()` function is in `stdlib.h` 

[see `malloc(3)`](http://man.openbsd.org/malloc)

trivial patch, Makes our port nicer to handle.

thanks.