### PR TITLE
add devtools options to break on data errors with GDB connected + flag to access full 8mb main memory in DS mode

### DIFF
--- a/src/ARM.h
+++ b/src/ARM.h
@@ -206,6 +206,7 @@ protected:
     bool IsSingleStep;
     bool BreakReq;
     bool BreakOnStartup;
+    bool BreakOnError;
     u16 Port;
 
 public:

--- a/src/Args.h
+++ b/src/Args.h
@@ -79,6 +79,7 @@ struct GDBArgs
     u16 PortARM9 = 0;
     bool ARM7BreakOnStartup = false;
     bool ARM9BreakOnStartup = false;
+    bool BreakOnError = false;
 };
 
 /// Arguments to pass into the NDS constructor.

--- a/src/NDS.cpp
+++ b/src/NDS.cpp
@@ -444,7 +444,7 @@ void NDS::Reset()
     else
     {
         ARM9ClockShift = 1;
-        MainRAMMask = 0x3FFFFF;
+        MainRAMMask = useExtendedMemory ? 0x7FFFFF : 0x3FFFFF;
     }
     // has to be called before InitTimings
     // otherwise some PU settings are completely
@@ -4343,6 +4343,11 @@ void NDS::ARM7IOWrite32(u32 addr, u32 val)
     }
 
     Log(LogLevel::Debug, "unknown ARM7 IO write32 %08X %08X %08X\n", addr, val, ARM7.R[15]);
+}
+
+void NDS::SetMemoryExtension(bool enabled)
+{
+    useExtendedMemory = enabled;
 }
 
 }

--- a/src/NDS.h
+++ b/src/NDS.h
@@ -469,6 +469,8 @@ public: // TODO: Encapsulate the rest of these members
     virtual void ARM7IOWrite16(u32 addr, u16 val);
     virtual void ARM7IOWrite32(u32 addr, u32 val);
 
+    void SetMemoryExtension(bool enabled);
+
 #ifdef JIT_ENABLED
     [[nodiscard]] bool IsJITEnabled() const noexcept { return EnableJIT; }
     void SetJITArgs(std::optional<JITArgs> args) noexcept;
@@ -527,6 +529,7 @@ private:
     void EnterSleepMode();
     template <CPUExecuteMode cpuMode>
     u32 RunFrame();
+    bool useExtendedMemory = false;
 
 public:
     NDS(NDSArgs&& args, void* userdata = nullptr) noexcept : NDS(std::move(args), 0, userdata) {}

--- a/src/frontend/qt_sdl/Config.cpp
+++ b/src/frontend/qt_sdl/Config.cpp
@@ -310,6 +310,7 @@ LegacyEntry LegacyFile[] =
 
 #ifdef GDBSTUB_ENABLED
     {"GdbEnabled", 1, "Gdb.Enabled", false},
+    {"GdbBreakOnError", 1, "Gdb.BreakOnError", true},
     {"GdbPortARM7", 0, "Gdb.ARM7.Port", true},
     {"GdbPortARM9", 0, "Gdb.ARM9.Port", true},
     {"GdbARM7BreakOnStartup", 1, "Gdb.ARM7.BreakOnStartup", true},

--- a/src/frontend/qt_sdl/EmuInstance.cpp
+++ b/src/frontend/qt_sdl/EmuInstance.cpp
@@ -1285,6 +1285,7 @@ bool EmuInstance::updateConsole(UpdateConsoleNDSArgs&& _ndsargs, UpdateConsoleGB
             static_cast<u16>(gdbopt.GetInt("ARM9.Port")),
             gdbopt.GetBool("ARM7.BreakOnStartup"),
             gdbopt.GetBool("ARM9.BreakOnStartup"),
+            gdbopt.GetBool("BreakOnError")
     };
     auto gdbargs = gdbopt.GetBool("Enabled") ? std::make_optional(_gdbargs) : std::nullopt;
 #else

--- a/src/frontend/qt_sdl/EmuInstance.cpp
+++ b/src/frontend/qt_sdl/EmuInstance.cpp
@@ -1353,6 +1353,7 @@ bool EmuInstance::updateConsole(UpdateConsoleNDSArgs&& _ndsargs, UpdateConsoleGB
             nds = new NDS(std::move(ndsargs), this);
 
         NDS::Current = nds;
+        nds->SetMemoryExtension(localCfg.GetBool("Debug.ExtendedMemory"));
         nds->Reset();
         loadRTCData();
         //emuThread->updateVideoRenderer(); // not actually needed?

--- a/src/frontend/qt_sdl/EmuSettingsDialog.cpp
+++ b/src/frontend/qt_sdl/EmuSettingsDialog.cpp
@@ -96,6 +96,7 @@ EmuSettingsDialog::EmuSettingsDialog(QWidget* parent) : QDialog(parent), ui(new 
 
 #ifdef GDBSTUB_ENABLED
     ui->cbGdbEnabled->setChecked(instcfg.GetBool("Gdb.Enabled"));
+    ui->cbGdbBreakOnError->setChecked(instcfg.GetBool("Gdb.BreakOnError"));
     ui->intGdbPortA7->setValue(instcfg.GetInt("Gdb.ARM7.Port"));
     ui->intGdbPortA9->setValue(instcfg.GetInt("Gdb.ARM9.Port"));
     ui->cbGdbBOSA7->setChecked(instcfg.GetBool("Gdb.ARM7.BreakOnStartup"));
@@ -294,6 +295,7 @@ void EmuSettingsDialog::done(int r)
 #endif
 #ifdef GDBSTUB_ENABLED
             instcfg.SetBool("Gdb.Enabled", ui->cbGdbEnabled->isChecked());
+            instcfg.SetBool("Gdb.BreakOnError", ui->cbGdbBreakOnError->isChecked());
             instcfg.SetInt("Gdb.ARM7.Port", ui->intGdbPortA7->value());
             instcfg.SetInt("Gdb.ARM9.Port", ui->intGdbPortA9->value());
             instcfg.SetBool("Gdb.ARM7.BreakOnStartup", ui->cbGdbBOSA7->isChecked());

--- a/src/frontend/qt_sdl/EmuSettingsDialog.cpp
+++ b/src/frontend/qt_sdl/EmuSettingsDialog.cpp
@@ -109,6 +109,8 @@ EmuSettingsDialog::EmuSettingsDialog(QWidget* parent) : QDialog(parent), ui(new 
     ui->cbGdbBOSA9->setDisabled(true);
 #endif
 
+    ui->cbDebugExtendedMem->setChecked(instcfg.GetBool("Debug.ExtendedMemory"));
+
     on_chkEnableJIT_toggled();
     on_cbGdbEnabled_toggled();
     on_chkExternalBIOS_toggled();
@@ -301,6 +303,7 @@ void EmuSettingsDialog::done(int r)
             instcfg.SetBool("Gdb.ARM7.BreakOnStartup", ui->cbGdbBOSA7->isChecked());
             instcfg.SetBool("Gdb.ARM9.BreakOnStartup", ui->cbGdbBOSA9->isChecked());
 #endif
+            instcfg.SetBool("Debug.ExtendedMemory", ui->cbDebugExtendedMem->isChecked());
 
             cfg.SetInt("Emu.ConsoleType", ui->cbxConsoleType->currentIndex());
             cfg.SetBool("Emu.DirectBoot", ui->chkDirectBoot->isChecked());

--- a/src/frontend/qt_sdl/EmuSettingsDialog.ui
+++ b/src/frontend/qt_sdl/EmuSettingsDialog.ui
@@ -607,14 +607,21 @@
          </property>
         </widget>
        </item>
-       <item row="4" column="0" colspan="7">
+       <item row="3" column="0" colspan="3">
+        <widget class="QCheckBox" name="cbGdbBreakOnError">
+         <property name="text">
+          <string>Break on data error</string>
+         </property>
+        </widget>
+       </item>
+       <item row="5" column="0" colspan="7">
         <widget class="QLabel" name="label_18">
          <property name="text">
           <string>Note: melonDS must be restarted in order for these changes to have effect</string>
          </property>
         </widget>
        </item>
-       <item row="3" column="0" colspan="7">
+       <item row="4" column="0" colspan="7">
         <widget class="QLabel" name="label_19">
          <property name="text">
           <string>Note: GDB stub cannot be used together with the JIT recompiler</string>

--- a/src/frontend/qt_sdl/EmuSettingsDialog.ui
+++ b/src/frontend/qt_sdl/EmuSettingsDialog.ui
@@ -580,7 +580,7 @@
          </property>
         </widget>
        </item>
-       <item row="5" column="0">
+       <item row="6" column="0">
         <spacer name="verticalSpacer_4">
          <property name="orientation">
           <enum>Qt::Vertical</enum>
@@ -614,7 +614,14 @@
          </property>
         </widget>
        </item>
-       <item row="5" column="0" colspan="7">
+       <item row="5" column="0" colspan="5">
+        <widget class="QCheckBox" name="cbDebugExtendedMem">
+         <property name="text">
+          <string>Enable extended main RAM (8Mb)</string>
+         </property>
+        </widget>
+       </item>
+       <item row="7" column="0" colspan="7">
         <widget class="QLabel" name="label_18">
          <property name="text">
           <string>Note: melonDS must be restarted in order for these changes to have effect</string>


### PR DESCRIPTION
I found these useful when I was debugging issues with a ROM which uses more than 4mb memory under specific optimization levels (at higher optimization levels it fits fine, but with optimizations disabled it needs more than 4mb total).

- the GDB `BreakOnError` flag can help to track down errors related to memory access/allocation
- the `Debug.ExtendedMemory` flag allows access to the full 8mb main memory range, instead of mirroring the lower 4mb to the upper 4mb

no retail DS provides access to the upper 4mb, but per gbatek there were hardware debugger machines which can use the full 8mb. this PR does not implement everything covered by the debugger machine, only allows access to more memory for debugging purposes. this does mean that the behaviour of the emulator with the 8mb flag enabled is a bit far from retail.