### PR TITLE
sort of hack to fix extremely cursed nonsense with the way a polygon's orientation is determined

### DIFF
--- a/src/GPU3D.cpp
+++ b/src/GPU3D.cpp
@@ -1013,6 +1013,18 @@ void GPU3D::SubmitPolygon() noexcept
             return;
         }
     }
+    // dot == 0
+    // kinda gross hack to get the "correct" result 
+    // polygons should be treated as facing *neither* direction if the first/second vertex is equal to the third vertex's position,
+    // and as facing *both* directions under any other circumstances (with a dot of 0, ofc)
+    // needs more testing to make sure this actually covers every edge case
+    else if (!((v0->Position[0] == v2->Position[0] && v0->Position[1] == v2->Position[1]) ||
+             (v1->Position[0] == v2->Position[0] && v1->Position[1] == v2->Position[1])) &&
+             !(CurPolygonAttr & (3<<6)))
+    {
+        LastStripPolygon = NULL;
+        return;
+    }
 
     // for strips, check whether we can attach to the previous polygon
     // this requires two original vertices shared with the previous polygon, and that


### PR DESCRIPTION
so sometimes a polygon is 'normal' and is neither front or back facing
but under specific circumstances a polygon that *should* have a completely identical dot ends up facing *both* front and backfacing
this fixes this to work like on hardware maybe i think
this is almost certainly __not__ the correct fix.
but i haven't found any cases that are wrong so it's good enough for me(?)
but i guarantee you there's loads of them and i just haven't found them yet.