### PR TITLE
fixes for some glitches with polygon strips

### DIFF
--- a/src/GPU3D.h
+++ b/src/GPU3D.h
@@ -322,6 +322,7 @@ public:
     u32 VertexNumInPoly = 0;
     u32 NumConsecutivePolygons = 0;
     Polygon* LastStripPolygon = nullptr;
+    u32 NullVertices = 0;
     u32 NumOpaquePolygons = 0;
 
     Vertex VertexRAM[6144 * 2] {};

--- a/src/GPU3D.h
+++ b/src/GPU3D.h
@@ -39,8 +39,13 @@ struct Vertex
 
     // final vertex attributes.
     // allows them to be reused in polygon strips.
-
+    
+    // with sw renderer FinalPosition is primarily used for calculating the slope of a polygon (not where it begins/ends)
+    // (it does get used to determine where slopes should start and end with the gl renderers)
+    // the initial set of coordinates gets updated by the next polygon in a strip
+    // which can cause rendering issues if they wind up different than their initial value (due to a viewport change)
     s32 FinalPosition[2];
+
     s32 FinalColor[3];
 
     // hi-res position (4-bit fractional part)
@@ -54,6 +59,13 @@ struct Polygon
 {
     Vertex* Vertices[10];
     u32 NumVertices;
+
+    // essentially a per-polygon copy of its vertices' coordinates
+    // (not 100% sure why they do it like this? but a glitch requires this for proper behavior, so we gotta do it too)
+    // unlike each vertices' final position variable, it is *not* updated by the next polygon in a polygon strip
+    // it is used by the software renderer to determine where to begin/end each slope
+    // TODO: track hires versions of this for the hardware renderers to use?
+    s32 SlopePosition[10][2];
 
     s32 FinalZ[10];
     s32 FinalW[10];
@@ -272,6 +284,7 @@ public:
     u32 RenderClearAttr2 = 0;
 
     bool RenderFrameIdentical = false; // not part of the hardware state, don't serialize
+    bool UpdateLastPoly = false; // used to track whether the next polygon should update the previous one's vtx coordinates (as a small optimization)
 
     bool AbortFrame = false;
 

--- a/src/GPU3D_Soft.cpp
+++ b/src/GPU3D_Soft.cpp
@@ -691,27 +691,27 @@ void SoftRenderer::SetupPolygon(SoftRenderer::RendererPolygon* rp, Polygon* poly
         rp->NextVR = rp->CurVR + 1;
         if (rp->NextVR >= nverts) rp->NextVR = 0;
     }
-
+    /*
     if (ybot == ytop)
     {
         vtop = 0; vbot = 0;
         int i;
 
         i = 1;
-        if (polygon->SlopePosition[i][0] < polygon->SlopePosition[vtop][0]) vtop = i;
-        if (polygon->SlopePosition[i][0] > polygon->SlopePosition[vbot][0]) vbot = i;
+        if (polygon->Vertices[i]->FinalPosition[0] < polygon->Vertices[vtop]->FinalPosition[0]) vtop = i;
+        if (polygon->Vertices[i]->FinalPosition[0] > polygon->Vertices[vbot]->FinalPosition[0]) vbot = i;
 
         i = nverts - 1;
-        if (polygon->SlopePosition[i][0] < polygon->SlopePosition[vtop][0]) vtop = i;
-        if (polygon->SlopePosition[i][0] > polygon->SlopePosition[vbot][0]) vbot = i;
+        if (polygon->Vertices[i]->FinalPosition[0] < polygon->Vertices[vtop]->FinalPosition[0]) vtop = i;
+        if (polygon->Vertices[i]->FinalPosition[0] > polygon->Vertices[vbot]->FinalPosition[0]) vbot = i;
 
         rp->CurVL = vtop; rp->NextVL = vtop;
         rp->CurVR = vbot; rp->NextVR = vbot;
 
-        rp->XL = rp->SlopeL.SetupDummy(polygon->SlopePosition[rp->CurVL][0]);
-        rp->XR = rp->SlopeR.SetupDummy(polygon->SlopePosition[rp->CurVR][0]);
+        rp->XL = rp->SlopeL.SetupDummy(polygon->Vertices[rp->CurVL]->FinalPosition[0]);
+        rp->XR = rp->SlopeR.SetupDummy(polygon->Vertices[rp->CurVR]->FinalPosition[0]);
     }
-    else
+    else*/
     {
         SetupPolygonLeftEdge(rp, ytop);
         SetupPolygonRightEdge(rp, ytop);

--- a/src/GPU3D_Soft.cpp
+++ b/src/GPU3D_Soft.cpp
@@ -725,7 +725,7 @@ void SoftRenderer::SetupPolygon(SoftRenderer::RendererPolygon* rp, Polygon* poly
 
         rp->XL = rp->SlopeL.Setup(polygon->Vertices[rp->CurVL]->FinalPosition[0], polygon->Vertices[rp->NextVL]->FinalPosition[0],
                                   polygon->Vertices[rp->CurVL]->FinalPosition[1], y1,
-                                  polygon->FinalW[rp->CurVL], polygon->FinalW[rp->NextVL], y, polygon->WBuffer);
+                                  polygon->FinalW[rp->CurVL], polygon->FinalW[rp->NextVL], y);
         
         y = ytop;
         if (y < polygon->Vertices[rp->CurVR]->FinalPosition[1])
@@ -737,7 +737,7 @@ void SoftRenderer::SetupPolygon(SoftRenderer::RendererPolygon* rp, Polygon* poly
 
         rp->XR = rp->SlopeR.Setup(polygon->Vertices[rp->CurVR]->FinalPosition[0], polygon->Vertices[rp->NextVR]->FinalPosition[0],
                                   polygon->Vertices[rp->CurVR]->FinalPosition[1], y1,
-                                  polygon->FinalW[rp->CurVR], polygon->FinalW[rp->NextVR], y, polygon->WBuffer);
+                                  polygon->FinalW[rp->CurVR], polygon->FinalW[rp->NextVR], y);
     }
 }
 
@@ -891,7 +891,6 @@ void SoftRenderer::RenderShadowMaskScanline(const GPU3D& gpu3d, RendererPolygon*
         r_edgelen += 256 - xend;
         xend = 511;
     }
-    s32 x = xstart;
     Interpolator<0> interpX(xstart, xend+1, wl, wr);
 
     s32 xlimit;
@@ -1155,7 +1154,6 @@ void SoftRenderer::RenderPolygonScanline(const GPU& gpu, RendererPolygon* rp, s3
         r_edgelen += 256 - xend;
         xend = 511;
     }
-    s32 x = xstart;
     Interpolator<0> interpX(xstart, xend+1, wl, wr);
 
     s32 xlimit;

--- a/src/GPU3D_Soft.h
+++ b/src/GPU3D_Soft.h
@@ -341,7 +341,7 @@ private:
             if (Negative) ret = x0 - (dx >> 18);
             else          ret = x0 + (dx >> 18);
 
-            return ret;
+            return ret << 21 >> 21; // treated as a signed 11 bit integer (for some reason)
         }
 
         template<bool swapped>


### PR DESCRIPTION
fix polygon rasterization not completely breaking down when updating viewport mid-strip
sort of fix some weird behavior that occurs when continuing a polygon strip through a buffer swap