### PR TITLE
Allow `CartGameSolarSensor::LightLevel` to be set explicitly

### DIFF
--- a/src/GBACart.cpp
+++ b/src/GBACart.cpp
@@ -582,7 +582,8 @@ int CartGameSolarSensor::SetInput(int num, bool pressed)
     return -1;
 }
 
-void CartGameSolarSensor::SetLightLevel(u8 level) noexcept {
+void CartGameSolarSensor::SetLightLevel(u8 level) noexcept
+{
     LightLevel = std::clamp<u8>(level, 0, 10);
 }
 

--- a/src/GBACart.cpp
+++ b/src/GBACart.cpp
@@ -582,6 +582,10 @@ int CartGameSolarSensor::SetInput(int num, bool pressed)
     return -1;
 }
 
+void CartGameSolarSensor::SetLightLevel(u8 level) noexcept {
+    LightLevel = std::clamp<u8>(level, 0, 10);
+}
+
 void CartGameSolarSensor::ProcessGPIO()
 {
     if (GPIO.data & 4) return; // Boktai chip select

--- a/src/GBACart.h
+++ b/src/GBACart.h
@@ -158,6 +158,7 @@ public:
     void DoSavestate(Savestate* file) override;
 
     int SetInput(int num, bool pressed) override;
+    void SetLightLevel(u8 level) noexcept;
 
 protected:
     void ProcessGPIO() override;

--- a/src/GBACart.h
+++ b/src/GBACart.h
@@ -159,6 +159,7 @@ public:
 
     int SetInput(int num, bool pressed) override;
     void SetLightLevel(u8 level) noexcept;
+    [[nodiscard]] u8 GetLightLevel() const noexcept { return LightLevel; }
 
 protected:
     void ProcessGPIO() override;


### PR DESCRIPTION
I'm working on integrating solar sensor support into melonDS DS, and I'd like to use the host's photosensor where available. However, `CartGameSolarSensor` only allows modifying `LightLevel` through `CartGameSolarSensor::SetInput` with `Input_SolarSensorDown` and `Input_SolarSensorUp`; this isn't ideal for mapping a number that comes from a real sensor. This PR adds a getter and setter for `CartGameSolarSensor::LightLevel` to accommodate this use case.