### PR TITLE
Slot-2 Motion Pak, Guitar Grip emulation

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -30,6 +30,7 @@ add_library(core STATIC
     FATStorage.cpp
     FIFO.h
     GBACart.cpp
+    GBACartMotionPak.cpp
     GPU.cpp
     GPU2D.cpp
     GPU2D_Soft.cpp

--- a/src/GBACart.cpp
+++ b/src/GBACart.cpp
@@ -906,6 +906,9 @@ std::unique_ptr<CartCommon> LoadAddon(int type, void* userdata)
         // JP Boktai 3
         cart = CreateFakeSolarSensorROM("U33J", nullptr, userdata);
         break;
+    case GBAAddon_MotionPak:
+        Cart = std::make_unique<CartMotionPak>(userdata);
+        break;
     default:
         Log(LogLevel::Warn, "GBACart: !! invalid addon type %d\n", type);
         return nullptr;

--- a/src/GBACart.cpp
+++ b/src/GBACart.cpp
@@ -775,6 +775,27 @@ void CartRumblePak::ROMWrite(u32 addr, u16 val)
     }
 }
 
+CartGuitarGrip::CartGuitarGrip(void* userdata) : 
+    CartCommon(GuitarGrip),
+    UserData(userdata)
+{
+}
+
+CartGuitarGrip::~CartGuitarGrip() = default;
+
+u16 CartGuitarGrip::ROMRead(u32 addr) const
+{
+    return 0xF9FF;
+}
+
+u8 CartGuitarGrip::SRAMRead(u32 addr)
+{
+    return ~((Platform::Addon_KeyDown(Platform::KeyGuitarGripGreen, UserData) ? 0x40 : 0)
+        | (Platform::Addon_KeyDown(Platform::KeyGuitarGripRed, UserData) ? 0x20 : 0)
+        | (Platform::Addon_KeyDown(Platform::KeyGuitarGripYellow, UserData) ? 0x10 : 0)
+        | (Platform::Addon_KeyDown(Platform::KeyGuitarGripBlue, UserData) ? 0x08 : 0));
+}
+
 GBACartSlot::GBACartSlot(melonDS::NDS& nds, std::unique_ptr<CartCommon>&& cart) noexcept : NDS(nds), Cart(std::move(cart))
 {
 }
@@ -906,8 +927,14 @@ std::unique_ptr<CartCommon> LoadAddon(int type, void* userdata)
         // JP Boktai 3
         cart = CreateFakeSolarSensorROM("U33J", nullptr, userdata);
         break;
-    case GBAAddon_MotionPak:
-        Cart = std::make_unique<CartMotionPak>(userdata);
+    case GBAAddon_MotionPakHomebrew:
+        Cart = std::make_unique<CartMotionPakHomebrew>(userdata);
+        break;
+    case GBAAddon_MotionPakRetail:
+        Cart = std::make_unique<CartMotionPakRetail>(userdata);
+        break;
+    case GBAAddon_GuitarGrip:
+        Cart = std::make_unique<CartGuitarGrip>(userdata);
         break;
     default:
         Log(LogLevel::Warn, "GBACart: !! invalid addon type %d\n", type);

--- a/src/GBACart.cpp
+++ b/src/GBACart.cpp
@@ -928,13 +928,13 @@ std::unique_ptr<CartCommon> LoadAddon(int type, void* userdata)
         cart = CreateFakeSolarSensorROM("U33J", nullptr, userdata);
         break;
     case GBAAddon_MotionPakHomebrew:
-        Cart = std::make_unique<CartMotionPakHomebrew>(userdata);
+        cart = std::make_unique<CartMotionPakHomebrew>(userdata);
         break;
     case GBAAddon_MotionPakRetail:
-        Cart = std::make_unique<CartMotionPakRetail>(userdata);
+        cart = std::make_unique<CartMotionPakRetail>(userdata);
         break;
     case GBAAddon_GuitarGrip:
-        Cart = std::make_unique<CartGuitarGrip>(userdata);
+        cart = std::make_unique<CartGuitarGrip>(userdata);
         break;
     default:
         Log(LogLevel::Warn, "GBACart: !! invalid addon type %d\n", type);

--- a/src/GBACart.h
+++ b/src/GBACart.h
@@ -33,6 +33,7 @@ enum CartType
     GameSolarSensor = 0x102,
     RAMExpansion = 0x201,
     RumblePak = 0x202,
+    MotionPak = 0x203,
 };
 
 // See https://problemkaputt.de/gbatek.htm#gbacartridgeheader for details
@@ -230,6 +231,25 @@ public:
 private:
     void* UserData;
     u16 RumbleState = 0;
+};
+
+// CartMotionPak -- DS Motion Pak (Kionix/homebrew)
+class CartMotionPak : public CartCommon
+{
+public:
+    CartMotionPak(void* userdata);
+    ~CartMotionPak() override;
+
+    void Reset() override;
+
+    void DoSavestate(Savestate* file) override;
+
+    u16 ROMRead(u32 addr) const override;
+    u8 SRAMRead(u32 addr) override;
+
+private:
+    void* UserData;
+    u16 ShiftVal = 0;
 };
 
 // possible inputs for GBA carts that might accept user input

--- a/src/GBACart.h
+++ b/src/GBACart.h
@@ -33,7 +33,9 @@ enum CartType
     GameSolarSensor = 0x102,
     RAMExpansion = 0x201,
     RumblePak = 0x202,
-    MotionPak = 0x203,
+    MotionPakHomebrew = 0x203,
+    MotionPakRetail = 0x204,
+    GuitarGrip = 0x205,
 };
 
 // See https://problemkaputt.de/gbatek.htm#gbacartridgeheader for details
@@ -233,12 +235,26 @@ private:
     u16 RumbleState = 0;
 };
 
-// CartMotionPak -- DS Motion Pak (Kionix/homebrew)
-class CartMotionPak : public CartCommon
+// CartGuitarGrip -- DS Guitar Grip (used in various NDS games)
+class CartGuitarGrip : public CartCommon
 {
 public:
-    CartMotionPak(void* userdata);
-    ~CartMotionPak() override;
+    CartGuitarGrip(void* userdata);
+    ~CartGuitarGrip() override;
+
+    u16 ROMRead(u32 addr) const override;
+    u8 SRAMRead(u32 addr) override;
+
+private:
+    void* UserData;
+};
+
+// CartMotionPakHomebrew -- DS Motion Pak (Homebrew)
+class CartMotionPakHomebrew : public CartCommon
+{
+public:
+    CartMotionPakHomebrew(void* userdata);
+    ~CartMotionPakHomebrew() override;
 
     void Reset() override;
 
@@ -252,11 +268,35 @@ private:
     u16 ShiftVal = 0;
 };
 
+// CartMotionPakRetail -- DS Motion Pack (Retail)
+class CartMotionPakRetail : public CartCommon
+{
+public:
+    CartMotionPakRetail(void* userdata);
+    ~CartMotionPakRetail() override;
+
+    void Reset() override;
+
+    void DoSavestate(Savestate* file) override;
+
+    u16 ROMRead(u32 addr) const override;
+    u8 SRAMRead(u32 addr) override;
+
+private:
+    void* UserData;
+    u8 Value;
+    u8 Step = 16;
+};
+
 // possible inputs for GBA carts that might accept user input
 enum
 {
     Input_SolarSensorDown = 0,
     Input_SolarSensorUp,
+    Input_GuitarGripGreen,
+    Input_GuitarGripRed,
+    Input_GuitarGripYellow,
+    Input_GuitarGripBlue,
 };
 
 class GBACartSlot

--- a/src/GBACartMotionPak.cpp
+++ b/src/GBACartMotionPak.cpp
@@ -113,7 +113,8 @@ u8 CartMotionPakHomebrew::SRAMRead(u32 addr)
         return 0;
     case 8:
         // Read Z rotation
-        ShiftVal = RotationToMotionPak(Platform::Addon_MotionQuery(Platform::MotionRotationZ, UserData)) << 4;
+        // CHECKME: This is a guess, compare with real hardware
+        ShiftVal = RotationToMotionPak(-Platform::Addon_MotionQuery(Platform::MotionRotationZ, UserData)) << 4;
         return 0;
     case 10:
         // Identify cart

--- a/src/GBACartMotionPak.cpp
+++ b/src/GBACartMotionPak.cpp
@@ -161,7 +161,7 @@ void CartMotionPakRetail::DoSavestate(Savestate* file)
 
 u16 CartMotionPakRetail::ROMRead(u32 addr) const
 {
-    // CHECKME: Retail cartridge seems to return 0x7C7C.
+    // A9-A8 is pulled low on a real Motion Pack.
     return 0xFCFF;
 }
 

--- a/src/GBACartMotionPak.cpp
+++ b/src/GBACartMotionPak.cpp
@@ -1,0 +1,134 @@
+/*
+    Copyright 2016-2024 melonDS team
+
+    This file is part of melonDS.
+
+    melonDS is free software: you can redistribute it and/or modify it under
+    the terms of the GNU General Public License as published by the Free
+    Software Foundation, either version 3 of the License, or (at your option)
+    any later version.
+
+    melonDS is distributed in the hope that it will be useful, but WITHOUT ANY
+    WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+    FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with melonDS. If not, see http://www.gnu.org/licenses/.
+*/
+
+#include <assert.h>
+#include "NDS.h"
+#include "GBACart.h"
+#include "Platform.h"
+#include <algorithm>
+#include "math.h"
+
+namespace melonDS
+{
+using Platform::Log;
+using Platform::LogLevel;
+
+namespace GBACart
+{
+
+CartMotionPak::CartMotionPak(void* userdata) : 
+    CartCommon(MotionPak),
+    UserData(userdata)
+{
+}
+
+CartMotionPak::~CartMotionPak() = default;
+
+void CartMotionPak::Reset()
+{
+    ShiftVal = 0;
+}
+
+void CartMotionPak::DoSavestate(Savestate* file)
+{
+    CartCommon::DoSavestate(file);
+    file->Var16(&ShiftVal);
+}
+
+u16 CartMotionPak::ROMRead(u32 addr) const
+{
+    // CHECKME: Does this apply to the Kionix/homebrew cart as well?
+    return 0xFCFF;
+}
+
+static int AccelerationToMotionPak(float accel)
+{
+    const float GRAVITY_M_S2 = 9.80665f;
+    const int COUNTS_PER_G = 819;
+    const int CENTER = 2048;
+
+    return std::clamp(
+        (int) ((accel / GRAVITY_M_S2 * COUNTS_PER_G) + CENTER + 0.5),
+        0, 4095
+    );
+}
+
+static int RotationToMotionPak(float rot)
+{
+    const float DEGREES_PER_RAD = 180 / M_PI;
+    const float COUNTS_PER_DEG_PER_SEC = 0.825;
+    const int CENTER = 1680;
+
+    return std::clamp(
+        (int) ((rot * DEGREES_PER_RAD * COUNTS_PER_DEG_PER_SEC) + CENTER + 0.5),
+        0, 4095
+    );
+}
+
+u8 CartMotionPak::SRAMRead(u32 addr)
+{
+    // CHECKME: SRAM address mask
+    addr &= 0xFFFF;
+
+    switch (addr)
+    {
+    case 0:
+        // Read next byte
+        break;
+    case 2:
+        // Read X acceleration
+        ShiftVal = AccelerationToMotionPak(Platform::Addon_MotionQuery(Platform::MotionAccelerationX, UserData)) << 4;
+        // CHECKME: First byte returned when reading acceleration/rotation
+        return 0;
+    case 4:
+        // Read Y acceleration
+        ShiftVal = AccelerationToMotionPak(Platform::Addon_MotionQuery(Platform::MotionAccelerationY, UserData)) << 4;
+        return 0;
+    case 6:
+        // Read Z acceleration
+        ShiftVal = AccelerationToMotionPak(Platform::Addon_MotionQuery(Platform::MotionAccelerationZ, UserData)) << 4;
+        return 0;
+    case 8:
+        // Read Z rotation
+        ShiftVal = RotationToMotionPak(Platform::Addon_MotionQuery(Platform::MotionRotationZ, UserData)) << 4;
+        return 0;
+    case 10:
+        // Identify cart
+        ShiftVal = 0xF00F;
+        return 0;
+    case 12:
+    case 14:
+    case 16:
+    case 18:
+        // Read/enable analog inputs
+        //
+        // These are not connected by defualt and require do-it-yourself cart
+        // modification, so there is no reason to emulate them.
+        ShiftVal = 0;
+        break;
+    }
+
+    // Read high byte from the emulated shift register
+    u8 val = ShiftVal >> 8;
+    ShiftVal <<= 8;
+    return val;
+}
+
+}
+
+}

--- a/src/GBACartMotionPak.cpp
+++ b/src/GBACartMotionPak.cpp
@@ -161,6 +161,7 @@ void CartMotionPakRetail::DoSavestate(Savestate* file)
 
 u16 CartMotionPakRetail::ROMRead(u32 addr) const
 {
+    // CHECKME: Retail cartridge seems to return 0x7C7C.
     return 0xFCFF;
 }
 

--- a/src/GBACartMotionPak.cpp
+++ b/src/GBACartMotionPak.cpp
@@ -59,12 +59,20 @@ u16 CartMotionPakHomebrew::ROMRead(u32 addr) const
 static int AccelerationToMotionPak(float accel)
 {
     const float GRAVITY_M_S2 = 9.80665f;
-    const int COUNTS_PER_G = 819;
-    const int CENTER = 2048;
 
     return std::clamp(
-        (int) ((accel / GRAVITY_M_S2 * COUNTS_PER_G) + CENTER + 0.5),
+        (int) ((accel / (5 * GRAVITY_M_S2) + 0.5) * 4096),
         0, 4095
+    );
+}
+
+static int AccelerationToMotionPakRetail(float accel)
+{
+    const float GRAVITY_M_S2 = 9.80665f;
+
+    return std::clamp(
+        (int) ((accel / (5 * GRAVITY_M_S2) + 0.5) * 256),
+        0, 254
     );
 }
 
@@ -127,18 +135,6 @@ u8 CartMotionPakHomebrew::SRAMRead(u32 addr)
     u8 val = ShiftVal >> 8;
     ShiftVal <<= 8;
     return val;
-}
-
-static int AccelerationToMotionPakRetail(float accel)
-{
-    // Formula provided by xperia64 (melonDS/#74)
-    const float GRAVITY_M_S2 = 9.80665f;
-    const float VOLTAGE = 3.3f;
-
-    return std::clamp(
-        (int) ((accel * (VOLTAGE / 5) / GRAVITY_M_S2 + (VOLTAGE / 2)) * 256 / VOLTAGE),
-        0, 254
-    );
 }
 
 CartMotionPakRetail::CartMotionPakRetail(void* userdata) : 

--- a/src/NDS.h
+++ b/src/NDS.h
@@ -221,6 +221,7 @@ enum
     GBAAddon_SolarSensorBoktai1 = 3,
     GBAAddon_SolarSensorBoktai2 = 4,
     GBAAddon_SolarSensorBoktai3 = 5,
+    GBAAddon_MotionPak = 6,
 };
 
 class SPU;

--- a/src/NDS.h
+++ b/src/NDS.h
@@ -221,7 +221,9 @@ enum
     GBAAddon_SolarSensorBoktai1 = 3,
     GBAAddon_SolarSensorBoktai2 = 4,
     GBAAddon_SolarSensorBoktai3 = 5,
-    GBAAddon_MotionPak = 6,
+    GBAAddon_MotionPakHomebrew = 6,
+    GBAAddon_MotionPakRetail = 7,
+    GBAAddon_GuitarGrip = 8,
 };
 
 class SPU;

--- a/src/Platform.h
+++ b/src/Platform.h
@@ -331,6 +331,42 @@ void Addon_RumbleStart(u32 len, void* userdata);
 // rumble effects on the connected game controller, if available.
 void Addon_RumbleStop(void* userdata);
 
+enum MotionQueryType
+{
+    /**
+     * @brief X axis acceleration, measured in SI meters per second squared.
+     * On a DS, the X axis refers to the top screen X-axis (left ... right).
+     */
+    MotionAccelerationX,
+    /**
+     * @brief Y axis acceleration, measured in SI meters per second squared.
+     * On a DS, the Y axis refers to the top screen Y-axis (bottom ... top).
+     */
+    MotionAccelerationY,
+    /**
+     * @brief Z axis acceleration, measured in SI meters per second squared.
+     * On a DS, the Z axis refers to the axis perpendicular to the top screen (farther ... closer).
+     */
+    MotionAccelerationZ,
+    /**
+     * @brief X axis rotation, measured in radians per second.
+     */
+    MotionRotationX,
+    /**
+     * @brief Y axis rotation, measured in radians per second.
+     */
+    MotionRotationY,
+    /**
+     * @brief Z axis rotation, measured in radians per second.
+     */
+    MotionRotationZ,
+};
+
+// Called by the DS Motion Pak emulation to query the game controller's
+// aceelration and rotation, if available.
+// @param type The value being queried.
+float Addon_MotionQuery(MotionQueryType type, void* userdata);
+
 struct DynamicLibrary;
 
 /**

--- a/src/Platform.h
+++ b/src/Platform.h
@@ -322,6 +322,18 @@ void Camera_CaptureFrame(int num, u32* frame, int width, int height, bool yuv, v
 
 // interface for addon inputs
 
+enum KeyType
+{
+    KeyGuitarGripGreen,
+    KeyGuitarGripRed,
+    KeyGuitarGripYellow,
+    KeyGuitarGripBlue,
+};
+
+// Check if a given key is being pressed.
+// @param type The type of the key to check.
+bool Addon_KeyDown(KeyType type, void* userdata);
+
 // Called by the DS Rumble Pak emulation to start the necessary
 // rumble effects on the connected game controller, if available.
 // @param len The duration of the controller rumble effect in milliseconds.

--- a/src/frontend/qt_sdl/Config.cpp
+++ b/src/frontend/qt_sdl/Config.cpp
@@ -169,6 +169,10 @@ LegacyEntry LegacyFile[] =
     {"HKKey_PowerButton",         0, "Keyboard.HK_PowerButton", true},
     {"HKKey_VolumeUp",            0, "Keyboard.HK_VolumeUp", true},
     {"HKKey_VolumeDown",          0, "Keyboard.HK_VolumeDown", true},
+    {"HKKey_GuitarGripGreen",     0, "Keyboard.HK_GuitarGripGreen", true},
+    {"HKKey_GuitarGripRed",       0, "Keyboard.HK_GuitarGripRed", true},
+    {"HKKey_GuitarGripYellow",    0, "Keyboard.HK_GuitarGripYellow", true},
+    {"HKKey_GuitarGripBlue",      0, "Keyboard.HK_GuitarGripBlue", true},
 
     {"HKJoy_Lid",                 0, "Joystick.HK_Lid", true},
     {"HKJoy_Mic",                 0, "Joystick.HK_Mic", true},
@@ -185,6 +189,10 @@ LegacyEntry LegacyFile[] =
     {"HKJoy_PowerButton",         0, "Joystick.HK_PowerButton", true},
     {"HKJoy_VolumeUp",            0, "Joystick.HK_VolumeUp", true},
     {"HKJoy_VolumeDown",          0, "Joystick.HK_VolumeDown", true},
+    {"HKJoy_GuitarGripGreen",     0, "Joystick.HK_GuitarGripGreen", true},
+    {"HKJoy_GuitarGripRed",       0, "Joystick.HK_GuitarGripRed", true},
+    {"HKJoy_GuitarGripYellow",    0, "Joystick.HK_GuitarGripYellow", true},
+    {"HKJoy_GuitarGripBlue",      0, "Joystick.HK_GuitarGripBlue", true},
 
     {"JoystickID", 0, "JoystickID", true},
 

--- a/src/frontend/qt_sdl/EmuInstance.cpp
+++ b/src/frontend/qt_sdl/EmuInstance.cpp
@@ -2148,8 +2148,12 @@ QString EmuInstance::gbaAddonName(int addon)
         return "Solar Sensor (Boktai 2)";
     case GBAAddon_SolarSensorBoktai3:
         return "Solar Sensor (Boktai 3)";
-    case GBAAddon_MotionPak:
-        return "Motion Pak";
+    case GBAAddon_MotionPakHomebrew:
+        return "Motion Pak (Homebrew)";
+    case GBAAddon_MotionPakRetail:
+        return "Motion Pack (Retail)";
+    case GBAAddon_GuitarGrip:
+        return "Guitar Grip";
     }
 
     return "???";

--- a/src/frontend/qt_sdl/EmuInstance.cpp
+++ b/src/frontend/qt_sdl/EmuInstance.cpp
@@ -2148,6 +2148,8 @@ QString EmuInstance::gbaAddonName(int addon)
         return "Solar Sensor (Boktai 2)";
     case GBAAddon_SolarSensorBoktai3:
         return "Solar Sensor (Boktai 3)";
+    case GBAAddon_MotionPak:
+        return "Motion Pak";
     }
 
     return "???";

--- a/src/frontend/qt_sdl/EmuInstance.h
+++ b/src/frontend/qt_sdl/EmuInstance.h
@@ -51,6 +51,10 @@ enum
     HK_SlowMo,
     HK_FastForwardToggle,
     HK_SlowMoToggle,
+    HK_GuitarGripGreen,
+    HK_GuitarGripRed,
+    HK_GuitarGripYellow,
+    HK_GuitarGripBlue,
     HK_MAX
 };
 
@@ -143,6 +147,8 @@ public:
     void inputLoadConfig();
     void inputRumbleStart(melonDS::u32 len_ms);
     void inputRumbleStop();
+
+    bool inputHotkeyDown(int id) { return hotkeyDown(id); }
     float inputMotionQuery(melonDS::Platform::MotionQueryType type);
 
     void setJoystick(int id);

--- a/src/frontend/qt_sdl/EmuInstance.h
+++ b/src/frontend/qt_sdl/EmuInstance.h
@@ -21,6 +21,7 @@
 
 #include <SDL2/SDL.h>
 
+#include "Platform.h"
 #include "main.h"
 #include "NDS.h"
 #include "EmuThread.h"
@@ -142,6 +143,7 @@ public:
     void inputLoadConfig();
     void inputRumbleStart(melonDS::u32 len_ms);
     void inputRumbleStop();
+    float inputMotionQuery(melonDS::Platform::MotionQueryType type);
 
     void setJoystick(int id);
     int getJoystickID() { return joystickID; }
@@ -332,6 +334,8 @@ private:
     int joystickID;
     SDL_Joystick* joystick;
     SDL_GameController* controller;
+    bool hasAccelerometer = false;
+    bool hasGyroscope = false;
     bool hasRumble = false;
     bool isRumbling = false;
 

--- a/src/frontend/qt_sdl/EmuInstanceInput.cpp
+++ b/src/frontend/qt_sdl/EmuInstanceInput.cpp
@@ -62,7 +62,11 @@ const char* EmuInstance::hotkeyNames[HK_MAX] =
     "HK_VolumeDown",
     "HK_SlowMo",
     "HK_FastForwardToggle",
-    "HK_SlowMoToggle"
+    "HK_SlowMoToggle",
+    "HK_GuitarGripGreen",
+    "HK_GuitarGripRed",
+    "HK_GuitarGripYellow",
+    "HK_GuitarGripBlue"
 };
 
 
@@ -212,7 +216,6 @@ void EmuInstance::closeJoystick()
     hasAccelerometer = false;
     hasGyroscope = false;
     }
-
     if (joystick)
     {
         SDL_JoystickClose(joystick);

--- a/src/frontend/qt_sdl/EmuInstanceInput.cpp
+++ b/src/frontend/qt_sdl/EmuInstanceInput.cpp
@@ -174,6 +174,8 @@ float EmuInstance::inputMotionQuery(melonDS::Platform::MotionQueryType type)
                 }
             }
     }
+    if (type == melonDS::Platform::MotionAccelerationZ)
+        return SDL_STANDARD_GRAVITY;
     return 0.0f;
 }
 

--- a/src/frontend/qt_sdl/EmuInstanceInput.cpp
+++ b/src/frontend/qt_sdl/EmuInstanceInput.cpp
@@ -144,13 +144,35 @@ float EmuInstance::inputMotionQuery(melonDS::Platform::MotionQueryType type)
     {
         if (controller && hasAccelerometer)
             if (SDL_GameControllerGetSensorData(controller, SDL_SENSOR_ACCEL, values, 3) == 0)
-                return values[type % 3];
+            {
+                // Map values from DS console orientation to SDL controller orientation.
+                switch (type)
+                {
+                case melonDS::Platform::MotionAccelerationX:
+                    return values[0];
+                case melonDS::Platform::MotionAccelerationY:
+                    return -values[2];
+                case melonDS::Platform::MotionAccelerationZ:
+                    return values[1];
+                }
+            }
     }
     else if (type <= melonDS::Platform::MotionRotationZ)
     {
         if (controller && hasGyroscope)
             if (SDL_GameControllerGetSensorData(controller, SDL_SENSOR_GYRO, values, 3) == 0)
-                return values[type % 3];
+            {
+                // Map values from DS console orientation to SDL controller orientation.
+                switch (type)
+                {
+                case melonDS::Platform::MotionRotationX:
+                    return values[0];
+                case melonDS::Platform::MotionRotationY:
+                    return -values[2];
+                case melonDS::Platform::MotionRotationZ:
+                    return values[1];
+                }
+            }
     }
     return 0.0f;
 }

--- a/src/frontend/qt_sdl/InputConfig/InputConfigDialog.h
+++ b/src/frontend/qt_sdl/InputConfig/InputConfigDialog.h
@@ -32,12 +32,20 @@ static constexpr std::initializer_list<int> hk_addons =
 {
     HK_SolarSensorIncrease,
     HK_SolarSensorDecrease,
+    HK_GuitarGripGreen,
+    HK_GuitarGripRed,
+    HK_GuitarGripYellow,
+    HK_GuitarGripBlue,
 };
 
 static constexpr std::initializer_list<const char*> hk_addons_labels =
 {
     "[Boktai] Sunlight + ",
     "[Boktai] Sunlight - ",
+    "[Guitar Grip] Green",
+    "[Guitar Grip] Red",
+    "[Guitar Grip] Yellow",
+    "[Guitar Grip] Blue",
 };
 
 static_assert(hk_addons.size() == hk_addons_labels.size());

--- a/src/frontend/qt_sdl/Platform.cpp
+++ b/src/frontend/qt_sdl/Platform.cpp
@@ -550,6 +550,18 @@ void Camera_CaptureFrame(int num, u32* frame, int width, int height, bool yuv, v
     return camManager[num]->captureFrame(frame, width, height, yuv);
 }
 
+static const int hotkeyMap[] = {
+    HK_GuitarGripGreen,
+    HK_GuitarGripRed,
+    HK_GuitarGripYellow,
+    HK_GuitarGripBlue,
+};
+
+bool Addon_KeyDown(KeyType type, void* userdata)
+{
+    return ((EmuInstance*)userdata)->inputHotkeyDown(hotkeyMap[type]);
+}
+
 void Addon_RumbleStart(u32 len, void* userdata)
 {
     ((EmuInstance*)userdata)->inputRumbleStart(len);

--- a/src/frontend/qt_sdl/Platform.cpp
+++ b/src/frontend/qt_sdl/Platform.cpp
@@ -35,6 +35,7 @@
 
 #include "Platform.h"
 #include "Config.h"
+#include "EmuInstance.h"
 #include "main.h"
 #include "CameraManager.h"
 #include "Net.h"
@@ -557,6 +558,11 @@ void Addon_RumbleStart(u32 len, void* userdata)
 void Addon_RumbleStop(void* userdata)
 {
     ((EmuInstance*)userdata)->inputRumbleStop();
+}
+
+float Addon_MotionQuery(MotionQueryType type, void* userdata)
+{
+    return ((EmuInstance*)userdata)->inputMotionQuery(type);
 }
 
 DynamicLibrary* DynamicLibrary_Load(const char* lib)

--- a/src/frontend/qt_sdl/Window.cpp
+++ b/src/frontend/qt_sdl/Window.cpp
@@ -16,6 +16,7 @@
     with melonDS. If not, see http://www.gnu.org/licenses/.
 */
 
+#include "NDS.h"
 #include <stdlib.h>
 #include <time.h>
 #include <stdio.h>
@@ -320,7 +321,7 @@ MainWindow::MainWindow(int id, EmuInstance* inst, QWidget* parent) :
                 QMenu * submenu = menu->addMenu("Insert add-on cart");
                 QAction *act;
 
-                int addons[] = {GBAAddon_RAMExpansion, GBAAddon_RumblePak, GBAAddon_SolarSensorBoktai1, GBAAddon_SolarSensorBoktai2, GBAAddon_SolarSensorBoktai3, -1};
+                int addons[] = {GBAAddon_RAMExpansion, GBAAddon_RumblePak, GBAAddon_SolarSensorBoktai1, GBAAddon_SolarSensorBoktai2, GBAAddon_SolarSensorBoktai3, GBAAddon_MotionPak, -1};
                 for (int i = 0; addons[i] != -1; i++)
                 {
                     int addon = addons[i];

--- a/src/frontend/qt_sdl/Window.cpp
+++ b/src/frontend/qt_sdl/Window.cpp
@@ -321,7 +321,18 @@ MainWindow::MainWindow(int id, EmuInstance* inst, QWidget* parent) :
                 QMenu * submenu = menu->addMenu("Insert add-on cart");
                 QAction *act;
 
-                int addons[] = {GBAAddon_RAMExpansion, GBAAddon_RumblePak, GBAAddon_SolarSensorBoktai1, GBAAddon_SolarSensorBoktai2, GBAAddon_SolarSensorBoktai3, GBAAddon_MotionPak, -1};
+                int addons[] = {
+                    GBAAddon_RAMExpansion,
+                    GBAAddon_RumblePak,
+                    GBAAddon_SolarSensorBoktai1,
+                    GBAAddon_SolarSensorBoktai2,
+                    GBAAddon_SolarSensorBoktai3,
+                    GBAAddon_MotionPakHomebrew,
+                    GBAAddon_MotionPakRetail,
+                    GBAAddon_GuitarGrip,
+                    -1
+                };
+
                 for (int i = 0; addons[i] != -1; i++)
                 {
                     int addon = addons[i];

--- a/src/frontend/qt_sdl/main.cpp
+++ b/src/frontend/qt_sdl/main.cpp
@@ -309,6 +309,10 @@ int main(int argc, char** argv)
     {
         printf("SDL couldn't init joystick\n");
     }
+    if (SDL_Init(SDL_INIT_SENSOR) < 0)
+    {
+        printf("SDL couldn't init motion sensors\n");
+    }
     if (SDL_Init(SDL_INIT_AUDIO) < 0)
     {
         const char* err = SDL_GetError();


### PR DESCRIPTION
This PR adds emulation of the following Slot-2 devices:

* The homebrew Motion Pak, supporting X/Y/Z acceleration and Z rotation measurements. I have validated, with the help of a friend, the X/Y/Z acceleration support; I do not have any hardware which supports the Z rotation, however, so that's a bit of a guess.
  * The Motion Pak is mapped to accelerometer/gyroscope readouts from the connected SDL game controller; think DualSense or Switch Pro Controller.
* The official Motion Pack (sic!), as bundled with Tony Hawk's Motion, as described in https://github.com/melonDS-emu/melonDS/issues/74 . There's really no reason to use that one - it omits the gyroscope, has only 8 bits and not 12 bits of accuracy, and for some bizarre reason the game itself supports the homebrew pak too (!?). I have not tested it, as I don't own the game.
* The Guitar Grip. This is a "low-hanging fruit" with regards to adding other devices that support external inputs, such as the Paddle and Piano Controller. Tested, but only with a homebrew test ROM.

Closes https://github.com/melonDS-emu/melonDS/issues/74 and https://github.com/melonDS-emu/melonDS/issues/73 . Related to https://github.com/melonDS-emu/melonDS/issues/755 . Testing welcome.