### PR TITLE
Rework to how polygon orientation is determined

### DIFF
--- a/src/GPU3D.cpp
+++ b/src/GPU3D.cpp
@@ -995,7 +995,7 @@ void GPU3D::SubmitPolygon() noexcept
 
         facingview = (cross >= 0);
         
-        if (cross >= 0)
+        if (cross > 0)
         {
             if (!(CurPolygonAttr & (1<<7)))
             {
@@ -1003,9 +1003,17 @@ void GPU3D::SubmitPolygon() noexcept
                 return;
             }
         }
-        else if (cross <= 0)
+        else if (cross < 0)
         {
             if (!(CurPolygonAttr & (1<<6)))
+            {
+                LastStripPolygon = NULL;
+                return;
+            }
+        }
+        else // cross == 0
+        {
+            if (!(CurPolygonAttr & (3<<6)))
             {
                 LastStripPolygon = NULL;
                 return;
@@ -1357,10 +1365,10 @@ void GPU3D::SubmitVertex() noexcept
     Vertex* vertextrans = &TempVertexBuffer[VertexNumInPoly];
 
     UpdateClipMatrix();
-    vertextrans->Position[0] = (vertex[0]*ClipMatrix[0] + vertex[1]*ClipMatrix[4] + vertex[2]*ClipMatrix[8] + vertex[3]*ClipMatrix[12]) >> 12;
-    vertextrans->Position[1] = (vertex[0]*ClipMatrix[1] + vertex[1]*ClipMatrix[5] + vertex[2]*ClipMatrix[9] + vertex[3]*ClipMatrix[13]) >> 12;
-    vertextrans->Position[2] = (vertex[0]*ClipMatrix[2] + vertex[1]*ClipMatrix[6] + vertex[2]*ClipMatrix[10] + vertex[3]*ClipMatrix[14]) >> 12;
-    vertextrans->Position[3] = (vertex[0]*ClipMatrix[3] + vertex[1]*ClipMatrix[7] + vertex[2]*ClipMatrix[11] + vertex[3]*ClipMatrix[15]) >> 12;
+    vertextrans->Position[0] = ((vertex[0]*ClipMatrix[0] + vertex[1]*ClipMatrix[4] + vertex[2]*ClipMatrix[8] + vertex[3]*ClipMatrix[12]) << 25) >> 41;
+    vertextrans->Position[1] = ((vertex[0]*ClipMatrix[1] + vertex[1]*ClipMatrix[5] + vertex[2]*ClipMatrix[9] + vertex[3]*ClipMatrix[13]) << 25) >> 41;
+    vertextrans->Position[2] = ((vertex[0]*ClipMatrix[2] + vertex[1]*ClipMatrix[6] + vertex[2]*ClipMatrix[10] + vertex[3]*ClipMatrix[14]) << 25) >> 41;
+    vertextrans->Position[3] = ((vertex[0]*ClipMatrix[3] + vertex[1]*ClipMatrix[7] + vertex[2]*ClipMatrix[11] + vertex[3]*ClipMatrix[15]) << 25) >> 41;
 
     // this probably shouldn't be.
     // the way color is handled during clipping needs investigation. TODO

--- a/src/GPU3D.cpp
+++ b/src/GPU3D.cpp
@@ -977,41 +977,39 @@ void GPU3D::SubmitPolygon() noexcept
     v1 = &TempVertexBuffer[1];
     v2 = &TempVertexBuffer[2];
     v3 = &TempVertexBuffer[3];
+    
+    s32 vector[4];
+    vector[0] = v0->Position[0] - v2->Position[0];
+    vector[1] = v0->Position[1] - v2->Position[1];
+    vector[2] = v1->Position[0] - v2->Position[0];
+    vector[3] = v1->Position[1] - v2->Position[1];
 
-    normalX = ((s64)(v0->Position[1]-v1->Position[1]) * (v2->Position[3]-v1->Position[3]))
-        - ((s64)(v0->Position[3]-v1->Position[3]) * (v2->Position[1]-v1->Position[1]));
-    normalY = ((s64)(v0->Position[3]-v1->Position[3]) * (v2->Position[0]-v1->Position[0]))
-        - ((s64)(v0->Position[0]-v1->Position[0]) * (v2->Position[3]-v1->Position[3]));
-    normalZ = ((s64)(v0->Position[0]-v1->Position[0]) * (v2->Position[1]-v1->Position[1]))
-        - ((s64)(v0->Position[1]-v1->Position[1]) * (v2->Position[0]-v1->Position[0]));
-
-    while ((((normalX>>31) ^ (normalX>>63)) != 0) ||
-           (((normalY>>31) ^ (normalY>>63)) != 0) ||
-           (((normalZ>>31) ^ (normalZ>>63)) != 0))
+    bool facingview;
+    if ((vector[0] | vector[1]) == 0 || (vector[2] | vector[3]) == 0) // if either vector is 0 the polygon is accepted and treated as front facing.
     {
-        normalX >>= 4;
-        normalY >>= 4;
-        normalZ >>= 4;
+        facingview = true;
     }
-
-    dot = ((s64)v1->Position[0] * normalX) + ((s64)v1->Position[1] * normalY) + ((s64)v1->Position[3] * normalZ);
-
-    bool facingview = (dot <= 0);
-
-    if (dot < 0)
+    else
     {
-        if (!(CurPolygonAttr & (1<<7)))
+        s64 cross = (vector[0] * vector[3]) - (vector[1] * vector[2]);
+
+        facingview = (cross >= 0);
+        
+        if (cross >= 0)
         {
-            LastStripPolygon = NULL;
-            return;
+            if (!(CurPolygonAttr & (1<<7)))
+            {
+                LastStripPolygon = NULL;
+                return;
+            }
         }
-    }
-    else if (dot > 0)
-    {
-        if (!(CurPolygonAttr & (1<<6)))
+        else if (cross <= 0)
         {
-            LastStripPolygon = NULL;
-            return;
+            if (!(CurPolygonAttr & (1<<6)))
+            {
+                LastStripPolygon = NULL;
+                return;
+            }
         }
     }
 


### PR DESCRIPTION
Reworks the way that a polygon's orientation is determined to use a simpler algorithm, the main reason for this is to give a *slightly* better reason to explain some weird quirky behavior i've noticed.
Specifically how a polygon with a dot of 0 can be treated as either both facing directions or neither facing direction for poly face culling depending on whether the first/second vertex is overlapping the 3rd vertex.
This can now be semi-logically explained by the fact that the vectors have a length of 0.
Doesn't really explain *why* they decided to handle those vectors differently, but it at least gives some basis to the theory.

also the coordinates seem to be clamped to 27 bits (including sign bit) before the orientation calc (just for it?)

Current caveats:
I'll be honest, i don't really 100% understand what the original code was trying to handle with regards to overflows or using the W coordinate in the calculations.
I haven't yet noticed anything personally that indicated needing anything fancy but i also haven't tested too thoroughly yet.
