### PR TITLE
CLI option to toggle gdb breakOnStart

### DIFF
--- a/src/frontend/qt_sdl/CLI.cpp
+++ b/src/frontend/qt_sdl/CLI.cpp
@@ -44,6 +44,13 @@ CommandLineOptions* ManageArgs(QApplication& melon)
     parser.addOption(QCommandLineOption({"b", "boot"}, "Whether to boot firmware on startup. Defaults to \"auto\" (boot if NDS rom given)", "auto/always/never", "auto"));
     parser.addOption(QCommandLineOption({"f", "fullscreen"}, "Start melonDS in fullscreen mode"));
 
+#ifdef GDBSTUB_ENABLED
+    parser.addOption(QCommandLineOption("break-arm9", "Yield ARM9 execution to the GDB stub immediately on startup"));
+    parser.addOption(QCommandLineOption("break-arm7", "Yield ARM7 execution to the GDB stub immediately on startup"));
+    parser.addOption(QCommandLineOption("no-break-arm9", "Do not wait for GDB on ARM9 startup, even if the option to do so is enabled"));
+    parser.addOption(QCommandLineOption("no-break-arm7", "Do not wait for GDB on ARM9 startup, even if the option to do so is enabled"));
+#endif
+
 #ifdef ARCHIVE_SUPPORT_ENABLED
     parser.addOption(QCommandLineOption({"a", "archive-file"}, "Specify file to load inside an archive given (NDS)", "rom"));
     parser.addOption(QCommandLineOption({"A", "archive-file-gba"}, "Specify file to load inside an archive given (GBA)", "rom"));
@@ -54,6 +61,25 @@ CommandLineOptions* ManageArgs(QApplication& melon)
     CommandLineOptions* options = new CommandLineOptions;
 
     options->fullscreen = parser.isSet("fullscreen");
+
+#ifdef GDBSTUB_ENABLED
+    if (parser.isSet("break-arm9"))
+    {
+        options->arm9BreakOnStartup = true;
+    }
+    if (parser.isSet("no-break-arm9"))
+    {
+        options->arm9BreakOnStartup = false;
+    }
+    if (parser.isSet("break-arm7"))
+    {
+        options->arm7BreakOnStartup = true;
+    }
+    if (parser.isSet("no-break-arm7"))
+    {
+        options->arm7BreakOnStartup = false;
+    }
+#endif
 
     QStringList posargs = parser.positionalArguments();
     switch (posargs.size())

--- a/src/frontend/qt_sdl/CLI.h
+++ b/src/frontend/qt_sdl/CLI.h
@@ -34,6 +34,10 @@ struct CommandLineOptions
     std::optional<QString> gbaRomArchivePath;
     bool fullscreen;
     bool boot;
+#ifdef GDBSTUB_ENABLED
+    std::optional<bool> arm9BreakOnStartup;
+    std::optional<bool> arm7BreakOnStartup;
+#endif
 };
 
 extern CommandLineOptions* ManageArgs(QApplication& melon);

--- a/src/frontend/qt_sdl/EmuInstance.cpp
+++ b/src/frontend/qt_sdl/EmuInstance.cpp
@@ -65,7 +65,12 @@ const string kWifiSettingsPath = "wfcsettings.bin";
 extern Net net;
 
 
-EmuInstance::EmuInstance(int inst) : deleting(false),
+EmuInstance::EmuInstance(int inst, std::optional<bool> arm9BreakOnStart, std::optional<bool> arm7BreakOnStart) :
+#ifdef GDBSTUB_ENABLED
+    overrideArm9BreakOnStart(arm9BreakOnStart),
+    overrideArm7BreakOnStart(arm7BreakOnStart),
+#endif
+    deleting(false),
     instanceID(inst),
     globalCfg(Config::GetGlobalTable()),
     localCfg(Config::GetLocalTable(inst))
@@ -147,6 +152,12 @@ EmuInstance::EmuInstance(int inst) : deleting(false),
         if (enable)
             createWindow(i);
     }
+}
+
+EmuInstance::EmuInstance(int inst) :
+    EmuInstance(inst, std::nullopt, std::nullopt)
+{
+
 }
 
 EmuInstance::~EmuInstance()
@@ -1287,8 +1298,8 @@ bool EmuInstance::updateConsole(UpdateConsoleNDSArgs&& _ndsargs, UpdateConsoleGB
     GDBArgs _gdbargs {
             static_cast<u16>(gdbopt.GetInt("ARM7.Port")),
             static_cast<u16>(gdbopt.GetInt("ARM9.Port")),
-            gdbopt.GetBool("ARM7.BreakOnStartup"),
-            gdbopt.GetBool("ARM9.BreakOnStartup"),
+            overrideArm7BreakOnStart.value_or(gdbopt.GetBool("ARM7.BreakOnStartup")),
+            overrideArm9BreakOnStart.value_or(gdbopt.GetBool("ARM9.BreakOnStartup")),
     };
     auto gdbargs = gdbopt.GetBool("Enabled") ? std::make_optional(_gdbargs) : std::nullopt;
 #else

--- a/src/frontend/qt_sdl/EmuInstance.h
+++ b/src/frontend/qt_sdl/EmuInstance.h
@@ -79,6 +79,7 @@ class EmuInstance
 {
 public:
     EmuInstance(int inst);
+    EmuInstance(int inst, std::optional<bool> arm9BreakOnStart, std::optional<bool> arm7BreakOnStart);
     ~EmuInstance();
 
     int getInstanceID() { return instanceID; }
@@ -259,6 +260,11 @@ private:
     std::string baseGBAROMDir;
     std::string baseGBAROMName;
     std::string baseGBAAssetName;
+
+#ifdef GDBSTUB_ENABLED
+    std::optional<bool> overrideArm9BreakOnStart = std::nullopt;
+    std::optional<bool> overrideArm7BreakOnStart = std::nullopt;
+#endif
 
     // HACK
 public:

--- a/src/frontend/qt_sdl/Window.cpp
+++ b/src/frontend/qt_sdl/Window.cpp
@@ -1688,7 +1688,7 @@ void MainWindow::onOpenTitleManager()
 
 void MainWindow::onMPNewInstance()
 {
-    createEmuInstance();
+    createEmuInstance(std::nullopt, std::nullopt);
 }
 
 void MainWindow::onLANStartHost()

--- a/src/frontend/qt_sdl/main.cpp
+++ b/src/frontend/qt_sdl/main.cpp
@@ -118,7 +118,7 @@ void NetInit()
 }
 
 
-bool createEmuInstance()
+bool createEmuInstance(std::optional<bool> arm9BreakOnStartup, std::optional<bool> arm7BreakOnStartup)
 {
     int id = -1;
     for (int i = 0; i < kMaxEmuInstances; i++)
@@ -133,7 +133,11 @@ bool createEmuInstance()
     if (id == -1)
         return false;
 
+#ifdef GDBSTUB_ENABLED
+    auto inst = new EmuInstance(id, arm9BreakOnStartup, arm7BreakOnStartup);
+#else
     auto inst = new EmuInstance(id);
+#endif
     emuInstances[id] = inst;
 
     return true;
@@ -348,9 +352,11 @@ int main(int argc, char** argv)
     setMPInterface(MPInterface_Local);
 
     NetInit();
-
-    createEmuInstance();
-
+#ifdef GDBSTUB_ENABLED
+    createEmuInstance(options->arm9BreakOnStartup, options->arm7BreakOnStartup);
+#else
+    createEmuInstance(std::nullopt, std::nullopt);
+#endif
     {
         MainWindow* win = emuInstances[0]->getMainWindow();
         bool memberSyntaxUsed = false;

--- a/src/frontend/qt_sdl/main.h
+++ b/src/frontend/qt_sdl/main.h
@@ -54,7 +54,7 @@ extern QString emuDirectory;
 
 extern QElapsedTimer sysTimer;
 
-bool createEmuInstance();
+bool createEmuInstance(std::optional<bool> arm9BreakOnStartup, std::optional<bool> arm7BreakOnStartup);
 void deleteEmuInstance(int id);
 void deleteAllEmuInstances(int first = 0);
 int numEmuInstances();


### PR DESCRIPTION
I've found this patch quite useful in the 10 minutes so far that I've spent debugging startup problems in homebrew--it is much easier to add/remove a command line flag and begin running the game rather than having to startup gdb, connect to localhost and continue running.

I tried to make sure there was no global state added with this patch, although the code for passing arguments from the frontend to the emulator feels a bit messy. Maybe it should be refactored a bit, adding a more extendable way of passing arguments down? Although that may be beyond the scope of this PR.
