### PR TITLE
Allow frontends to use different headers for OpenGL declarations

### DIFF
--- a/src/PlatformOGL.h
+++ b/src/PlatformOGL.h
@@ -1,9 +1,16 @@
 #ifndef PLATFORMOGL_H
 #define PLATFORMOGL_H
 
-// if you don't wanna use glad for your platform
-// add your header here!
+// If you don't wanna use glad for your platform,
+// define MELONDS_GL_HEADER to the path of some other header
+// that pulls in the necessary OpenGL declarations.
+// Make sure to include quotes or angle brackets as needed,
+// and that all targets get the same MELONDS_GL_HEADER definition.
 
-#include "frontend/glad/glad.h"
+#ifndef MELONDS_GL_HEADER
+#define MELONDS_GL_HEADER "\"frontend/glad/glad.h\""
+#endif
+
+#include MELONDS_GL_HEADER
 
 #endif

--- a/src/frontend/qt_sdl/CMakeLists.txt
+++ b/src/frontend/qt_sdl/CMakeLists.txt
@@ -247,3 +247,11 @@ if (UNIX AND NOT APPLE)
             INTERPROCEDURAL_OPTIMIZATION_RELEASE OFF)
     endif()
 endif()
+
+if (ENABLE_OGLRENDERER)
+    set(MELONDS_GL_HEADER \"frontend/glad/glad.h\" CACHE STRING "Path to a header that contains OpenGL function and type declarations.")
+
+    target_compile_definitions(melonDS PUBLIC OGLRENDERER_ENABLED)
+    target_compile_definitions(melonDS PUBLIC MELONDS_GL_HEADER=${MELONDS_GL_HEADER})
+    target_compile_definitions(core PUBLIC MELONDS_GL_HEADER=${MELONDS_GL_HEADER})
+endif()


### PR DESCRIPTION
This PR allows frontends to use any header they want for pulling in OpenGL declarations. As stated in #1716 (which this PR supersedes), the OpenGL constants and types defined by GLAD will conflict with whatever alternative OpenGL loader a frontend uses.
