### PR TITLE
Implement a more accurate algorithm for z interpolation

### DIFF
--- a/src/GPU3D_Soft.cpp
+++ b/src/GPU3D_Soft.cpp
@@ -615,7 +615,7 @@ void SoftRenderer::SetupPolygonLeftEdge(SoftRenderer::RendererPolygon* rp, s32 y
 
     rp->XL = rp->SlopeL.Setup(polygon->Vertices[rp->CurVL]->FinalPosition[0], polygon->Vertices[rp->NextVL]->FinalPosition[0],
                               polygon->Vertices[rp->CurVL]->FinalPosition[1], polygon->Vertices[rp->NextVL]->FinalPosition[1],
-                              polygon->FinalW[rp->CurVL], polygon->FinalW[rp->NextVL], y);
+                              polygon->FinalW[rp->CurVL], polygon->FinalW[rp->NextVL], y, polygon->WBuffer);
 }
 
 void SoftRenderer::SetupPolygonRightEdge(SoftRenderer::RendererPolygon* rp, s32 y) const
@@ -642,7 +642,7 @@ void SoftRenderer::SetupPolygonRightEdge(SoftRenderer::RendererPolygon* rp, s32 
 
     rp->XR = rp->SlopeR.Setup(polygon->Vertices[rp->CurVR]->FinalPosition[0], polygon->Vertices[rp->NextVR]->FinalPosition[0],
                               polygon->Vertices[rp->CurVR]->FinalPosition[1], polygon->Vertices[rp->NextVR]->FinalPosition[1],
-                              polygon->FinalW[rp->CurVR], polygon->FinalW[rp->NextVR], y);
+                              polygon->FinalW[rp->CurVR], polygon->FinalW[rp->NextVR], y, polygon->WBuffer);
 }
 
 void SoftRenderer::SetupPolygon(SoftRenderer::RendererPolygon* rp, Polygon* polygon) const
@@ -748,8 +748,8 @@ void SoftRenderer::RenderShadowMaskScanline(const GPU3D& gpu3d, RendererPolygon*
     s32 wl = rp->SlopeL.Interp.Interpolate(polygon->FinalW[rp->CurVL], polygon->FinalW[rp->NextVL]);
     s32 wr = rp->SlopeR.Interp.Interpolate(polygon->FinalW[rp->CurVR], polygon->FinalW[rp->NextVR]);
 
-    s32 zl = rp->SlopeL.Interp.InterpolateZ(polygon->FinalZ[rp->CurVL], polygon->FinalZ[rp->NextVL], polygon->WBuffer);
-    s32 zr = rp->SlopeR.Interp.InterpolateZ(polygon->FinalZ[rp->CurVR], polygon->FinalZ[rp->NextVR], polygon->WBuffer);
+    s32 zl = rp->SlopeL.Interp.InterpolateZ(polygon->FinalZ[rp->CurVL], polygon->FinalZ[rp->NextVL]);
+    s32 zr = rp->SlopeR.Interp.InterpolateZ(polygon->FinalZ[rp->CurVR], polygon->FinalZ[rp->NextVR]);
 
     // right vertical edges are pushed 1px to the left as long as either:
     // the left edge slope is not 0, or the span is not 0 pixels wide, and it is not at the leftmost pixel of the screen
@@ -834,7 +834,7 @@ void SoftRenderer::RenderShadowMaskScanline(const GPU3D& gpu3d, RendererPolygon*
     int edge;
 
     s32 x = xstart;
-    Interpolator<0> interpX(xstart, xend+1, wl, wr);
+    Interpolator<0> interpX(xstart, xend+1, wl, wr, polygon->WBuffer, zl, zr);
 
     if (x < 0) x = 0;
     s32 xlimit;
@@ -856,7 +856,7 @@ void SoftRenderer::RenderShadowMaskScanline(const GPU3D& gpu3d, RendererPolygon*
 
         interpX.SetX(x);
 
-        s32 z = interpX.InterpolateZ(zl, zr, polygon->WBuffer);
+        s32 z = interpX.InterpolateZ(zl, zr);
         u32 dstattr = AttrBuffer[pixeladdr];
 
         if (!fnDepthTest(DepthBuffer[pixeladdr], z, dstattr))
@@ -882,7 +882,7 @@ void SoftRenderer::RenderShadowMaskScanline(const GPU3D& gpu3d, RendererPolygon*
 
         interpX.SetX(x);
 
-        s32 z = interpX.InterpolateZ(zl, zr, polygon->WBuffer);
+        s32 z = interpX.InterpolateZ(zl, zr);
         u32 dstattr = AttrBuffer[pixeladdr];
 
         if (!fnDepthTest(DepthBuffer[pixeladdr], z, dstattr))
@@ -908,7 +908,7 @@ void SoftRenderer::RenderShadowMaskScanline(const GPU3D& gpu3d, RendererPolygon*
 
         interpX.SetX(x);
 
-        s32 z = interpX.InterpolateZ(zl, zr, polygon->WBuffer);
+        s32 z = interpX.InterpolateZ(zl, zr);
         u32 dstattr = AttrBuffer[pixeladdr];
 
         if (!fnDepthTest(DepthBuffer[pixeladdr], z, dstattr))
@@ -973,8 +973,8 @@ void SoftRenderer::RenderPolygonScanline(const GPU& gpu, RendererPolygon* rp, s3
     s32 wl = rp->SlopeL.Interp.Interpolate(polygon->FinalW[rp->CurVL], polygon->FinalW[rp->NextVL]);
     s32 wr = rp->SlopeR.Interp.Interpolate(polygon->FinalW[rp->CurVR], polygon->FinalW[rp->NextVR]);
 
-    s32 zl = rp->SlopeL.Interp.InterpolateZ(polygon->FinalZ[rp->CurVL], polygon->FinalZ[rp->NextVL], polygon->WBuffer);
-    s32 zr = rp->SlopeR.Interp.InterpolateZ(polygon->FinalZ[rp->CurVR], polygon->FinalZ[rp->NextVR], polygon->WBuffer);
+    s32 zl = rp->SlopeL.Interp.InterpolateZ(polygon->FinalZ[rp->CurVL], polygon->FinalZ[rp->NextVL]);
+    s32 zr = rp->SlopeR.Interp.InterpolateZ(polygon->FinalZ[rp->CurVR], polygon->FinalZ[rp->NextVR]);
 
     // right vertical edges are pushed 1px to the left as long as either:
     // the left edge slope is not 0, or the span is not 0 pixels wide, and it is not at the leftmost pixel of the screen
@@ -1084,7 +1084,7 @@ void SoftRenderer::RenderPolygonScanline(const GPU& gpu, RendererPolygon* rp, s3
     int edge;
 
     s32 x = xstart;
-    Interpolator<0> interpX(xstart, xend+1, wl, wr);
+    Interpolator<0> interpX(xstart, xend+1, wl, wr, polygon->WBuffer, zl, zr);
 
     if (x < 0) x = 0;
     s32 xlimit;
@@ -1123,7 +1123,7 @@ void SoftRenderer::RenderPolygonScanline(const GPU& gpu, RendererPolygon* rp, s3
 
         interpX.SetX(x);
 
-        s32 z = interpX.InterpolateZ(zl, zr, polygon->WBuffer);
+        s32 z = interpX.InterpolateZ(zl, zr);
 
         // if depth test against the topmost pixel fails, test
         // against the pixel underneath
@@ -1219,7 +1219,7 @@ void SoftRenderer::RenderPolygonScanline(const GPU& gpu, RendererPolygon* rp, s3
 
         interpX.SetX(x);
 
-        s32 z = interpX.InterpolateZ(zl, zr, polygon->WBuffer);
+        s32 z = interpX.InterpolateZ(zl, zr);
 
         // if depth test against the topmost pixel fails, test
         // against the pixel underneath
@@ -1311,7 +1311,7 @@ void SoftRenderer::RenderPolygonScanline(const GPU& gpu, RendererPolygon* rp, s3
 
         interpX.SetX(x);
 
-        s32 z = interpX.InterpolateZ(zl, zr, polygon->WBuffer);
+        s32 z = interpX.InterpolateZ(zl, zr);
 
         // if depth test against the topmost pixel fails, test
         // against the pixel underneath

--- a/src/GPU3D_Soft.h
+++ b/src/GPU3D_Soft.h
@@ -180,41 +180,11 @@ private:
             {
                 // Z-buffering: linear interpolation
                 // still doesn't quite match hardware...
-                s32 disp = 0;
 
                 if (z0 < z1)
-                {
-                    disp = z1 - z0;
-                }
+                    return z0 + (((z1 - z0) / (xdiff << 1)) * (x<<1));
                 else
-                {
-                    disp = z0 - z1;
-                }
-                
-                /*if (dir)
-                {
-                    if (z0 < z1) return z0 + ((z1 - z0) * x / xdiff);
-                    else         return z1 + ((z0 - z1) - ((z0 - z1) * x / xdiff));
-                }*/
-
-                u32 recip, recip2;
-                u32 shift = 0;
-                recip2 = recip = (x << 16) / xdiff;
-                while (recip2 > 0x100)
-                {
-                    recip2 >>= 1;
-                    shift++;
-                }
-                disp >>= shift;
-                
-                if (z0 < z1)
-                {
-                    return z0 + ((disp * recip) >> (16 - shift));
-                }
-                else
-                {
-                    return z1 + ((z0-z1) - ((disp * recip) >> (16 - shift)));
-                }
+                    return z1 + (((z0 - z1) / (xdiff << 1)) * (xdiff-x<<1));
             }
         }
 

--- a/src/GPU3D_Soft.h
+++ b/src/GPU3D_Soft.h
@@ -194,22 +194,23 @@ private:
                     disp = z0 - z1,
                     factor = xdiff - x;
                 }
-
+                /*
                 if (dir)
                 {
-                    int shift = 0;
-                    while (disp > 0x3FF)
+                    return base + disp * factor / xdiff;
+                }
+                else*/
+                {
+                    u32 recip, recip2;
+                    u32 shift = 0;
+                    recip2 = recip = (factor << 16) / xdiff;
+                    while (recip2 > 0x100)
                     {
-                        disp >>= 1;
+                        recip2 >>= 1;
                         shift++;
                     }
-
-                    return base + ((((s64)disp * factor * xrecip_z) >> 22) << shift);
-                }
-                else
-                {
-                    disp >>= 9;
-                    return base + (((s64)disp * factor * xrecip_z) >> 13);
+                    disp >>= shift;
+                    return base + ((disp * recip) >> (16 - shift));
                 }
             }
         }

--- a/src/GPU3D_Soft.h
+++ b/src/GPU3D_Soft.h
@@ -180,37 +180,40 @@ private:
             {
                 // Z-buffering: linear interpolation
                 // still doesn't quite match hardware...
-                s32 base = 0, disp = 0, factor = 0;
+                s32 disp = 0;
 
                 if (z0 < z1)
                 {
-                    base = z0;
                     disp = z1 - z0;
-                    factor = x;
                 }
                 else
                 {
-                    base = z1;
-                    disp = z0 - z1,
-                    factor = xdiff - x;
+                    disp = z0 - z1;
                 }
-                /*
-                if (dir)
+                
+                /*if (dir)
                 {
-                    return base + disp * factor / xdiff;
+                    if (z0 < z1) return z0 + ((z1 - z0) * x / xdiff);
+                    else         return z1 + ((z0 - z1) - ((z0 - z1) * x / xdiff));
+                }*/
+
+                u32 recip, recip2;
+                u32 shift = 0;
+                recip2 = recip = (x << 16) / xdiff;
+                while (recip2 > 0x100)
+                {
+                    recip2 >>= 1;
+                    shift++;
                 }
-                else*/
+                disp >>= shift;
+                
+                if (z0 < z1)
                 {
-                    u32 recip, recip2;
-                    u32 shift = 0;
-                    recip2 = recip = (factor << 16) / xdiff;
-                    while (recip2 > 0x100)
-                    {
-                        recip2 >>= 1;
-                        shift++;
-                    }
-                    disp >>= shift;
-                    return base + ((disp * recip) >> (16 - shift));
+                    return z0 + ((disp * recip) >> (16 - shift));
+                }
+                else
+                {
+                    return z1 + ((z0-z1) - ((disp * recip) >> (16 - shift)));
                 }
             }
         }

--- a/src/GPU3D_Soft.h
+++ b/src/GPU3D_Soft.h
@@ -181,10 +181,22 @@ private:
                 // Z-buffering: linear interpolation
                 // still doesn't quite match hardware...
 
-                if (z0 < z1)
-                    return z0 + (((z1 - z0) / (xdiff << 1)) * (x<<1));
+                if (dir)
+                {
+                    // seems like y dir does different interpolation?
+                    // this probably isn't right...
+                    if (z0 < z1)
+                        return z0 + (z1-z0) * x / xdiff;
+                    else
+                        return z1 + (z0-z1) * (xdiff-x) / xdiff;
+                }
                 else
-                    return z1 + (((z0 - z1) / (xdiff << 1)) * (xdiff-x<<1));
+                {
+                    if (z0 < z1)
+                        return z0 + (((z1-z0) / xdiff & ~0x1) * x);
+                    else
+                        return z1 + (((z0-z1) / xdiff & ~0x1) * (xdiff-x) + ((z0-z1) & 0xFF));
+                }
             }
         }
 

--- a/src/GPU3D_Soft.h
+++ b/src/GPU3D_Soft.h
@@ -183,7 +183,7 @@ private:
 
                 if (dir)
                 {
-                    // seems like y dir does different interpolation?
+                    // seems like y dir does different interpolation than x?
                     // this probably isn't right...
                     if (z0 < z1)
                         return z0 + (z1-z0) * x / xdiff;
@@ -195,7 +195,7 @@ private:
                     if (z0 < z1)
                         return z0 + (((z1-z0) / xdiff & ~0x1) * x);
                     else
-                        return z1 + (((z0-z1) / xdiff & ~0x1) * (xdiff-x) + ((z0-z1) & 0xFF));
+                        return z1 + (((z0-z1) / xdiff & ~0x1) * (xdiff-x)) + ((z0-z1) % (xdiff << 1));
                 }
             }
         }

--- a/src/GPU3D_Soft.h
+++ b/src/GPU3D_Soft.h
@@ -179,23 +179,24 @@ private:
             else
             {
                 // Z-buffering: linear interpolation
-                // still doesn't quite match hardware...
+                // not perfect, but close
 
                 if (dir)
                 {
-                    // seems like y dir does different interpolation than x?
-                    // this probably isn't right...
+                    // interpolating along y uses a different algorithm than x
+                    // this algo probably isn't quite right though...
                     if (z0 < z1)
-                        return z0 + (z1-z0) * x / xdiff;
+                        return z0 + (s64)(z1-z0) * x / xdiff;
                     else
-                        return z1 + (z0-z1) * (xdiff-x) / xdiff;
+                        return z1 + (s64)(z0-z1) * (xdiff-x) / xdiff;
                 }
                 else
                 {
+                    // these algorithms are weiiird but i can't argue with the results
                     if (z0 < z1)
-                        return z0 + (((z1-z0) / xdiff & ~0x1) * x);
+                        return z0 + ((z1-z0 >> 1) / xdiff * x << 1);
                     else
-                        return z1 + (((z0-z1) / xdiff & ~0x1) * (xdiff-x)) + ((z0-z1) % (xdiff << 1));
+                        return z1 + (((z0-z1 >> 1) / xdiff * (xdiff-x)) + ((z0-z1 >> 1) % xdiff) << 1);
                 }
             }
         }


### PR DESCRIPTION
Implements a more accurate model for z interp which results in closely replicating the precision loss.

The amount of precision lost is directly correlated to how wide a polygon is.
This behavior seems to only apply to interpolation along x?
One theory I have is that it takes the difference between the left and right depth value and right shifts by 1. Followed by, in the case where z0 > z1, adding the remainder of the division of (z0-z1) and xdiff towards the end of the process.
Note: there are a few alternative ways to do this, while still getting an equivalent result. Such as by left shifting xdiff by 1 before division.

Some samples:
before > after > console
![image](https://github.com/melonDS-emu/melonDS/assets/102590697/e7413ff8-38c8-408f-bc5f-87a182f21447) ![image](https://github.com/melonDS-emu/melonDS/assets/102590697/723002f0-00cb-4d07-924f-821650dbd72b) ![image](https://github.com/melonDS-emu/melonDS/assets/102590697/a971c520-f92f-49e5-9386-1b85fd7d3b21)
![image](https://github.com/melonDS-emu/melonDS/assets/102590697/766c8382-bb3e-4b44-b691-2954563266b5) ![image](https://github.com/melonDS-emu/melonDS/assets/102590697/fd61d8cb-0035-4882-85d0-a30fcc95dfe0) ![image](https://github.com/melonDS-emu/melonDS/assets/102590697/d28016c5-0152-467f-8501-a4aa4848b363)
