### PR TITLE
Use Qt 6 by default on all platforms and update build instructions

### DIFF
--- a/.github/workflows/build-ubuntu.yml
+++ b/.github/workflows/build-ubuntu.yml
@@ -28,7 +28,7 @@ jobs:
         sudo apt install --allow-downgrades cmake ninja-build extra-cmake-modules libpcap0.8-dev libsdl2-dev libenet-dev \
           qt6-{base,base-private,multimedia}-dev libqt6svg6-dev libarchive-dev libzstd-dev libfuse2
     - name: Configure
-      run: cmake -B build -G Ninja -DUSE_QT6=ON -DCMAKE_INSTALL_PREFIX=/usr -DMELONDS_EMBED_BUILD_INFO=ON
+      run: cmake -B build -G Ninja -DCMAKE_INSTALL_PREFIX=/usr -DMELONDS_EMBED_BUILD_INFO=ON
     - name: Build
       run: |
         cmake --build build
@@ -79,7 +79,6 @@ jobs:
             -DPKG_CONFIG_EXECUTABLE=/usr/bin/aarch64-linux-gnu-pkg-config \
             -DCMAKE_C_COMPILER=aarch64-linux-gnu-gcc-12 \
             -DCMAKE_CXX_COMPILER=aarch64-linux-gnu-g++-12 \
-            -DUSE_QT6=ON \
             -DMELONDS_EMBED_BUILD_INFO=ON
       - name: Build
         shell: bash

--- a/BUILD.md
+++ b/BUILD.md
@@ -1,0 +1,81 @@
+# Building melonDS
+
+* [Linux](#linux)
+* [Windows](#windows)
+* [macOS](#macos)
+
+## Linux
+1. Install dependencies:
+   * Ubuntu:
+     * All versions: `sudo apt install cmake extra-cmake-modules libcurl4-gnutls-dev libpcap0.8-dev libsdl2-dev libarchive-dev libenet-dev libzstd-dev`
+     * 24.04: `sudo apt install qt6-{base,base-private,multimedia,svg}-dev`
+     * 22.04: `sudo apt install qtbase6-dev qtbase6-private-dev qtmultimedia6-dev libqt6svg6-dev`
+     * Older versions: `sudo apt install qtbase5-dev qtbase5-private-dev qtmultimedia5-dev libqt5svg5-dev`  
+       Also add `-DUSE_QT6=OFF` to the first CMake command below.
+   * Fedora: `sudo dnf install gcc-c++ cmake extra-cmake-modules SDL2-devel libarchive-devel enet-devel libzstd-devel qt6-{qtbase,qtmultimedia,qtsvg}-devel wayland-devel`
+   * Arch Linux: `sudo pacman -S base-devel cmake extra-cmake-modules git libpcap sdl2 qt6-{base,multimedia,svg} libarchive enet zstd`
+2. Download the melonDS repository and prepare:
+   ```bash
+   git clone https://github.com/melonDS-emu/melonDS
+   cd melonDS
+   ```
+3. Compile:
+   ```bash
+   cmake -B build
+   cmake --build build -j$(nproc --all)
+   ```
+
+## Windows
+1. Install [MSYS2](https://www.msys2.org/)
+2. Open the MSYS2 terminal from the Start menu:
+   * For x64 systems (most common), use **MSYS2 UCRT64**
+   * For ARM64 systems, use **MSYS2 CLANGARM64**
+3. Update the packages using `pacman -Syu` and reopen the same terminal if it asks you to
+4. Install git and clone the repository
+   ```bash
+   pacman -S git
+   git clone https://github.com/melonDS-emu/melonDS
+   cd melonDS
+   ```
+5. Install dependencies:  
+   Replace `<prefix>` below with `mingw-w64-ucrt-x86_64` on x64 systems, or `mingw-w64-clang-aarch64` on ARM64 systems.
+   ```bash
+   pacman -S <prefix>-{toolchain,cmake,SDL2,libarchive,enet,zstd}`
+   ```
+6. Install Qt and configure the build directory
+   * Dynamic builds (with DLLs)
+     1. Install Qt: `pacman -S <prefix>-{qt6-base,qt6-svg,qt6-multimedia,qt6-svg,qt6-tools}`
+     2. Set up the build directory with `cmake -B build`
+   * Static builds (without DLLs, standalone executable)
+     1. Install Qt: `pacman -S <prefi>-qt5-static`  
+        (Note: As of writing, the `qt6-static` package does not work.)
+     2. Set up the build directory with `cmake -B build -DBUILD_STATIC=ON -DUSE_QT6=OFF -DCMAKE_PREFIX_PATH=$MSYSTEM_PREFIX/qt5-static`
+7. Compile: `cmake --build build`
+
+If everything went well, melonDS should now be in the `build` folder. For dynamic builds, you may need to run melonDS from the MSYS2 terminal in order for it to find the required DLLs.
+
+## macOS
+1. Install the [Homebrew Package Manager](https://brew.sh)
+2. Install dependencies: `brew install git pkg-config cmake sdl2 qt@6 libarchive enet zstd`
+3. Download the melonDS repository and prepare:
+   ```zsh
+   git clone https://github.com/melonDS-emu/melonDS
+   cd melonDS
+   ```
+4. Compile:
+   ```zsh
+   cmake -B build -DCMAKE_PREFIX_PATH="$(brew --prefix qt@6);$(brew --prefix libarchive)"
+   cmake --build build -j$(sysctl -n hw.logicalcpu)
+   ```
+If everything went well, melonDS.app should now be in the `build` directory.
+
+### Self-contained app bundle
+If you want an app bundle that can be distributed to other computers without needing to install dependencies through Homebrew, you can additionally run `
+../tools/mac-libs.rb .` after the build is completed, or add `-DMACOS_BUNDLE_LIBS=ON` to the first CMake command.
+
+## Nix (macOS/Linux)
+
+melonDS provides a Nix flake with support for both macOS and Linux. The [Nix package manager](https://nixos.org) needs to be installed to use it.
+
+* To run melonDS, just type `nix run github:melonDS-emu/melonDS`.
+* To get a shell for development, clone the melonDS repository and type `nix develop` in its directory.

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -27,10 +27,6 @@
       "binaryDir": "${sourceDir}/build/release-mingw-x86_64",
       "generator": "Ninja",
       "cacheVariables": {
-        "USE_QT6": {
-          "type": "BOOL",
-          "value": "ON"
-        },
         "BUILD_STATIC": {
           "type": "BOOL",
           "value": "ON"

--- a/README.md
+++ b/README.md
@@ -32,75 +32,7 @@ DS BIOS dumps from a DSi or 3DS can be used with no compatibility issues. DSi BI
 As for the rest, the interface should be pretty straightforward. If you have a question, don't hesitate to ask, though!
 
 ## How to build
-
-### Linux
-1. Install dependencies:
-   * Ubuntu 22.04: `sudo apt install cmake extra-cmake-modules libcurl4-gnutls-dev libpcap0.8-dev libsdl2-dev qtbase5-dev qtbase5-private-dev qtmultimedia5-dev libqt5svg5-dev libarchive-dev libenet-dev libzstd-dev`
-   * Older Ubuntu: `sudo apt install cmake extra-cmake-modules libcurl4-gnutls-dev libpcap0.8-dev libsdl2-dev qt5-default qtbase5-private-dev qtmultimedia5-dev libqt5svg5-dev libarchive-dev libenet-dev libzstd-dev`
-   * Arch Linux: `sudo pacman -S base-devel cmake extra-cmake-modules git libpcap sdl2 qt5-base qt5-multimedia qt5-svg libarchive enet zstd`
-3. Download the melonDS repository and prepare:
-   ```bash
-   git clone https://github.com/melonDS-emu/melonDS
-   cd melonDS
-   ```
-
-3. Compile:
-   ```bash
-   cmake -B build
-   cmake --build build -j$(nproc --all)
-   ```
-
-### Windows
-1. Install [MSYS2](https://www.msys2.org/)
-2. Open the **MSYS2 MinGW 64-bit** terminal
-3. Update the packages using `pacman -Syu` and reopen the terminal if it asks you to
-4. Install git to clone the repository
-   ```bash
-   pacman -S git
-   ```
-5. Download the melonDS repository and prepare:
-   ```bash
-   git clone https://github.com/melonDS-emu/melonDS
-   cd melonDS
-   ```
-#### Dynamic builds (with DLLs)
-5. Install dependencies: `pacman -S mingw-w64-x86_64-{cmake,SDL2,toolchain,qt5-base,qt5-svg,qt5-multimedia,qt5-svg,qt5-tools,libarchive,enet,zstd}`
-6. Compile:
-   ```bash
-   cmake -B build
-   cmake --build build
-   cd build
-   ../tools/msys-dist.sh
-   ```
-If everything went well, melonDS and the libraries it needs should now be in the `dist` folder.
-
-#### Static builds (without DLLs, standalone executable)
-5. Install dependencies: `pacman -S mingw-w64-x86_64-{cmake,SDL2,toolchain,qt5-static,libarchive,enet,zstd}`
-6. Compile:
-   ```bash
-   cmake -B build -DBUILD_STATIC=ON -DCMAKE_PREFIX_PATH=/mingw64/qt5-static
-   cmake --build build
-   ```
-If everything went well, melonDS should now be in the `build` folder.
-
-### macOS
-1. Install the [Homebrew Package Manager](https://brew.sh)
-2. Install dependencies: `brew install git pkg-config cmake sdl2 qt@6 libarchive enet zstd`
-3. Download the melonDS repository and prepare:
-   ```zsh
-   git clone https://github.com/melonDS-emu/melonDS
-   cd melonDS
-   ```
-4. Compile:
-   ```zsh
-   cmake -B build -DCMAKE_PREFIX_PATH="$(brew --prefix qt@6);$(brew --prefix libarchive)"
-   cmake --build build -j$(sysctl -n hw.logicalcpu)
-   ```
-If everything went well, melonDS.app should now be in the `build` directory.
-
-#### Self-contained app bundle
-If you want an app bundle that can be distributed to other computers without needing to install dependencies through Homebrew, you can additionally run `
-../tools/mac-libs.rb .` after the build is completed, or add `-DMACOS_BUNDLE_LIBS=ON` to the first CMake command.
+See [BUILD.md](./BUILD.md) for build instructions.
 
 ## TODO LIST
 

--- a/cmake/ConfigureVcpkg.cmake
+++ b/cmake/ConfigureVcpkg.cmake
@@ -18,13 +18,6 @@ set(VCPKG_OVERLAY_TRIPLETS "${CMAKE_SOURCE_DIR}/cmake/overlay-triplets")
 
 option(USE_RECOMMENDED_TRIPLETS "Use the recommended triplets that are used for official builds" ON)
 
-# Duplicated here because it needs to be set before project()
-if (NOT WIN32)
-    option(USE_QT6 "Build using Qt 6 instead of 5" ON)
-else()
-    option(USE_QT6 "Build using Qt 6 instead of 5" OFF)
-endif()
-
 # Since the Linux build pulls in glib anyway, we can just use upstream libslirp
 if (UNIX AND NOT APPLE)
     option(USE_SYSTEM_LIBSLIRP "Use system libslirp instead of the bundled version" ON)

--- a/cmake/ConfigureVcpkg.cmake
+++ b/cmake/ConfigureVcpkg.cmake
@@ -18,6 +18,9 @@ set(VCPKG_OVERLAY_TRIPLETS "${CMAKE_SOURCE_DIR}/cmake/overlay-triplets")
 
 option(USE_RECOMMENDED_TRIPLETS "Use the recommended triplets that are used for official builds" ON)
 
+# Duplicated here because it needs to be set before project()
+option(USE_QT6 "Use Qt 6 instead of Qt 5" ON)
+
 # Since the Linux build pulls in glib anyway, we can just use upstream libslirp
 if (UNIX AND NOT APPLE)
     option(USE_SYSTEM_LIBSLIRP "Use system libslirp instead of the bundled version" ON)

--- a/src/frontend/qt_sdl/CMakeLists.txt
+++ b/src/frontend/qt_sdl/CMakeLists.txt
@@ -59,11 +59,7 @@ set(SOURCES_QT_SDL
     NetplayDialog.cpp
 )
 
-if (APPLE)
-    option(USE_QT6 "Build using Qt 6 instead of 5" ON)
-else()
-    option(USE_QT6 "Build using Qt 6 instead of 5" OFF)
-endif()
+option(USE_QT6 "Use Qt 6 instead of Qt 5" ON)
 
 if (USE_QT6)
     find_package(Qt6 COMPONENTS Core Gui Widgets Network Multimedia OpenGL OpenGLWidgets Svg REQUIRED)


### PR DESCRIPTION
* Switch to using Qt 6 everywhere by default. `USE_QT6` always defaults to enabled
* Use UCRT on Windows
* Move build instructions to BUILD.md and
  * Add packages for Ubuntu 24.04 and Fedora
  * Switch Linux and Windows to Qt 6
  * Clean up Windows build instructions and mention ARM64 support
  * Mention the Nix flake