### PR TITLE
This variable is unused, and not needed anymore.

### DIFF
--- a/src/NDS.cpp
+++ b/src/NDS.cpp
@@ -921,7 +921,6 @@ u32 NDS::RunFrame()
     GPU.TotalScanlines = 0;
 
     LagFrameFlag = true;
-    bool runFrame = Running && !(CPUStop & CPUStop_Sleep);
     while (Running)
     {
         u64 frametarget = SysTimestamp + 560190;


### PR DESCRIPTION
It's a variable I created a long time ago. Refactoring of NDS::RunFrame has made it obsolete.