### PR TITLE
Fix undefined behavior when indexing into `ARCode::Code`

### DIFF
--- a/src/AREngine.cpp
+++ b/src/AREngine.cpp
@@ -58,7 +58,8 @@ void AREngine::RunCheat(const ARCode& arcode)
 
     for (;;)
     {
-        if (code >= &arcode.Code[arcode.Code.size()])
+        if (code > &arcode.Code[arcode.Code.size() - 1])
+            // If the instruction pointer is past the end of the cheat code...
             break;
 
         u32 a = *code++;


### PR DESCRIPTION
- Indexing past the end of a `std::vector`'s length is undefined, even if there's extra capacity
- GCC 15 introduced an assert in `vector::operator[]`, so this line caused an abort if melonDS was built with GCC 15
- It was always undefined, but now the STL checks for it