### PR TITLE
fix: set default mode to 24 hours

### DIFF
--- a/src/RTC.cpp
+++ b/src/RTC.cpp
@@ -40,7 +40,7 @@ RTC::RTC(melonDS::NDS& nds) : NDS(nds)
 
     // indicate the power was off
     // this will be changed if a previously saved RTC state is loaded
-    State.StatusReg1 = 0x80;
+    State.StatusReg1 = 0x80 | (1<<1);
 }
 
 RTC::~RTC()


### PR DESCRIPTION
Here is my hacky fix for #1945 

This pull request should allow the RTC to always be initialised in 24 hours mode.