### PR TITLE
Fix console output on Windows

### DIFF
--- a/src/frontend/qt_sdl/main.cpp
+++ b/src/frontend/qt_sdl/main.cpp
@@ -361,6 +361,12 @@ int main(int argc, char** argv)
 
 int CALLBACK WinMain(HINSTANCE hinst, HINSTANCE hprev, LPSTR cmdline, int cmdshow)
 {
+    if (AttachConsole(ATTACH_PARENT_PROCESS) && GetStdHandle(STD_OUTPUT_HANDLE))
+    {
+        freopen("CONOUT$", "w", stdout);
+        freopen("CONOUT$", "w", stderr);
+    }
+
     int ret = main(__argc, __argv);
 
     printf("\n\n>");


### PR DESCRIPTION
This fixes console output on Windows by making it appear in the console where the emulator was started, by default. With this change, melonDS can also be started with a new console window by running `start cmd /c melonDS.exe`.

Thanks to @CasualPokePlayer for pointing me in the right direction.