### PR TITLE
fix a few dumb mistakes i made with framerate limiters

### DIFF
--- a/src/frontend/qt_sdl/EmuThread.cpp
+++ b/src/frontend/qt_sdl/EmuThread.cpp
@@ -366,7 +366,7 @@ void EmuThread::run()
 
             if (slowmo) emuInstance->curFPS = emuInstance->slowmoFPS;
             else if (fastforward) emuInstance->curFPS = emuInstance->fastForwardFPS;
-            else if (!emuInstance->doLimitFPS) emuInstance->curFPS = 1000.0;
+            else if (!emuInstance->doLimitFPS && !emuInstance->doAudioSync) emuInstance->curFPS = 1000.0;
             else emuInstance->curFPS = emuInstance->targetFPS;
 
             if (emuInstance->audioDSiVolumeSync && emuInstance->nds->ConsoleType == 1)
@@ -389,6 +389,7 @@ void EmuThread::run()
 
             if (frametimeStep < 0.001) frametimeStep = 0.001;
 
+            if (emuInstance->doLimitFPS)
             {
                 double curtime = SDL_GetPerformanceCounter() * perfCountsSec;
 
@@ -430,7 +431,7 @@ void EmuThread::run()
                 if (inst == 0)
                     snprintf(melontitle, sizeof(melontitle), "[%d/%.0f] melonDS " MELONDS_VERSION, fps, actualfps);
                 else
-                    snprintf(melontitle, sizeof(melontitle), "[%d/%.0f] melonDS (%d)", fps, fpstarget, inst+1);
+                    snprintf(melontitle, sizeof(melontitle), "[%d/%.0f] melonDS (%d)", fps, actualfps, inst+1);
                 changeWindowTitle(melontitle);
             }
         }


### PR DESCRIPTION
1. unbreak audio sync, and make it respect the framerate target set; (up to 88 fps, due to the hardcoded cap on the audio buffer size or w/e it was I had to cap to keep it from exploding. maybe we'll fix that some day...?)
2. make multiplayer windows show the proper framerate target of the sw running; (i forgot to update the variable they used...)