### PR TITLE
Don't return 0 when attempting to read from the GPA GPIO addresses with GPIO disabled

### DIFF
--- a/src/GBACart.cpp
+++ b/src/GBACart.cpp
@@ -242,8 +242,6 @@ u16 CartGame::ROMRead(u32 addr) const
             case 0xC8: return GPIO.control;
             }
         }
-        else
-            return 0;
     }
 
     // CHECKME: does ROM mirror?


### PR DESCRIPTION
Currently melon would return `0` if something is attempted to be read from the addresses 0x080000C4-0x080000C8, but gba roms can and do have data in that place, while games using custom gpio hardware have those bytes set to 0 since they're mapped to the gpio lines.
Now it will instead consider those addresses as special only if the game explicitly attempted to enable gpio by writing to the control address.

Fixes https://github.com/melonDS-emu/melonDS/issues/2264