### PR TITLE
small fix to how the translucency flag is assigned when setting up 

### DIFF
--- a/src/GPU3D.cpp
+++ b/src/GPU3D.cpp
@@ -1219,7 +1219,7 @@ void GPU3D::SubmitPolygon() noexcept
 
     u32 texfmt = (TexParam >> 26) & 0x7;
     u32 polyalpha = (CurPolygonAttr >> 16) & 0x1F;
-    poly->Translucent = ((texfmt == 1 || texfmt == 6) && !(CurPolygonAttr & 0x10)) || (polyalpha > 0 && polyalpha < 31);
+    poly->Translucent = (texfmt == 1 || texfmt == 6) || (polyalpha > 0 && polyalpha < 31);
 
     poly->IsShadowMask = ((CurPolygonAttr & 0x3F000030) == 0x00000030);
     poly->IsShadow = ((CurPolygonAttr & 0x30) == 0x30) && !poly->IsShadowMask;


### PR DESCRIPTION
yoinked this fix from a prior pull request.
Pretty cut and dry: hardware just does not have this check