### PR TITLE
Bind 'Toggle Fullscreen' hotkey to F11 by default

### DIFF
--- a/src/frontend/qt_sdl/Config.cpp
+++ b/src/frontend/qt_sdl/Config.cpp
@@ -48,6 +48,7 @@ toml::value RootTable;
 DefaultList<int> DefaultInts =
 {
     {"Instance*.Keyboard", -1},
+    {"Instance*.Keyboard.HK_FullscreenToggle", 16777274}, // F11 key
     {"Instance*.Joystick", -1},
     {"Instance*.Window*.Width", 256},
     {"Instance*.Window*.Height", 384},


### PR DESCRIPTION
This pull request updates the default settings to bind the hotkey which toggles fullscreen to the F11 key.

I am proposing this due to my personal initial impression with the emulator, where I experienced immediate confusion on how I was supposed to full-screen the emulator. At first I tried pressing F11, as is convention with all software, and nothing happened. I then attempted to find a fullscreen toggle in various corners of the menu bar, to no effect.

This lead to me having to use the internet to find out how to enter fullscreen, which lead to me finding a year old Reddit thread explaining that a hotkey existed and that many people were unnecessarily using command line parameters without knowing this information.

This seems like quite poor UX, so I believe that MelonDS should follow expected software convention and use the F11 key to enter fullscreen by default, as this is the behaviour that most users will expect.

I am unfamiliar with this codebase, so please correct me if I have approached implementing this incorrectly.