### PR TITLE
Pu region sizing/bounds fix

### DIFF
--- a/src/CP15.cpp
+++ b/src/CP15.cpp
@@ -187,9 +187,10 @@ void ARMv5::UpdatePURegion(u32 n)
     }
 
     u32 start = rgn >> 12;
-    u64 sz = (u64)2 << ((rgn >> 1) & 0x1F);
-    u64 end = start + (sz >> 12);
-    if (end > 0xFFFFF) end = 0xFFFFF;
+    s32 shift = ((rgn >> 1) & 0x1F) - 11;
+    if (shift < 0) shift = 0;
+    u64 end = start + (1 << shift);
+    if (end > 0x100000) end = 0x100000;
     // TODO: check alignment of start
 
     u8 usermask = 0;

--- a/src/CP15.cpp
+++ b/src/CP15.cpp
@@ -186,23 +186,12 @@ void ARMv5::UpdatePURegion(u32 n)
         return;
     }
 
-    u32 start;
-    u64 end;
-    s32 shift = ((rgn >> 1) & 0x1F);
-    if (shift == 0x1F)
-    {
-        start = 0;
-        end = 0x100000;
-    }
-    else
-    {
-        start = rgn >> 12;
-        shift -= 11;
-        if (shift < 0) shift = 0;
-        end = start + (1 << shift);
-        if (end > 0x100000) end = 0x100000;
-        // TODO: check alignment of start
-    }
+    u32 size = ((rgn >> 1) & 0x1F) + 1; // size is increased by 1
+    if (size < 12) size = 12; // min size is 12
+    u32 start = rgn >> size; // force align start to size
+    u32 end = start + 1 << (size-12); // then end is always one away from start
+    start <<= (size-12); // dont forget to fix the start value too :)
+    // dont need to bounds check the end point because the force alignment inherently prevents it from breaking
 
     u8 usermask = 0;
     u8 privmask = 0;

--- a/src/CP15.cpp
+++ b/src/CP15.cpp
@@ -187,11 +187,12 @@ void ARMv5::UpdatePURegion(u32 n)
     }
 
     // notes:
-    // * min size of a pu region is 4KiB
+    // * min size of a pu region is 4KiB (12 bits)
+    // * size is calculated as size + 1, but the 12 lsb of address space are ignored, therefore we need it as size + 1 - 12, or size - 11
     // * pu regions are aligned based on their size
-    u32 size = std::min(((rgn>>1) & 0x1F) - 11, 0); // obtain the size, subtract 11 and clamp to a min of 0
+    u32 size = std::max((int)((rgn>>1) & 0x1F) - 11, 0); // obtain the size, subtract 11 and clamp to a min of 0.
     u32 start = ((rgn >> 12) >> size) << size; // determine the start offset, and use shifts to force alignment with a multiple of the size.
-    u32 end = start + size; // add size to start to determine
+    u32 end = start + (1<<size); // add 1 left shifted by size to start to determine end point
     // dont need to bounds check the end point because the force alignment inherently prevents it from breaking
 
     u8 usermask = 0;

--- a/src/CP15.cpp
+++ b/src/CP15.cpp
@@ -186,11 +186,12 @@ void ARMv5::UpdatePURegion(u32 n)
         return;
     }
 
-    u32 size = ((rgn >> 1) & 0x1F) + 1; // size is increased by 1
-    if (size < 12) size = 12; // min size is 12 (4KiB)
-    u32 start = rgn >> size; // force align start point to a multiple of size by discarding bits
-    u32 end = (start + 1) << (size-12); // then we can determine the end point by simply adding one to the start
-    start <<= (size-12);
+    // notes:
+    // * min size of a pu region is 4KiB
+    // * pu regions are aligned based on their size
+    u32 size = std::min(((rgn>>1) & 0x1F) - 11, 0); // obtain the size, subtract 11 and clamp to a min of 0
+    u32 start = ((rgn >> 12) >> size) << size; // determine the start offset, and use shifts to force alignment with a multiple of the size.
+    u32 end = start + size; // add size to start to determine
     // dont need to bounds check the end point because the force alignment inherently prevents it from breaking
 
     u8 usermask = 0;

--- a/src/CP15.cpp
+++ b/src/CP15.cpp
@@ -187,10 +187,10 @@ void ARMv5::UpdatePURegion(u32 n)
     }
 
     u32 size = ((rgn >> 1) & 0x1F) + 1; // size is increased by 1
-    if (size < 12) size = 12; // min size is 12
-    u32 start = rgn >> size; // force align start to size
-    u32 end = start + 1 << (size-12); // then end is always one away from start
-    start <<= (size-12); // dont forget to fix the start value too :)
+    if (size < 12) size = 12; // min size is 12 (4KiB)
+    u32 start = rgn >> size; // force align start point to a multiple of size by discarding bits
+    u32 end = (start + 1) << (size-12); // then we can determine the end point by simply adding one to the start
+    start <<= (size-12);
     // dont need to bounds check the end point because the force alignment inherently prevents it from breaking
 
     u8 usermask = 0;

--- a/src/CP15.cpp
+++ b/src/CP15.cpp
@@ -187,8 +187,9 @@ void ARMv5::UpdatePURegion(u32 n)
     }
 
     u32 start = rgn >> 12;
-    u32 sz = 2 << ((rgn >> 1) & 0x1F);
-    u32 end = start + (sz >> 12);
+    u64 sz = (u64)2 << ((rgn >> 1) & 0x1F);
+    u64 end = start + (sz >> 12);
+    if (end > 0xFFFFF) end = 0xFFFFF;
     // TODO: check alignment of start
 
     u8 usermask = 0;

--- a/src/CP15.cpp
+++ b/src/CP15.cpp
@@ -186,12 +186,23 @@ void ARMv5::UpdatePURegion(u32 n)
         return;
     }
 
-    u32 start = rgn >> 12;
-    s32 shift = ((rgn >> 1) & 0x1F) - 11;
-    if (shift < 0) shift = 0;
-    u64 end = start + (1 << shift);
-    if (end > 0x100000) end = 0x100000;
-    // TODO: check alignment of start
+    u32 start;
+    u64 end;
+    s32 shift = ((rgn >> 1) & 0x1F);
+    if (shift == 0x1F)
+    {
+        start = 0;
+        end = 0x100000;
+    }
+    else
+    {
+        start = rgn >> 12;
+        shift -= 11;
+        if (shift < 0) shift = 0;
+        end = start + (1 << shift);
+        if (end > 0x100000) end = 0x100000;
+        // TODO: check alignment of start
+    }
 
     u8 usermask = 0;
     u8 privmask = 0;
@@ -241,7 +252,7 @@ void ARMv5::UpdatePURegion(u32 n)
         "PU region %d: %08X-%08X, user=%02X priv=%02X, %08X/%08X\n",
         n,
         start << 12,
-        (end > 0xFFFFF ? 0xFFFFFFFF : end << 12),
+        (end << 12) - 1,
         usermask,
         privmask,
         PU_DataRW,
@@ -578,22 +589,16 @@ void ARMv5::CP15Write(u32 id, u32 val)
     case 0x671:
         char log_output[1024];
         PU_Region[(id >> 4) & 0xF] = val;
-        {
-        u32 start = (val & 0xFFFFF000);
-        u64 sz = (2 << ((val & 0x3E) >> 1));
-        if (sz < 0x1000) sz = 0x1000;
-        u64 end = start + sz;
-        if (end > 0x100000000) end = 0xFFFFFFFF;
+
         std::snprintf(log_output,
                  sizeof(log_output),
-                 "PU: region %d = %08X : %s, %08X-%08X\n",
+                 "PU: region %d = %08X : %s, start: %08X size: %02X\n",
                  (id >> 4) & 0xF,
                  val,
                  val & 1 ? "enabled" : "disabled",
-                 start,
-                 end
+                 val & 0xFFFFF000,
+                 (val & 0x3E) >> 1
         );
-        }
         Log(LogLevel::Debug, "%s", log_output);
         // Some implementations of Log imply a newline, so we build up the line before printing it
 


### PR DESCRIPTION
Adjusts the sizing of PU regions
Enforces a minimum size of 4kb to them.
~~Enforces a cap of 0x100000 to the endpoint variable.~~ Not needed anymore (someone double check my math)
Makes it so that the start point is force aligned to a multiple of the size
which improves hw accuracy, and also fixes it potentially overflowing the size variable, or breaking the bounds of the array and corrupting things.
Fixes one of the bugs impacting GBARunner3.
Also adjusts some logging.