### PR TITLE
Expose some fields of `DSi_BPTWL` needed to support direct boot

### DIFF
--- a/src/DSi_I2C.cpp
+++ b/src/DSi_I2C.cpp
@@ -68,7 +68,7 @@ DSi_BPTWL::~DSi_BPTWL()
 void DSi_BPTWL::Reset()
 {
     CurPos = -1;
-    memset(Registers, 0x5A, 0x100);
+    Registers.fill(0x5a);
 
     Registers[0x00] = 0x33; // TODO: support others??
     Registers[0x01] = 0x00;
@@ -112,7 +112,7 @@ void DSi_BPTWL::DoSavestate(Savestate* file)
 {
     file->Section("I2BP");
 
-    file->VarArray(Registers, 0x100);
+    file->VarArray(Registers.data(), Registers.size());
     file->Var32(&CurPos);
 }
 

--- a/src/DSi_I2C.cpp
+++ b/src/DSi_I2C.cpp
@@ -68,7 +68,7 @@ DSi_BPTWL::~DSi_BPTWL()
 void DSi_BPTWL::Reset()
 {
     CurPos = -1;
-    Registers.fill(0x5a);
+    memset(Registers, 0x5A, 0x100);
 
     Registers[0x00] = 0x33; // TODO: support others??
     Registers[0x01] = 0x00;
@@ -112,7 +112,7 @@ void DSi_BPTWL::DoSavestate(Savestate* file)
 {
     file->Section("I2BP");
 
-    file->VarArray(Registers.data(), Registers.size());
+    file->VarArray(Registers, 0x100);
     file->Var32(&CurPos);
 }
 

--- a/src/DSi_I2C.h
+++ b/src/DSi_I2C.h
@@ -87,6 +87,7 @@ public:
     void DoSavestate(Savestate* file) override;
 
     u8 GetBootFlag() const;
+    void SetBootFlag(u8 boot) noexcept { Registers[0x70] = boot; }
 
     bool GetBatteryCharging() const;
     void SetBatteryCharging(bool charging);

--- a/src/DSi_I2C.h
+++ b/src/DSi_I2C.h
@@ -19,7 +19,6 @@
 #ifndef DSI_I2C_H
 #define DSI_I2C_H
 
-#include <array>
 #include "types.h"
 #include "Savestate.h"
 
@@ -88,7 +87,6 @@ public:
     void DoSavestate(Savestate* file) override;
 
     u8 GetBootFlag() const;
-    void SetBootFlag(u8 boot) noexcept { Registers[0x70] = boot; }
 
     bool GetBatteryCharging() const;
     void SetBatteryCharging(bool charging);
@@ -120,9 +118,6 @@ public:
     void DoPowerButtonForceShutdown();
     void DoVolumeSwitchPress(u32 key);
 
-    [[nodiscard]] const std::array<u8, 0x100>& GetRegisters() const noexcept { return Registers; }
-    [[nodiscard]] std::array<u8, 0x100>& GetRegisters() noexcept { return Registers; }
-
     void SetIRQ(u8 irqFlag);
 
     void Acquire() override;
@@ -146,7 +141,7 @@ private:
     bool VolumeSwitchDownFlag ;
     u32 VolumeSwitchKeysDown;
 
-    std::array<u8, 0x100> Registers;
+    u8 Registers[0x100];
     u32 CurPos;
 
     bool GetIRQMode() const;

--- a/src/DSi_I2C.h
+++ b/src/DSi_I2C.h
@@ -19,6 +19,7 @@
 #ifndef DSI_I2C_H
 #define DSI_I2C_H
 
+#include <array>
 #include "types.h"
 #include "Savestate.h"
 
@@ -87,6 +88,7 @@ public:
     void DoSavestate(Savestate* file) override;
 
     u8 GetBootFlag() const;
+    void SetBootFlag(u8 boot) noexcept { Registers[0x70] = boot; }
 
     bool GetBatteryCharging() const;
     void SetBatteryCharging(bool charging);
@@ -118,6 +120,9 @@ public:
     void DoPowerButtonForceShutdown();
     void DoVolumeSwitchPress(u32 key);
 
+    [[nodiscard]] const std::array<u8, 0x100>& GetRegisters() const noexcept { return Registers; }
+    [[nodiscard]] std::array<u8, 0x100>& GetRegisters() noexcept { return Registers; }
+
     void SetIRQ(u8 irqFlag);
 
     void Acquire() override;
@@ -141,7 +146,7 @@ private:
     bool VolumeSwitchDownFlag ;
     u32 VolumeSwitchKeysDown;
 
-    u8 Registers[0x100];
+    std::array<u8, 0x100> Registers;
     u32 CurPos;
 
     bool GetIRQMode() const;


### PR DESCRIPTION
This PR exposes the registers defined in `DSi_BPTWL`, so that direct-boot can be used for DSi games. See https://github.com/JesseTG/melonds-ds/issues/148 for details on why I'd like to be able to do this.