### PR TITLE
Make CameraManager request the camera access permission when using Qt 6

### DIFF
--- a/src/frontend/qt_sdl/CMakeLists.txt
+++ b/src/frontend/qt_sdl/CMakeLists.txt
@@ -260,3 +260,5 @@ if (ENABLE_OGLRENDERER)
     target_compile_definitions(melonDS PUBLIC MELONDS_GL_HEADER=${MELONDS_GL_HEADER})
     target_compile_definitions(core PUBLIC MELONDS_GL_HEADER=${MELONDS_GL_HEADER})
 endif()
+
+qt_finalize_target(melonDS)


### PR DESCRIPTION
Camera access seems to have changed to require explicitly asking for permission rather than doing it for you.

Starting the session was moved to the camStart slot so that the permission prompt will show up when the camera is actually used the first time rather than in some cases before the main window even shows up.