### PR TITLE
Subtle fixes for compressed texture coloration/bit depth

### DIFF
--- a/src/GPU3D_Soft.cpp
+++ b/src/GPU3D_Soft.cpp
@@ -287,7 +287,7 @@ void SoftRenderer::TextureLookup(const GPU& gpu, u32 texparam, u32 texpal, s16 s
             {
                 u16 color = ReadVRAM_TexPal<u16>(texpal + paloffset, gpu);
                 *alpha = 31;
-                if (!((palinfo >> 14) & 0x1) || gpu.GPU3D.RenderRasterRev)
+                if (!((palinfo >> 14) & 0x1))
                     ColorConv<true>(color, tr, tg, tb);
                 else
                     ColorConv<false>(color, tr, tg, tb);
@@ -298,7 +298,7 @@ void SoftRenderer::TextureLookup(const GPU& gpu, u32 texparam, u32 texpal, s16 s
             {
                 u16 color = ReadVRAM_TexPal<u16>(texpal + paloffset + 2, gpu);
                 *alpha = 31;
-                if (!((palinfo >> 14) & 0x1) || gpu.GPU3D.RenderRasterRev)
+                if (!((palinfo >> 14) & 0x1))
                     ColorConv<true>(color, tr, tg, tb);
                 else
                     ColorConv<false>(color, tr, tg, tb);

--- a/src/GPU3D_Soft.cpp
+++ b/src/GPU3D_Soft.cpp
@@ -259,6 +259,7 @@ void SoftRenderer::TextureLookup(const GPU& gpu, u32 texparam, u32 texpal, s16 s
             // NOTE: compressed textures have a bug where the wont add +1 to their texture color when increasing bit depth
             // This only happens in modes 1 and 3, but this *is* fixed by the revised rasterizer circuit
             // ...except they forgot to fix it for the interpolated colors so uh... partial credit
+            // Interpolated colors are unique in being 6 bit colors; they dont discard their least significant bit.
             vramaddr += ((t & 0x3FC) * (width>>2)) + (s & 0x3FC);
             vramaddr += (t & 0x3);
             vramaddr &= 0x7FFFF; // address used for all calcs wraps around after slot 3
@@ -317,9 +318,9 @@ void SoftRenderer::TextureLookup(const GPU& gpu, u32 texparam, u32 texpal, s16 s
                     u32 g1 = color1 & 0x03E0;
                     u32 b1 = color1 & 0x7C00;
 
-                    *tr = (r0 + r1) + 1         & 0x3E;
-                    *tg = ((g0 + g1) >> 5) + 1  & 0x3E;
-                    *tb = ((b0 + b1) >> 10) + 1 & 0x3E;
+                    *tr = (r0 + r1);
+                    *tg = ((g0 + g1) >> 5);
+                    *tb = ((b0 + b1) >> 10);
                 }
                 else if ((palinfo >> 14) == 3)
                 {
@@ -333,9 +334,9 @@ void SoftRenderer::TextureLookup(const GPU& gpu, u32 texparam, u32 texpal, s16 s
                     u32 g1 = color1 & 0x03E0;
                     u32 b1 = color1 & 0x7C00;
 
-                    *tr = ((r0*5 + r1*3) >> 2) + 1  & 0x3E;
-                    *tg = ((g0*5 + g1*3) >> 7) + 1  & 0x3E;
-                    *tb = ((b0*5 + b1*3) >> 12) + 1 & 0x3E;
+                    *tr = ((r0*5 + r1*3) >> 2);
+                    *tg = ((g0*5 + g1*3) >> 7);
+                    *tb = ((b0*5 + b1*3) >> 12);
                 }
                 else
                 {
@@ -364,9 +365,9 @@ void SoftRenderer::TextureLookup(const GPU& gpu, u32 texparam, u32 texpal, s16 s
                     u32 g1 = color1 & 0x03E0;
                     u32 b1 = color1 & 0x7C00;
 
-                    *tr = ((r0*3 + r1*5) >> 2) + 1  & 0x3E;
-                    *tg = ((g0*3 + g1*5) >> 7) + 1  & 0x3E;
-                    *tb = ((b0*3 + b1*5) >> 12) + 1 & 0x3E;
+                    *tr = ((r0*3 + r1*5) >> 2);
+                    *tg = ((g0*3 + g1*5) >> 7);
+                    *tb = ((b0*3 + b1*5) >> 12);
 
                     *alpha = 31;
                 }

--- a/src/GPU3D_Soft.cpp
+++ b/src/GPU3D_Soft.cpp
@@ -141,9 +141,9 @@ void SoftRenderer::SetThreaded(bool threaded, GPU& gpu) noexcept
 template <bool colorcorrect>
 inline void SoftRenderer::ColorConv(const u16 color, u8* r, u8* g, u8* b) const
 {
-    *r = (color << 1) & 0x3E; if (colorcorrect && *r) *r++;
-    *g = (color >> 4) & 0x3E; if (colorcorrect && *g) *g++;
-    *b = (color >> 9) & 0x3E; if (colorcorrect && *b) *b++;
+    *r = (color << 1) & 0x3E; if (colorcorrect && *r) ++*r;
+    *g = (color >> 4) & 0x3E; if (colorcorrect && *g) ++*g;
+    *b = (color >> 9) & 0x3E; if (colorcorrect && *b) ++*b;
 }
 
 void SoftRenderer::TextureLookup(const GPU& gpu, u32 texparam, u32 texpal, s16 s, s16 t, u8* tr, u8* tg, u8* tb, u8* alpha) const

--- a/src/GPU3D_Soft.cpp
+++ b/src/GPU3D_Soft.cpp
@@ -317,9 +317,9 @@ void SoftRenderer::TextureLookup(const GPU& gpu, u32 texparam, u32 texpal, s16 s
                     u32 g1 = color1 & 0x03E0;
                     u32 b1 = color1 & 0x7C00;
 
-                    *tr = (r0 + r1)        & 0x3E;
-                    *tg = ((g0 + g1) >> 5) & 0x3E;
-                    *tb = ((b0 + b1) >> 10) & 0x3E;
+                    *tr = (r0 + r1) + 1         & 0x3E;
+                    *tg = ((g0 + g1) >> 5) + 1  & 0x3E;
+                    *tb = ((b0 + b1) >> 10) + 1 & 0x3E;
                 }
                 else if ((palinfo >> 14) == 3)
                 {
@@ -333,9 +333,9 @@ void SoftRenderer::TextureLookup(const GPU& gpu, u32 texparam, u32 texpal, s16 s
                     u32 g1 = color1 & 0x03E0;
                     u32 b1 = color1 & 0x7C00;
 
-                    *tr = ((r0*5 + r1*3) >> 2)  & 0x3E;
-                    *tg = ((g0*5 + g1*3) >> 7)  & 0x3E;
-                    *tb = ((b0*5 + b1*3) >> 12) & 0x3E;
+                    *tr = ((r0*5 + r1*3) >> 2) + 1  & 0x3E;
+                    *tg = ((g0*5 + g1*3) >> 7) + 1  & 0x3E;
+                    *tb = ((b0*5 + b1*3) >> 12) + 1 & 0x3E;
                 }
                 else
                 {
@@ -364,9 +364,9 @@ void SoftRenderer::TextureLookup(const GPU& gpu, u32 texparam, u32 texpal, s16 s
                     u32 g1 = color1 & 0x03E0;
                     u32 b1 = color1 & 0x7C00;
 
-                    *tr = ((r0*3 + r1*5) >> 2)  & 0x3E;
-                    *tg = ((g0*3 + g1*5) >> 7)  & 0x3E;
-                    *tb = ((b0*3 + b1*5) >> 12) & 0x3E;
+                    *tr = ((r0*3 + r1*5) >> 2) + 1  & 0x3E;
+                    *tg = ((g0*3 + g1*5) >> 7) + 1  & 0x3E;
+                    *tb = ((b0*3 + b1*5) >> 12) + 1 & 0x3E;
 
                     *alpha = 31;
                 }

--- a/src/GPU3D_Soft.cpp
+++ b/src/GPU3D_Soft.cpp
@@ -138,7 +138,7 @@ void SoftRenderer::SetThreaded(bool threaded, GPU& gpu) noexcept
     }
 }
 
-void SoftRenderer::TextureLookup(const GPU& gpu, u32 texparam, u32 texpal, s16 s, s16 t, u16* color, u8* alpha) const
+bool SoftRenderer::TextureLookup(const GPU& gpu, u32 texparam, u32 texpal, s16 s, s16 t, u16* color, u8* alpha) const
 {
     u32 vramaddr = (texparam & 0xFFFF) << 3;
 
@@ -199,7 +199,7 @@ void SoftRenderer::TextureLookup(const GPU& gpu, u32 texparam, u32 texpal, s16 s
             *color = ReadVRAM_TexPal<u16>(texpal + ((pixel&0x1F)<<1), gpu);
             *alpha = ((pixel >> 3) & 0x1C) + (pixel >> 6);
         }
-        break;
+        return true;
 
     case 2: // 4-color
         {
@@ -212,7 +212,7 @@ void SoftRenderer::TextureLookup(const GPU& gpu, u32 texparam, u32 texpal, s16 s
             *color = ReadVRAM_TexPal<u16>(texpal + (pixel<<1), gpu);
             *alpha = (pixel==0) ? alpha0 : 31;
         }
-        break;
+        return true;
 
     case 3: // 16-color
         {
@@ -225,7 +225,7 @@ void SoftRenderer::TextureLookup(const GPU& gpu, u32 texparam, u32 texpal, s16 s
             *color = ReadVRAM_TexPal<u16>(texpal + (pixel<<1), gpu);
             *alpha = (pixel==0) ? alpha0 : 31;
         }
-        break;
+        return true;
 
     case 4: // 256-color
         {
@@ -236,10 +236,13 @@ void SoftRenderer::TextureLookup(const GPU& gpu, u32 texparam, u32 texpal, s16 s
             *color = ReadVRAM_TexPal<u16>(texpal + (pixel<<1), gpu);
             *alpha = (pixel==0) ? alpha0 : 31;
         }
-        break;
+        return true;
 
     case 5: // compressed
         {
+            // NOTE: compressed textures have a bug where the wont add +1 their texture color when increasing bit depth
+            // This only happens in the modes 1 and 3, but this *is* fixed by the revised rasterizer circuit
+            // ...except they forgot to fix it for the interpolated colors so uh... partial credit
             vramaddr += ((t & 0x3FC) * (width>>2)) + (s & 0x3FC);
             vramaddr += (t & 0x3);
             vramaddr &= 0x7FFFF; // address used for all calcs wraps around after slot 3
@@ -266,12 +269,12 @@ void SoftRenderer::TextureLookup(const GPU& gpu, u32 texparam, u32 texpal, s16 s
             case 0:
                 *color = ReadVRAM_TexPal<u16>(texpal + paloffset, gpu);
                 *alpha = 31;
-                break;
+                return ((palinfo >> 14) & 0x1) ? gpu.GPU3D.RenderRasterRev : true;
 
             case 1:
                 *color = ReadVRAM_TexPal<u16>(texpal + paloffset + 2, gpu);
                 *alpha = 31;
-                break;
+                return ((palinfo >> 14) & 0x1) ? gpu.GPU3D.RenderRasterRev : true;
 
             case 2:
                 if ((palinfo >> 14) == 1)
@@ -320,6 +323,7 @@ void SoftRenderer::TextureLookup(const GPU& gpu, u32 texparam, u32 texpal, s16 s
                 {
                     *color = ReadVRAM_TexPal<u16>(texpal + paloffset + 6, gpu);
                     *alpha = 31;
+                    break;
                 }
                 else if ((palinfo >> 14) == 3)
                 {
@@ -339,16 +343,22 @@ void SoftRenderer::TextureLookup(const GPU& gpu, u32 texparam, u32 texpal, s16 s
 
                     *color = r | g | b;
                     *alpha = 31;
+                    break;
                 }
                 else
                 {
                     *color = 0;
                     *alpha = 0;
+                    break;
                 }
                 break;
+
+            default:
+                __builtin_unreachable();
             }
+            // only colors 2 and 3 should make it to here.
+            return !((palinfo >> 14) & 1);
         }
-        break;
 
     case 6: // A5I3
         {
@@ -359,7 +369,7 @@ void SoftRenderer::TextureLookup(const GPU& gpu, u32 texparam, u32 texpal, s16 s
             *color = ReadVRAM_TexPal<u16>(texpal + ((pixel&0x7)<<1), gpu);
             *alpha = (pixel >> 3);
         }
-        break;
+        return true;
 
     case 7: // direct color
         {
@@ -367,7 +377,10 @@ void SoftRenderer::TextureLookup(const GPU& gpu, u32 texparam, u32 texpal, s16 s
             *color = ReadVRAM_Texture<u16>(vramaddr, gpu);
             *alpha = (*color & 0x8000) ? 31 : 0;
         }
-        break;
+        return true;
+
+    default:
+        __builtin_unreachable();
     }
 }
 
@@ -488,11 +501,11 @@ u32 SoftRenderer::RenderPixel(const GPU& gpu, const Polygon* polygon, u8 vr, u8 
         u8 tr, tg, tb;
 
         u16 tcolor; u8 talpha;
-        TextureLookup(gpu, polygon->TexParam, polygon->TexPalette, s, t, &tcolor, &talpha);
+        bool plusone = TextureLookup(gpu, polygon->TexParam, polygon->TexPalette, s, t, &tcolor, &talpha);
 
-        tr = (tcolor << 1) & 0x3E; if (tr) tr++;
-        tg = (tcolor >> 4) & 0x3E; if (tg) tg++;
-        tb = (tcolor >> 9) & 0x3E; if (tb) tb++;
+        tr = (tcolor << 1) & 0x3E; if (plusone && tr) tr++;
+        tg = (tcolor >> 4) & 0x3E; if (plusone && tg) tg++;
+        tb = (tcolor >> 9) & 0x3E; if (plusone && tb) tb++;
 
         if (blendmode & 0x1)
         {

--- a/src/GPU3D_Soft.h
+++ b/src/GPU3D_Soft.h
@@ -455,7 +455,7 @@ private:
     };
 
     RendererPolygon PolygonList[2048];
-    void TextureLookup(const GPU& gpu, u32 texparam, u32 texpal, s16 s, s16 t, u16* color, u8* alpha) const;
+    bool TextureLookup(const GPU& gpu, u32 texparam, u32 texpal, s16 s, s16 t, u16* color, u8* alpha) const;
     u32 RenderPixel(const GPU& gpu, const Polygon* polygon, u8 vr, u8 vg, u8 vb, s16 s, s16 t) const;
     void PlotTranslucentPixel(const GPU3D& gpu3d, u32 pixeladdr, u32 color, u32 z, u32 polyattr, u32 shadow);
     void SetupPolygonLeftEdge(RendererPolygon* rp, s32 y) const;

--- a/src/GPU3D_Soft.h
+++ b/src/GPU3D_Soft.h
@@ -455,7 +455,8 @@ private:
     };
 
     RendererPolygon PolygonList[2048];
-    bool TextureLookup(const GPU& gpu, u32 texparam, u32 texpal, s16 s, s16 t, u16* color, u8* alpha) const;
+    template <bool colorcorrect> inline void ColorConv(const u16 color, u8* r, u8* g, u8* b) const;
+    void TextureLookup(const GPU& gpu, u32 texparam, u32 texpal, s16 s, s16 t, u8* tr, u8* tg, u8* tb, u8* alpha) const;
     u32 RenderPixel(const GPU& gpu, const Polygon* polygon, u8 vr, u8 vg, u8 vb, s16 s, s16 t) const;
     void PlotTranslucentPixel(const GPU3D& gpu3d, u32 pixeladdr, u32 color, u32 z, u32 polyattr, u32 shadow);
     void SetupPolygonLeftEdge(RendererPolygon* rp, s32 y) const;


### PR DESCRIPTION
this is just two fixes for compressed textures from https://github.com/melonDS-emu/melonDS/pull/1994 isolated out.
this pr can be ignored if you'd rather opt to merge the other one.

Fixes:
1. compressed textures under certain modes should not increment their color by +1
2. compressed textures do not discard bit depth when working with interpolated colors, they use the full 6 bits