### PR TITLE
Fix a missing `#include` on Windows builds

### DIFF
--- a/src/ARMJIT_Memory.h
+++ b/src/ARMJIT_Memory.h
@@ -29,8 +29,8 @@
 #  if defined(__SWITCH__)
 #    include <switch.h>
 #  elif defined(_WIN32)
-#include <vector>
-#include <windows.h>
+#    include <vector>
+#    include <windows.h>
 #  else
 #    include <sys/mman.h>
 #    include <sys/stat.h>

--- a/src/ARMJIT_Memory.h
+++ b/src/ARMJIT_Memory.h
@@ -29,6 +29,7 @@
 #  if defined(__SWITCH__)
 #    include <switch.h>
 #  elif defined(_WIN32)
+#include <vector>
 #include <windows.h>
 #  else
 #    include <sys/mman.h>


### PR DESCRIPTION
This PR `#include`s `<vector>` in `ARMJIT_Memory.h`, as it's (conditionally) used in the `ARMJIT_Memory` class declaration. The build [was failing in melonDS DS](https://github.com/JesseTG/melonds-ds/actions/runs/15164802143/job/42639759921#step:18:200), most likely because `<vector>` was included implicitly in the past.