### PR TITLE
dont waste 12MB of savestate size

### DIFF
--- a/src/NDS.cpp
+++ b/src/NDS.cpp
@@ -630,7 +630,7 @@ bool NDS::DoSavestate(Savestate* file)
         }
     }
 
-    file->VarArray(MainRAM, MainRAMMaxSize);
+    file->VarArray(MainRAM, MainRAMMask+1);
     file->VarArray(SharedWRAM, SharedWRAMSize);
     file->VarArray(ARM7WRAM, ARM7WRAMSize);
 


### PR DESCRIPTION
NDS was writing the entire allocated main RAM buffer to savestates. The buffer is always allocated for DSi mode, and this leads to savestates being over twice the size they need to be. Now it writes an amount appropriate for the console type.