### PR TITLE
Fix gdbstub not activating until the console is reset

### DIFF
--- a/src/ARM.cpp
+++ b/src/ARM.cpp
@@ -115,7 +115,7 @@ ARM::ARM(u32 num, bool jit, std::optional<GDBArgs> gdb, melonDS::NDS& nds) :
     Num(num), // well uh
     NDS(nds)
 {
-    SetGdbArgs(jit ? gdb : std::nullopt);
+    SetGdbArgs(jit ? std::nullopt : gdb);
 }
 
 ARM::~ARM()


### PR DESCRIPTION
The check for initialising the gdbstub depending on whether the JIT was enabled or not was the wrong way around: previously, it would only enable the gdbstub if the JIT was enabled.

The stub started working again if you reset the console, as NDS::SetGdbArgs didn't have any such check and it was called by EmuInstance::updateConsole.