### PR TITLE
Fix the build when the JIT is disabled

### DIFF
--- a/src/ARM.cpp
+++ b/src/ARM.cpp
@@ -609,6 +609,7 @@ void ARMv5::Execute()
 
     while (NDS.ARM9Timestamp < NDS.ARM9Target)
     {
+#ifdef JIT_ENABLED
         if constexpr (mode == CPUExecuteMode::JIT)
         {
             u32 instrAddr = R[15] - ((CPSR&0x20)?2:4);
@@ -647,6 +648,7 @@ void ARMv5::Execute()
             }
         }
         else
+#endif
         {
             if (CPSR & 0x20) // THUMB
             {
@@ -747,6 +749,7 @@ void ARMv4::Execute()
 
     while (NDS.ARM7Timestamp < NDS.ARM7Target)
     {
+#ifdef JIT_ENABLED
         if constexpr (mode == CPUExecuteMode::JIT)
         {
             u32 instrAddr = R[15] - ((CPSR&0x20)?2:4);
@@ -784,6 +787,7 @@ void ARMv4::Execute()
             }
         }
         else
+#endif
         {
             if (CPSR & 0x20) // THUMB
             {


### PR DESCRIPTION
This PR fixes compiler errors in builds that exclude JIT support. [A recent commit](https://github.com/melonDS-emu/melonDS/commit/dd386d12a94252364b5e0706ec719c390faf90b8) introduced JIT-specific changes without ensuring that the JIT is actually available; as a result, errors such as [these](https://github.com/JesseTG/melonds-ds/actions/runs/10446155500/job/28923156089) occur.