### PR TITLE
ssize_t is not defined in GdbStub.h or GdbCmds.h

### DIFF
--- a/src/debug/GdbStub.h
+++ b/src/debug/GdbStub.h
@@ -3,6 +3,7 @@
 #define GDBSTUB_H_
 
 #include <stddef.h>
+#include <sys/types.h>
 #include <map>
 #include <vector>
 


### PR DESCRIPTION
i had to add sys/types.h and patch my gentoo ebuilds for a successful compilation.