### PR TITLE
fix potential for a gpu threading desync when exiting sleep mode

### DIFF
--- a/src/NDS.cpp
+++ b/src/NDS.cpp
@@ -1341,7 +1341,6 @@ void NDS::SetIRQ(u32 cpu, u32 irq)
         {
             CPUStop &= ~CPUStop_Sleep;
             CPUStop |= CPUStop_Wakeup;
-            GPU.GPU3D.RestartFrame(GPU);
         }
     }
 }


### PR DESCRIPTION
To surmise the fix: the use of restart frame here means that the 3d gpu starts from 0, but the 2d gpu picks up where it left off. which has potential to cause problems since the sync mechanism assumes that the 2d gpu will always be behind the 3d gpu.