### PR TITLE
Fix gdb break on start & gdb ports not closing after restarting/crashing

### DIFF
--- a/src/ARM.cpp
+++ b/src/ARM.cpp
@@ -110,6 +110,7 @@ const u32 ARM::ConditionTable[16] =
 ARM::ARM(u32 num, bool jit, std::optional<GDBArgs> gdb, melonDS::NDS& nds) :
 #ifdef GDBSTUB_ENABLED
     GdbStub(this, gdb ? (num ? gdb->PortARM7 : gdb->PortARM9) : 0),
+    BreakOnStartup(gdb ? (num ? gdb->ARM7BreakOnStartup : gdb->ARM9BreakOnStartup) : false),
 #endif
     Num(num), // well uh
     NDS(nds)

--- a/src/debug/GdbStub.cpp
+++ b/src/debug/GdbStub.cpp
@@ -101,6 +101,11 @@ bool GdbStub::Init()
 		Log(LogLevel::Error, "[GDB] err: can't create a socket fd\n");
 		goto err;
 	}
+	{
+		// Make sure the port can be reused immediately after melonDS stops and/or restarts
+		int enable = 1;
+		setsockopt(SockFd, SOL_SOCKET, SO_REUSEADDR, &enable, sizeof(enable));
+	}
 #ifndef __linux__
 	SocketSetBlocking(SockFd, false);
 #endif

--- a/src/debug/GdbStub.cpp
+++ b/src/debug/GdbStub.cpp
@@ -104,7 +104,7 @@ bool GdbStub::Init()
 	{
 		// Make sure the port can be reused immediately after melonDS stops and/or restarts
 		int enable = 1;
-		setsockopt(SockFd, SOL_SOCKET, SO_REUSEADDR, &enable, sizeof(enable));
+		setsockopt(SockFd, SOL_SOCKET, SO_REUSEADDR, (void*)&enable, sizeof(enable));
 	}
 #ifndef __linux__
 	SocketSetBlocking(SockFd, false);

--- a/src/debug/GdbStub.cpp
+++ b/src/debug/GdbStub.cpp
@@ -104,7 +104,11 @@ bool GdbStub::Init()
 	{
 		// Make sure the port can be reused immediately after melonDS stops and/or restarts
 		int enable = 1;
-		setsockopt(SockFd, SOL_SOCKET, SO_REUSEADDR, (void*)&enable, sizeof(enable));
+#ifdef _WIN32
+		setsockopt(SockFd, SOL_SOCKET, SO_REUSEADDR, (const char*)&enable, sizeof(enable));
+#else
+		setsockopt(SockFd, SOL_SOCKET, SO_REUSEADDR, &enable, sizeof(enable));
+#endif
 	}
 #ifndef __linux__
 	SocketSetBlocking(SockFd, false);


### PR DESCRIPTION
Closes #2007

This PR fixes two bugs: gdb ports not being freed (resulting in errors when trying to debug, see below) and Break On Startup not having any effect.

Prior to this, restarting melonDS with GDB enabled may produce the following error:

```
[GDB] err: can't bind to address <any> and port 7000
```

This PR fixes the error by enabling SO_REUSEADDR on the socket opened for the GDB stub. The error no longer occurs on my end with this patch.
