### PR TITLE
Add support for NDS devkit (8MB) and 3DS (32MB) MainRAM configurations

### DIFF
--- a/src/ARMJIT_Memory.cpp
+++ b/src/ARMJIT_Memory.cpp
@@ -1038,6 +1038,12 @@ bool ARMJIT_Memory::GetMirrorLocation(int region, u32 num, u32 addr, u32& memory
         }
         return false;
     case memregion_MainRAM:
+        // 0x02xxxxxx region is limited to 16MiB
+        if (addr < 0x0C000000) {
+            mirrorStart = addr & ~(NDS.MainRAMMask & 0xFFFFFF);
+            mirrorSize = (NDS.MainRAMMask & 0xFFFFFF) + 1;
+            return true;
+        }
         mirrorStart = addr & ~NDS.MainRAMMask;
         mirrorSize = NDS.MainRAMMask + 1;
         return true;
@@ -1283,6 +1289,8 @@ int ARMJIT_Memory::ClassifyAddress9(u32 addr) const noexcept
             return memregion_VRAM;
         case 0x0C000000:
             return (NDS.ConsoleType==1) ? memregion_MainRAM : memregion_Other;
+        case 0x0D000000:
+            return (NDS.ConsoleType==1 && NDS.MainRAMMask>=0x1FFFFFF) ? memregion_MainRAM : memregion_Other;
         default:
             return memregion_Other;
         }
@@ -1341,6 +1349,9 @@ int ARMJIT_Memory::ClassifyAddress7(u32 addr) const noexcept
         case 0x0C000000:
         case 0x0C800000:
             return (NDS.ConsoleType==1) ? memregion_MainRAM : memregion_Other;
+        case 0x0D000000:
+        case 0x0D800000:
+            return (NDS.ConsoleType==1 && NDS.MainRAMMask>=0x1FFFFFF) ? memregion_MainRAM : memregion_Other;
         default:
             return memregion_Other;
         }

--- a/src/MemConstants.h
+++ b/src/MemConstants.h
@@ -23,7 +23,8 @@
 
 namespace melonDS
 {
-constexpr u32 MainRAMMaxSize = 0x1000000;
+constexpr u32 MainRAMPrimaryMappingMaxSize = 0x1000000;
+constexpr u32 MainRAMMaxSize = 0x2000000;
 constexpr u32 SharedWRAMSize = 0x8000;
 constexpr u32 ARM7WRAMSize = 0x10000;
 constexpr u32 NWRAMSize = 0x40000;

--- a/src/NDS.cpp
+++ b/src/NDS.cpp
@@ -87,8 +87,9 @@ NDS::NDS() noexcept :
 {
 }
 
-NDS::NDS(NDSArgs&& args, int type, void* userdata) noexcept :
+NDS::NDS(NDSArgs&& args, int type, int debugbc, void* userdata) noexcept :
     ConsoleType(type),
+    DebugBoardConfig(debugbc),
     UserData(userdata),
     ARM7BIOS(*args.ARM7BIOS),
     ARM9BIOS(*args.ARM9BIOS),
@@ -446,12 +447,14 @@ void NDS::Reset()
         // BIOS files are now loaded by the frontend
 
         ARM9ClockShift = 2;
-        MainRAMMask = 0xFFFFFF;
+        MainRAMMask = DebugBoardConfig ? 0x1FFFFFF : 0x1FFFFFF; // Intentional default
+        MainRAMPresent = DebugBoardConfig ? 0x2000000 : 0x1000000; // 32MiB and 16MiB
     }
     else
     {
         ARM9ClockShift = 1;
-        MainRAMMask = 0x3FFFFF;
+        MainRAMMask = DebugBoardConfig ? 0x7FFFFF : 0x3FFFFF;
+        MainRAMPresent = DebugBoardConfig ? 0x800000 : 0x400000; // 8MiB and 4MiB
     }
     // has to be called before InitTimings
     // otherwise some PU settings are completely

--- a/src/NDS.h
+++ b/src/NDS.h
@@ -249,6 +249,7 @@ public: // TODO: Encapsulate the rest of these members
     void* UserData;
 
     int ConsoleType;
+    int DebugBoardConfig;
     int CurCPU;
 
     SchedEvent SchedList[Event_MAX] {};
@@ -293,8 +294,7 @@ public: // TODO: Encapsulate the rest of these members
 
     u8* MainRAM;
     u32 MainRAMMask;
-
-    const u32 MainRAMMaxSize = 0x1000000;
+    u32 MainRAMPresent;
 
     const u32 SharedWRAMSize = 0x8000;
     u8* SharedWRAM;
@@ -547,7 +547,7 @@ private:
     u32 RunFrame();
 
 public:
-    NDS(NDSArgs&& args, void* userdata = nullptr) noexcept : NDS(std::move(args), 0, userdata) {}
+    NDS(NDSArgs&& args, void* userdata = nullptr) noexcept : NDS(std::move(args), 0, 0, userdata) {}
     NDS() noexcept;
     virtual ~NDS() noexcept;
     NDS(const NDS&) = delete;
@@ -557,7 +557,7 @@ public:
 
     static thread_local NDS* Current;
 protected:
-    explicit NDS(NDSArgs&& args, int type, void* userdata) noexcept;
+    explicit NDS(NDSArgs&& args, int type, int debugbc, void* userdata) noexcept;
     virtual void DoSavestateExtra(Savestate* file) {}
 };
 

--- a/src/frontend/qt_sdl/Config.cpp
+++ b/src/frontend/qt_sdl/Config.cpp
@@ -77,6 +77,7 @@ DefaultList<int> DefaultInts =
 RangeList IntRanges =
 {
     {"Emu.ConsoleType", {0, 1}},
+    {"Emu.DebugBoardConfig", {0, 1}},
     {"3D.Renderer", {0, renderer3D_Max-1}},
     {"Screen.VSyncInterval", {1, 20}},
     {"3D.GL.ScaleFactor", {1, 16}},

--- a/src/frontend/qt_sdl/EmuInstance.cpp
+++ b/src/frontend/qt_sdl/EmuInstance.cpp
@@ -70,6 +70,7 @@ EmuInstance::EmuInstance(int inst) : deleting(false),
     localCfg(Config::GetLocalTable(inst))
 {
     consoleType = globalCfg.GetInt("Emu.ConsoleType");
+    debugBoardConfig = globalCfg.GetInt("Emu.DebugBoardConfig");
 
     ndsSave = nullptr;
     cartType = -1;
@@ -1240,6 +1241,7 @@ bool EmuInstance::updateConsole() noexcept
 {
     // update the console type
     consoleType = globalCfg.GetInt("Emu.ConsoleType");
+    debugBoardConfig = globalCfg.GetInt("Emu.DebugBoardConfig");
 
     // Let's get the cart we want to use;
     // if we want to keep the cart, we'll eject it from the existing console first.
@@ -1353,7 +1355,7 @@ bool EmuInstance::updateConsole() noexcept
     }
 
     renderLock.lock();
-    if ((!nds) || (consoleType != nds->ConsoleType))
+    if ((!nds) || (consoleType != nds->ConsoleType) || (debugBoardConfig != nds->DebugBoardConfig))
     {
         if (nds)
         {
@@ -1366,6 +1368,7 @@ bool EmuInstance::updateConsole() noexcept
         else
             nds = new NDS(std::move(ndsargs), this);
 
+        nds->DebugBoardConfig = debugBoardConfig;
         nds->Reset();
         loadRTCData();
         //emuThread->updateVideoRenderer(); // not actually needed?

--- a/src/frontend/qt_sdl/EmuInstance.h
+++ b/src/frontend/qt_sdl/EmuInstance.h
@@ -88,6 +88,7 @@ public:
 
     int getInstanceID() { return instanceID; }
     int getConsoleType() { return consoleType; }
+    int getDebugBoardConfig() { return debugBoardConfig; }
     EmuThread* getEmuThread() { return emuThread; }
     melonDS::NDS* getNDS() { return nds; }
 
@@ -264,6 +265,7 @@ private:
     Config::Table localCfg;
 
     int consoleType;
+    int debugBoardConfig;
     melonDS::NDS* nds;
 
     int cartType;

--- a/src/frontend/qt_sdl/EmuSettingsDialog.cpp
+++ b/src/frontend/qt_sdl/EmuSettingsDialog.cpp
@@ -72,8 +72,10 @@ EmuSettingsDialog::EmuSettingsDialog(QWidget* parent) : QDialog(parent), ui(new 
     ui->txtDSiNANDPath->setText(cfg.GetQString("DSi.NANDPath"));
 
     ui->cbxConsoleType->addItem("DS");
+    ui->cbxConsoleType->addItem("DS devkit (experimental)");
     ui->cbxConsoleType->addItem("DSi (experimental)");
-    ui->cbxConsoleType->setCurrentIndex(cfg.GetInt("Emu.ConsoleType"));
+    ui->cbxConsoleType->addItem("3DS (experimental)");
+    ui->cbxConsoleType->setCurrentIndex((cfg.GetInt("Emu.ConsoleType")<<1)+cfg.GetInt("Emu.DebugBoardConfig"));
 
     ui->chkDirectBoot->setChecked(cfg.GetBool("Emu.DirectBoot"));
 
@@ -297,7 +299,8 @@ void EmuSettingsDialog::done(int r)
             instcfg.SetBool("Gdb.ARM9.BreakOnStartup", ui->cbGdbBOSA9->isChecked());
 #endif
 
-            cfg.SetInt("Emu.ConsoleType", ui->cbxConsoleType->currentIndex());
+            cfg.SetInt("Emu.ConsoleType", ui->cbxConsoleType->currentIndex()>>1);
+            cfg.SetInt("Emu.DebugBoardConfig", ui->cbxConsoleType->currentIndex()&1);
             cfg.SetBool("Emu.DirectBoot", ui->chkDirectBoot->isChecked());
 
             Config::Save();

--- a/src/frontend/qt_sdl/RAMInfoDialog.cpp
+++ b/src/frontend/qt_sdl/RAMInfoDialog.cpp
@@ -242,14 +242,15 @@ void RAMSearchThread::run()
     if (SearchMode == ramInfoSTh_SearchAll || RowDataVector->size() == 0)
     {
         // First search mode
-        for (u32 addr = 0x02000000; SearchRunning && addr < 0x02000000+MainRAMMaxSize; addr += SearchByteType)
+        // TODO: 3DS/devit 32MiB
+        for (u32 addr = 0x02000000; SearchRunning && addr < 0x02000000+MainRAMPrimaryMappingMaxSize; addr += SearchByteType)
         {
             const s32& value = GetMainRAMValue(*Dialog->emuInstance->getNDS(), addr, SearchByteType);
 
             RowDataVector->push_back({ addr, value, value });
 
             // A solution to prevent to call too many slot.
-            u32 newProgress = (int)((addr-0x02000000) / (MainRAMMaxSize-1.0f) * 100);
+            u32 newProgress = (int)((addr-0x02000000) / (MainRAMPrimaryMappingMaxSize-1.0f) * 100);
             if (progress < newProgress)
             {
                 progress = newProgress;


### PR DESCRIPTION
- Both JIT/interpreter are tested and working (afaict)
- 32MB is tested against BlocksDS's detection heuristics and matching my tests against 3DS vs DSi
  - Including memory mirrors vs open bus behavior, open-bus is the default expected by applications (and was the default before this PR), the memory mirroring at 0x0D000000 is untested at the moment because SCFG writes are ignored and it's a bit edge-casey behavior anyway.
- 8MB (NDS devkit) is completely untested and might not even exist for all I know, but GBATEK has at least one mention of the configuration and the current mirroring behavior should be fine. Maybe useful for prototype dumps or something.