### PR TITLE
Improve audio sampling at non-60 fps targets

### DIFF
--- a/src/frontend/qt_sdl/EmuInstanceAudio.cpp
+++ b/src/frontend/qt_sdl/EmuInstanceAudio.cpp
@@ -29,7 +29,7 @@ using namespace melonDS;
 
 int EmuInstance::audioGetNumSamplesOut(int outlen)
 {
-    float f_len_in = (outlen * 32823.6328125) / (float)audioFreq;
+    float f_len_in = (outlen * 32823.6328125 * (curFPS/60.0)) / (float)audioFreq;
     f_len_in += audioSampleFrac;
     int len_in = (int)floor(f_len_in);
     audioSampleFrac = f_len_in - len_in;
@@ -73,6 +73,7 @@ void EmuInstance::audioCallback(void* data, Uint8* stream, int len)
     // resample incoming audio to match the output sample rate
 
     int len_in = inst->audioGetNumSamplesOut(len);
+    if (len_in > 1024) len_in = 1024;
     s16 buf_in[1024*2];
     int num_in;
 


### PR DESCRIPTION
should remedy a subtle issue with audio and configurable framerate targets.
also makes extremely high/slow speeds sound really funny instead of horribly broken, so that's a plus.
shouldn't improve audio during framerate dips, unfortunately.
I cheated and capped the sample length at 1024 to keep it from crashing, that might cause issues, but i think it should only matter with a significantly increased framerate target? ie. fast forward.
was a very hastily/lazily assembled fix, so if you want something improved or changed feel free to ask.