### PR TITLE
Fix horizontal mosaic on sprites

### DIFF
--- a/src/GPU2D_Soft.cpp
+++ b/src/GPU2D_Soft.cpp
@@ -1507,7 +1507,7 @@ void SoftRenderer::ApplySpriteMosaicX()
 
     u32* objLine = OBJLine[CurUnit->Num];
 
-    u8* curOBJXMosaicTable = MosaicTable[CurUnit->OBJMosaicSize[1]].data();
+    u8* curOBJXMosaicTable = MosaicTable[CurUnit->OBJMosaicSize[0]].data();
 
     u32 lastcolor = objLine[0];
 


### PR DESCRIPTION
The code itself is correct, but the variable being read is the Y mosaic
coordinate, not the X coordinate.