### PR TITLE
Handle failure of OpenGL context creation

### DIFF
--- a/src/frontend/qt_sdl/Screen.cpp
+++ b/src/frontend/qt_sdl/Screen.cpp
@@ -753,10 +753,8 @@ bool ScreenPanelGL::createContext()
     if (parentwin)
     {
         if (windowinfo.has_value())
-        {
-            glContext = parentwin->getOGLContext()->CreateSharedContext(*windowinfo);
-            glContext->DoneCurrent();
-        }
+            if (glContext = parentwin->getOGLContext()->CreateSharedContext(*windowinfo))
+                glContext->DoneCurrent();
     }
     else
     {
@@ -764,10 +762,8 @@ bool ScreenPanelGL::createContext()
                 GL::Context::Version{GL::Context::Profile::Core, 4, 3},
                 GL::Context::Version{GL::Context::Profile::Core, 3, 2}};
         if (windowinfo.has_value())
-        {
-            glContext = GL::Context::Create(*windowinfo, versionsToTry);
-            glContext->DoneCurrent();
-        }
+            if (glContext = GL::Context::Create(*windowinfo, versionsToTry))
+                glContext->DoneCurrent();
     }
 
     return glContext != nullptr;

--- a/src/frontend/qt_sdl/Window.cpp
+++ b/src/frontend/qt_sdl/Window.cpp
@@ -837,7 +837,15 @@ void MainWindow::createScreenPanel()
 
         panel = panelGL;
 
-        panelGL->createContext();
+        // Check that creating the context hasn't failed
+        if (panelGL->createContext() == false)
+        {
+            Log(LogLevel::Error, "Failed to create OpenGL context, falling back to Software Renderer.\n");
+            hasOGL = false;
+
+            globalCfg.SetBool("Screen.UseGL", false);
+            globalCfg.SetInt("3D.Renderer", renderer3D_Software);
+        }
     }
 
     if (!hasOGL)


### PR DESCRIPTION
Devices lacking OpenGL Support causes a segfault when selecting OpenGL related options.

When such situations occurs, we log it, then we reset potentially problematic settings and finally fall back to the software renderer.

Note: The Video setting Dialog isn't getting updated & would require either a signal or a way to access the object.