### PR TITLE
Make SPU audio single-buffered (audio latency improvement)

### DIFF
--- a/src/NDS.cpp
+++ b/src/NDS.cpp
@@ -1045,7 +1045,6 @@ u32 NDS::RunFrame()
             ARM7Timestamp-SysTimestamp,
             GPU.GPU3D.Timestamp-SysTimestamp);
 #endif
-        SPU.TransferOutput();
         break;
     }
 

--- a/src/SPU.h
+++ b/src/SPU.h
@@ -241,7 +241,6 @@ public:
     int GetOutputSize() const;
     void Sync(bool wait);
     int ReadOutput(s16* data, int samples);
-    void TransferOutput();
 
     u8 Read8(u32 addr);
     u16 Read16(u32 addr);
@@ -251,14 +250,11 @@ public:
     void Write32(u32 addr, u32 val);
 
 private:
-    static const u32 OutputBufferSize = 2*2048;
+    static const u32 OutputBufferSize = 2*1024;  // TODO: configurable audio buffer sizes?
     melonDS::NDS& NDS;
-    s16 OutputBackbuffer[2 * OutputBufferSize] {};
-    u32 OutputBackbufferWritePosition = 0;
-
-    s16 OutputFrontBuffer[2 * OutputBufferSize] {};
-    u32 OutputFrontBufferWritePosition = 0;
-    u32 OutputFrontBufferReadPosition = 0;
+    s16 OutputBuffer[2 * OutputBufferSize] {};
+    u32 OutputBufferWritePos = 0;
+    u32 OutputBufferReadPos = 0;
 
     Platform::Mutex* AudioLock;
 

--- a/src/frontend/qt_sdl/EmuInstance.h
+++ b/src/frontend/qt_sdl/EmuInstance.h
@@ -305,6 +305,7 @@ private:
 
     SDL_AudioDeviceID audioDevice;
     int audioFreq;
+    int audioBufSize;
     float audioSampleFrac;
     bool audioMuted;
     SDL_cond* audioSyncCond;


### PR DESCRIPTION
### Why this PR exists

Since commit 05b94ef, audio produced by the emulated SPU has been double-buffered (2x2048 samples, 128 ms @ ~32 kHz/~7.7 frames latency). Adding on top the output latency (another 1024 samples @ 48 kHz/~21ms/1.4 frames) gives a maximum output latency of just under 150(!) ms (>10 frames) of audio lag. This makes some games (in particular rhythm games) feel very unresponsive to input compared to real hardware.

### What this PR does

This pull request does the following:

- Reverts the SPU audio output to single-buffered, but keeping the thread safety (via use of the `AudioLock` mutex) and reduces the buffer size back to 1024 (for an SPU output latency of 32 ms, what it was before commit 05b94ef). This improves total audio latency to a maximum ~53 ms (~3.2 frames), which greatly improves responsiveness of the emulated software.
- Makes the audio output buffer size configurable via a single variable (named `audioBufSize`). This (along with `audioFreq`) should be made configurable in a future release (I might give it a go at some point).
- Audio init now handles driver changes to the output buffer size (same as what is done with the sample rate). This prevents buffer sizes that the audio driver can't handle (too small/large) being used (and adding SDL overhead). This will become useful when the buffer size is made user-configurable (see below).

### Notes

- This is one of my first times ever writing anything in C++, scrutinize accordingly.
- I *did* read the contribution guidelines, which said I should use `PascalCase` for my variable name, but I used `camelCase` instead (since that's what the previous person did, so I copied them without reading the contribution guidelines before commiting my work :/). Should I change this (along with variable type to e.g. `s32`)?

EDIT: fixed latency calculations (I accidentally used 48 KHz for SPU buffer latency calculations when it should've been ~32 KHz...)

EDIT 2: tried to clarify how I calculated the audio latencies. I used 32 kHz for the SPU output buffer (I can't remember the exact value at the time of writing, but 32 kHz seems close enough), and 48 kHz for the SDL audio output latency.