### PR TITLE
Re-render the 3D buffer when loading a savestate

### DIFF
--- a/src/GPU.cpp
+++ b/src/GPU.cpp
@@ -272,12 +272,14 @@ void GPU::DoSavestate(Savestate* file) noexcept
             VRAMPtr_BOBJ[i] = GetUniqueBankPtr(VRAMMap_BOBJ[i], i << 14);
     }
 
+    // This should happen before re-rendering the 3D buffer.
+    if (!file->Saving)
+        ResetVRAMCache();
+
     GPU2D_A.DoSavestate(file);
     GPU2D_B.DoSavestate(file);
     GPU3D.DoSavestate(file);
 
-    if (!file->Saving)
-        ResetVRAMCache();
 }
 
 void GPU::AssignFramebuffers() noexcept

--- a/src/GPU.cpp
+++ b/src/GPU.cpp
@@ -210,7 +210,7 @@ void GPU::Stop() noexcept
     memset(Framebuffer[1][0].get(), 0, fbsize*4);
     memset(Framebuffer[1][1].get(), 0, fbsize*4);
 
-    GPU3D.Stop(*this);
+    GPU3D.Stop();
 }
 
 void GPU::DoSavestate(Savestate* file) noexcept
@@ -901,7 +901,7 @@ void GPU::StartHBlank(u32 line) noexcept
     }
     else if (VCount == 215)
     {
-        GPU3D.VCount215(*this);
+        GPU3D.VCount215();
     }
     else if (VCount == 262)
     {
@@ -927,7 +927,7 @@ void GPU::FinishFrame(u32 lines) noexcept
 
     if (GPU3D.AbortFrame)
     {
-        GPU3D.RestartFrame(*this);
+        GPU3D.RestartFrame();
         GPU3D.AbortFrame = false;
     }
 }
@@ -1020,7 +1020,7 @@ void GPU::StartScanline(u32 line) noexcept
             // texture memory anyway and only update it before the start
             //of the next frame.
             // So we can give the rasteriser a bit more headroom
-            GPU3D.VCount144(*this);
+            GPU3D.VCount144();
 
             // VBlank
             DispStat[0] |= (1<<0);
@@ -1040,7 +1040,7 @@ void GPU::StartScanline(u32 line) noexcept
 
             // Need a better way to identify the openGL renderer in particular
             if (GPU3D.IsRendererAccelerated())
-                GPU3D.Blit(*this);
+                GPU3D.Blit();
         }
     }
 

--- a/src/GPU3D.cpp
+++ b/src/GPU3D.cpp
@@ -555,11 +555,9 @@ void GPU3D::DoSavestate(Savestate* file) noexcept
     file->Var32(&CurPolygonAttr);
     file->Var32(&TexParam);
     file->Var32(&TexPalette);
+
     RenderFrameIdentical = false;
-    if (softRenderer && softRenderer->IsThreaded())
-    {
-        softRenderer->EnableRenderThread();
-    }
+    CurrentRenderer->RenderFrame();
 }
 
 

--- a/src/GPU3D.cpp
+++ b/src/GPU3D.cpp
@@ -316,7 +316,7 @@ void GPU3D::DoSavestate(Savestate* file) noexcept
     SoftRenderer* softRenderer = dynamic_cast<SoftRenderer*>(CurrentRenderer.get());
     if (softRenderer && softRenderer->IsThreaded())
     {
-        softRenderer->SetupRenderThread(NDS.GPU);
+        softRenderer->SetupRenderThread();
     }
 
     CmdFIFO.DoSavestate(file);
@@ -2427,20 +2427,20 @@ void GPU3D::CheckFIFODMA() noexcept
         NDS.CheckDMAs(0, 0x07);
 }
 
-void GPU3D::VCount144(GPU& gpu) noexcept
+void GPU3D::VCount144() noexcept
 {
-    CurrentRenderer->VCount144(gpu);
+    CurrentRenderer->VCount144();
 }
 
-void GPU3D::RestartFrame(GPU& gpu) noexcept
+void GPU3D::RestartFrame() noexcept
 {
-    CurrentRenderer->RestartFrame(gpu);
+    CurrentRenderer->RestartFrame();
 }
 
-void GPU3D::Stop(const GPU& gpu) noexcept
+void GPU3D::Stop() noexcept
 {
     if (CurrentRenderer)
-        CurrentRenderer->Stop(gpu);
+        CurrentRenderer->Stop();
 }
 
 
@@ -2533,9 +2533,9 @@ void GPU3D::VBlank() noexcept
     }
 }
 
-void GPU3D::VCount215(GPU& gpu) noexcept
+void GPU3D::VCount215() noexcept
 {
-    CurrentRenderer->RenderFrame(gpu);
+    CurrentRenderer->RenderFrame();
 }
 
 void GPU3D::SetRenderXPos(u16 xpos) noexcept
@@ -2995,10 +2995,10 @@ void GPU3D::Write32(u32 addr, u32 val) noexcept
     Log(LogLevel::Debug, "unknown GPU3D write32 %08X %08X\n", addr, val);
 }
 
-void GPU3D::Blit(const GPU& gpu) noexcept
+void GPU3D::Blit() noexcept
 {
     if (CurrentRenderer)
-        CurrentRenderer->Blit(gpu);
+        CurrentRenderer->Blit();
 }
 
 Renderer3D::Renderer3D(bool Accelerated)

--- a/src/GPU3D.h
+++ b/src/GPU3D.h
@@ -103,12 +103,12 @@ public:
     void CheckFIFOIRQ() noexcept;
     void CheckFIFODMA() noexcept;
 
-    void VCount144(GPU& gpu) noexcept;
+    void VCount144() noexcept;
     void VBlank() noexcept;
-    void VCount215(GPU& gpu) noexcept;
+    void VCount215() noexcept;
 
-    void RestartFrame(GPU& gpu) noexcept;
-    void Stop(const GPU& gpu) noexcept;
+    void RestartFrame() noexcept;
+    void Stop() noexcept;
 
     void SetRenderXPos(u16 xpos) noexcept;
     [[nodiscard]] u16 GetRenderXPos() const noexcept { return RenderXPos; }
@@ -127,7 +127,7 @@ public:
     void Write8(u32 addr, u8 val) noexcept;
     void Write16(u32 addr, u16 val) noexcept;
     void Write32(u32 addr, u32 val) noexcept;
-    void Blit(const GPU& gpu) noexcept;
+    void Blit() noexcept;
 private:
     melonDS::NDS& NDS;
     typedef union
@@ -344,12 +344,12 @@ public:
     // are more detailed "traits" that we can ask of the Renderer3D type
     const bool Accelerated;
 
-    virtual void VCount144(GPU& gpu) {};
-    virtual void Stop(const GPU& gpu) {}
-    virtual void RenderFrame(GPU& gpu) = 0;
-    virtual void RestartFrame(GPU& gpu) {};
+    virtual void VCount144() {};
+    virtual void Stop() {}
+    virtual void RenderFrame() = 0;
+    virtual void RestartFrame() {};
     virtual u32* GetLine(int line) = 0;
-    virtual void Blit(const GPU& gpu) {};
+    virtual void Blit() {};
 
     virtual void SetupAccelFrame() {}
     virtual void PrepareCaptureFrame() {}
@@ -360,6 +360,7 @@ public:
 
 protected:
     Renderer3D(bool Accelerated);
+    GPU* gpu;
 };
 
 }

--- a/src/GPU3D_Compute.h
+++ b/src/GPU3D_Compute.h
@@ -45,10 +45,10 @@ public:
 
     void SetRenderSettings(int scale, bool highResolutionCoordinates);
 
-    void VCount144(GPU& gpu) override;
+    void VCount144() override;
 
-    void RenderFrame(GPU& gpu) override;
-    void RestartFrame(GPU& gpu) override;
+    void RenderFrame() override;
+    void RestartFrame() override;
     u32* GetLine(int line) override;
 
     void SetupAccelFrame() override;
@@ -56,8 +56,8 @@ public:
 
     void BindOutputTexture(int buffer) override;
 
-    void Blit(const GPU& gpu) override;
-    void Stop(const GPU& gpu) override;
+    void Blit() override;
+    void Stop() override;
 
     bool NeedsShaderCompile() override { return ShaderStepIdx != 33; }
     void ShaderCompileStep(int& current, int& count) override;

--- a/src/GPU3D_OpenGL.h
+++ b/src/GPU3D_OpenGL.h
@@ -39,14 +39,14 @@ public:
     [[nodiscard]] bool GetBetterPolygons() const noexcept { return BetterPolygons; }
     [[nodiscard]] int GetScaleFactor() const noexcept { return ScaleFactor; }
 
-    void VCount144(GPU& gpu) override {};
-    void RenderFrame(GPU& gpu) override;
-    void Stop(const GPU& gpu) override;
+    void VCount144() override {};
+    void RenderFrame() override;
+    void Stop() override;
     u32* GetLine(int line) override;
 
     void SetupAccelFrame() override;
     void PrepareCaptureFrame() override;
-    void Blit(const GPU& gpu) override;
+    void Blit() override;
 
     void BindOutputTexture(int buffer) override;
 
@@ -84,7 +84,7 @@ private:
     int RenderSinglePolygon(int i) const;
     int RenderPolygonBatch(int i) const;
     int RenderPolygonEdgeBatch(int i) const;
-    void RenderSceneChunk(const GPU3D& gpu3d, int y, int h);
+    void RenderSceneChunk(int y, int h);
 
     enum
     {

--- a/src/GPU3D_Soft.h
+++ b/src/GPU3D_Soft.h
@@ -33,15 +33,15 @@ public:
     ~SoftRenderer() override;
     void Reset(GPU& gpu) override;
 
-    void SetThreaded(bool threaded, GPU& gpu) noexcept;
+    void SetThreaded(bool threaded) noexcept;
     [[nodiscard]] bool IsThreaded() const noexcept { return Threaded; }
 
-    void VCount144(GPU& gpu) override;
-    void RenderFrame(GPU& gpu) override;
-    void RestartFrame(GPU& gpu) override;
+    void VCount144() override;
+    void RenderFrame() override;
+    void RestartFrame() override;
     u32* GetLine(int line) override;
 
-    void SetupRenderThread(GPU& gpu);
+    void SetupRenderThread();
     void EnableRenderThread();
     void StopRenderThread();
 private:
@@ -430,7 +430,7 @@ private:
         s32 ycoverage, ycov_incr;
     };
 
-    u32 AlphaBlend(const GPU3D& gpu3d, u32 srccolor, u32 dstcolor, u32 alpha) const noexcept;
+    u32 AlphaBlend(u32 srccolor, u32 dstcolor, u32 alpha) const noexcept;
 
     struct RendererPolygon
     {
@@ -445,21 +445,21 @@ private:
     };
 
     RendererPolygon PolygonList[2048];
-    void TextureLookup(const GPU& gpu, u32 texparam, u32 texpal, s16 s, s16 t, u16* color, u8* alpha) const;
-    u32 RenderPixel(const GPU& gpu, const Polygon* polygon, u8 vr, u8 vg, u8 vb, s16 s, s16 t) const;
-    void PlotTranslucentPixel(const GPU3D& gpu3d, u32 pixeladdr, u32 color, u32 z, u32 polyattr, u32 shadow);
+    void TextureLookup(u32 texparam, u32 texpal, s16 s, s16 t, u16* color, u8* alpha) const;
+    u32 RenderPixel(const Polygon* polygon, u8 vr, u8 vg, u8 vb, s16 s, s16 t) const;
+    void PlotTranslucentPixel(u32 pixeladdr, u32 color, u32 z, u32 polyattr, u32 shadow);
     void SetupPolygonLeftEdge(RendererPolygon* rp, s32 y) const;
     void SetupPolygonRightEdge(RendererPolygon* rp, s32 y) const;
     void SetupPolygon(RendererPolygon* rp, Polygon* polygon) const;
-    void RenderShadowMaskScanline(const GPU3D& gpu3d, RendererPolygon* rp, s32 y);
-    void RenderPolygonScanline(const GPU& gpu, RendererPolygon* rp, s32 y);
-    void RenderScanline(const GPU& gpu, s32 y, int npolys);
-    u32 CalculateFogDensity(const GPU3D& gpu3d, u32 pixeladdr) const;
-    void ScanlineFinalPass(const GPU3D& gpu3d, s32 y);
-    void ClearBuffers(const GPU& gpu);
-    void RenderPolygons(const GPU& gpu, bool threaded, Polygon** polygons, int npolys);
+    void RenderShadowMaskScanline(RendererPolygon* rp, s32 y);
+    void RenderPolygonScanline(RendererPolygon* rp, s32 y);
+    void RenderScanline(s32 y, int npolys);
+    u32 CalculateFogDensity(u32 pixeladdr) const;
+    void ScanlineFinalPass(s32 y);
+    void ClearBuffers();
+    void RenderPolygons(bool threaded, Polygon** polygons, int npolys);
 
-    void RenderThreadFunc(GPU& gpu);
+    void RenderThreadFunc();
 
     // buffer dimensions are 258x194 to add a offscreen 1px border
     // which simplifies edge marking tests

--- a/src/NDS.cpp
+++ b/src/NDS.cpp
@@ -1373,7 +1373,7 @@ void NDS::SetIRQ(u32 cpu, u32 irq)
         {
             CPUStop &= ~CPUStop_Sleep;
             CPUStop |= CPUStop_Wakeup;
-            GPU.GPU3D.RestartFrame(GPU);
+            GPU.GPU3D.RestartFrame();
         }
     }
 }

--- a/src/frontend/qt_sdl/EmuThread.cpp
+++ b/src/frontend/qt_sdl/EmuThread.cpp
@@ -870,8 +870,7 @@ void EmuThread::updateRenderer()
     {
         case renderer3D_Software:
             static_cast<SoftRenderer&>(emuInstance->nds->GPU.GetRenderer3D()).SetThreaded(
-                    cfg.GetBool("3D.Soft.Threaded"),
-                    emuInstance->nds->GPU);
+                    cfg.GetBool("3D.Soft.Threaded"));
             break;
         case renderer3D_OpenGL:
             static_cast<GLRenderer&>(emuInstance->nds->GPU.GetRenderer3D()).SetRenderSettings(


### PR DESCRIPTION
This avoids having either a black frame after loading a state or having the old render after loading a state.
The second commit is simple enough to redo it without the first, if wanted.