### PR TITLE
ARMJIT: Use compile-time constant sized arrays

### DIFF
--- a/src/ARMJIT.h
+++ b/src/ARMJIT.h
@@ -67,8 +67,10 @@ public:
     u32 LocaliseCodeAddress(u32 num, u32 addr) const noexcept;
 
     ARMJIT_Memory Memory;
+
+    static constexpr u32 MaxSupportedBlockSize = 32;
 private:
-    int MaxBlockSize {};
+    u32 MaxBlockSize {};
     bool LiteralOptimizations = false;
     bool BranchOptimizations = false;
     bool FastMemory = false;

--- a/src/Args.h
+++ b/src/Args.h
@@ -58,7 +58,7 @@ constexpr std::array<u8, N> BrokenBIOS = []() constexpr {
 /// Ignored in builds that don't have the JIT included.
 struct JITArgs
 {
-    unsigned MaxBlockSize = 32;
+    u32 MaxBlockSize = 32;
     bool LiteralOptimizations = true;
     bool BranchOptimizations = true;
 


### PR DESCRIPTION
These arrays were using the member variable `MaxBlockSize` as their size, but this is a dynamic runtime value. Using runtime values for array sizes could potentially lead to a dynamic allocation in the heap instead of being on the stack.

Ideally we would use a `std::array` to avoid these kinds of oversights but that's a slightly more intrusive change for now.