### PR TITLE
Implement BizHawk's touch input interpolation changes in the core

### DIFF
--- a/src/DSi_SPI_TSC.h
+++ b/src/DSi_SPI_TSC.h
@@ -40,6 +40,7 @@ public:
     void SetMode(u8 mode);
 
     void SetTouchCoords(u16 x, u16 y) override;
+    void MoveTouchCoords(u16 x, u16 y) override;
     void MicInputFrame(const s16* data, int samples) override;
 
     void Write(u8 val) override;

--- a/src/NDS.cpp
+++ b/src/NDS.cpp
@@ -1122,6 +1122,11 @@ void NDS::TouchScreen(u16 x, u16 y)
     SPI.GetTSC()->SetTouchCoords(x, y);
 }
 
+void NDS::MoveTouch(u16 x, u16 y)
+{
+    SPI.GetTSC()->MoveTouchCoords(x, y);
+}
+
 void NDS::ReleaseScreen()
 {
     SPI.GetTSC()->SetTouchCoords(0x000, 0xFFF);

--- a/src/NDS.h
+++ b/src/NDS.h
@@ -392,6 +392,7 @@ public: // TODO: Encapsulate the rest of these members
     bool IsRunning() const noexcept { return Running; }
 
     void TouchScreen(u16 x, u16 y);
+    void MoveTouch(u16 x, u16 y);
     void ReleaseScreen();
 
     void SetKeyMask(u32 mask);

--- a/src/SPI.h
+++ b/src/SPI.h
@@ -121,6 +121,7 @@ public:
     virtual void DoSavestate(Savestate* file) override;
 
     virtual void SetTouchCoords(u16 x, u16 y);
+    virtual void MoveTouchCoords(u16 x, u16 y);
     virtual void MicInputFrame(const s16* data, int samples);
 
     virtual void Write(u8 val) override;
@@ -131,9 +132,12 @@ protected:
     u16 ConvResult;
 
     u16 TouchX, TouchY;
+    s16 DeltaX, DeltaY;
 
     s16 MicBuffer[1024];
     int MicBufferLen;
+
+    s16 CreateTouchOffset(s16 delta) const;
 };
 
 


### PR DESCRIPTION
"Touch input interpolation" here is rather simple: it does a simple linear interpolation against the touch values between the last frame's touch position and the current frame's touch position, using the current frame cycle count. In case the last frame wasn't touching anything, it just touches immediately.

The API presented here was originally intended as a way to try to avoid merge conflicts. It is intended that before RunFrame(), the user would call MoveTouch(), then call TouchScreen() once RunFrame() returns.

Alternatively, TouchScreen() could be solely called before RunFrame() (this would probably be what the libretro port does, maybe some other ports). This however will run into issues for some games which do not like immediate changes to touch input every frame, rather needing touch input to go slowly across the frame, as touch input gets polled multiple times in a frame (see https://github.com/TASEmulators/BizHawk/issues/3397).

melonDS Qt doesn't do this however, instead just calling TouchScreen() within mouse event handlers, i.e. within the UI thread, not the emulator thread. This does end up making it (at least seemingly) avoid issues with games not liking exactly per frame touch changes, but it is just a giant race condition and probably should be changed.