### PR TITLE
Disable options when renderer requirements aren't met

### DIFF
--- a/src/frontend/qt_sdl/VideoSettingsDialog.cpp
+++ b/src/frontend/qt_sdl/VideoSettingsDialog.cpp
@@ -67,6 +67,7 @@ void VideoSettingsDialog::setEnabled()
 
     bool softwareRenderer = renderer == renderer3D_Software;
     ui->cbGLDisplay->setEnabled(softwareRenderer && base_gl);
+    ui->cbVSync->setEnabled(!softwareRenderer || (softwareRenderer && ogldisplay));
     ui->cbSoftwareThreaded->setEnabled(softwareRenderer);
     ui->cbxGLResolution->setEnabled(!softwareRenderer);
     ui->cbBetterPolygons->setEnabled(renderer == renderer3D_OpenGL);

--- a/src/frontend/qt_sdl/VideoSettingsDialog.h
+++ b/src/frontend/qt_sdl/VideoSettingsDialog.h
@@ -74,6 +74,7 @@ private slots:
 private:
     void setVsyncControlEnable(bool hasOGL);
     void setEnabled();
+    int getsupportedRenderers();
 
     Ui::VideoSettingsDialog* ui;
     EmuInstance* emuInstance;


### PR DESCRIPTION
More complicated that i would had hoped for it to be.

Disable OpenGL options (partially or completely) when available OpenGL version doesn't meet requirements.

the `getsupportedRenderers()` function could be moved to another file & / or class, lemme knows which one.

Also fixed VSYNC being disabled until an OpenGL option is used & the dialog is re-opened, it should now update properly.