### PR TITLE
EmuInstanceAudio.cpp: Dont open new mic device on audioEnable()

### DIFF
--- a/src/frontend/qt_sdl/EmuInstanceAudio.cpp
+++ b/src/frontend/qt_sdl/EmuInstanceAudio.cpp
@@ -495,11 +495,11 @@ void EmuInstance::audioUpdateSettings()
 void EmuInstance::audioEnable()
 {
     if (audioDevice) SDL_PauseAudioDevice(audioDevice, 0);
-    micOpen();
+    if (micDevice) SDL_PauseAudioDevice(micDevice, 0);
 }
 
 void EmuInstance::audioDisable()
 {
     if (audioDevice) SDL_PauseAudioDevice(audioDevice, 1);
-    micClose();
+    if (micDevice) SDL_PauseAudioDevice(micDevice, 1);
 }


### PR DESCRIPTION
Fixes memory leak when resetting the emu
resetting the emu calls `audioEnable()`, creating a new `micDevice` every time without deleting the old one.
Maybe (partly) responsible for #2096 