### PR TITLE
FIX: this should be namespace std:: to preserve compatibilty with non-glibc when building without gdb stub

### DIFF
--- a/src/frontend/qt_sdl/EmuInstance.cpp
+++ b/src/frontend/qt_sdl/EmuInstance.cpp
@@ -1292,7 +1292,7 @@ bool EmuInstance::updateConsole() noexcept
     };
     auto gdbargs = gdbopt.GetBool("Enabled") ? std::make_optional(_gdbargs) : std::nullopt;
 #else
-    optional<GDBArgs> gdbargs = std::nullopt;
+    std::optional<GDBArgs> gdbargs = std::nullopt;
 #endif
 
     NDSArgs ndsargs {


### PR DESCRIPTION
I am working on updating the OpenBSD port to 1.0rc, which builds with clang on our own libc/++. Currently, building with gdb stub support is broken for us, so I disabled the configure option. But- We don't have `optional` like how glibc does, so we should prepend `std::` here so building without gdb stub works even without glibc. This should in theory fix other *BSDs as well as musl targets building without gdb stub (if supported). I am unsure if this hack breaks glibc compat, and I don't have a means to test. OK?