### PR TITLE
Use standard sysconf

### DIFF
--- a/src/ARMJIT_Memory.cpp
+++ b/src/ARMJIT_Memory.cpp
@@ -753,7 +753,7 @@ bool ARMJIT_Memory::IsFastMemSupported()
 
         PageSize = RegularPageSize;
 #else
-        PageSize = __sysconf(_SC_PAGESIZE);
+        PageSize = sysconf(_SC_PAGESIZE);
         isSupported = PageSize == RegularPageSize || PageSize == LargePageSize;
 #endif
         PageShift = __builtin_ctz(PageSize);


### PR DESCRIPTION
Fixes compilation of JIT builds on non-glibc OSes. After some testing in a Fedora 41 VM, __sysconf and sysconf return the same value, and sysconf in glibc appears to just be an alias to __sysconf to begin with