### PR TITLE
implement gx hanging

### DIFF
--- a/src/GPU3D.h
+++ b/src/GPU3D.h
@@ -98,7 +98,7 @@ public:
 
     void ExecuteCommand() noexcept;
 
-    s32 CyclesToRunFor() const noexcept;
+    s64 CyclesToRunFor() const noexcept;
     void Run() noexcept;
     void CheckFIFOIRQ() noexcept;
     void CheckFIFODMA() noexcept;
@@ -143,9 +143,10 @@ private:
 
     void UpdateClipMatrix() noexcept;
     void ResetRenderingState() noexcept;
-    void AddCycles(s32 num) noexcept;
+    void AddCycles(s64 num) noexcept;
     void NextVertexSlot() noexcept;
     void StallPolygonPipeline(s32 delay, s32 nonstalldelay) noexcept;
+    void HangGX(const char* cause) noexcept;
     void SubmitPolygon() noexcept;
     void SubmitVertex() noexcept;
     void CalculateLighting() noexcept;
@@ -204,7 +205,7 @@ public:
     u32 ExecParams[32] {};
     u32 ExecParamCount = 0;
 
-    s32 CycleCount = 0;
+    s64 CycleCount = 0;
     s32 VertexPipeline = 0;
     s32 NormalPipeline = 0;
     s32 PolygonPipeline = 0;
@@ -305,7 +306,7 @@ public:
     s16 VecTestResult[3] {};
 
     Vertex TempVertexBuffer[4] {};
-    u32 VertexNum = 0;
+    bool IncompletePoly = false;
     u32 VertexNumInPoly = 0;
     u32 NumConsecutivePolygons = 0;
     Polygon* LastStripPolygon = nullptr;

--- a/src/NDS.cpp
+++ b/src/NDS.cpp
@@ -943,8 +943,7 @@ u32 NDS::RunFrame()
                 if (CPUStop & CPUStop_GXStall)
                 {
                     // GXFIFO stall
-                    s32 cycles = GPU.GPU3D.CyclesToRunFor();
-
+                    s64 cycles = GPU.GPU3D.CyclesToRunFor();
                     ARM9Timestamp = std::min(ARM9Target, ARM9Timestamp+(cycles<<ARM9ClockShift));
                 }
                 else if (CPUStop & CPUStop_DMA9)


### PR DESCRIPTION
implements hanging on:
begin poly with partial poly defined
box test with partial poly defined
swap buffers with partial poly defined

also remove some useless variables:
vertexnum wasn't used.
NumConsecPolys was only used by triangle strips