### PR TITLE
fix: GDB stub reading wrong code for vCont packet

### DIFF
--- a/src/debug/GdbCmds.cpp
+++ b/src/debug/GdbCmds.cpp
@@ -893,7 +893,10 @@ ExecResult GdbStub::Handle_v_Cont(GdbStub* stub, const u8* cmd, ssize_t len)
 		return ExecResult::Ok;
 	}
 
-	switch (cmd[0])
+	// Continue code should always be separated by a ';' (but maybe they aren't sometimes? not sure)
+	char actionCode = (cmd[0] == ';' && len >= 2) ? cmd[1] : cmd[0];
+
+	switch (actionCode)
 	{
 	case 'c':
 		stub->RespStr("OK");
@@ -905,7 +908,7 @@ ExecResult GdbStub::Handle_v_Cont(GdbStub* stub, const u8* cmd, ssize_t len)
 		stub->RespStr("OK");
 		return ExecResult::MustBreak;
 	default:
-		printf("invalid continue %c %s\n", cmd[0], cmd);
+		printf("invalid continue %c %s\n", actionCode, cmd);
 		stub->RespStr("E01");
 		return ExecResult::Ok;
 	}

--- a/src/debug/GdbCmds.cpp
+++ b/src/debug/GdbCmds.cpp
@@ -886,17 +886,14 @@ ExecResult GdbStub::Handle_v_MustReplyEmpty(GdbStub* stub, const u8* cmd, ssize_
 
 ExecResult GdbStub::Handle_v_Cont(GdbStub* stub, const u8* cmd, ssize_t len)
 {
-	if (len < 1)
+	if (len < 2)
 	{
 		printf("insufficient length");
 		stub->RespStr("E01");
 		return ExecResult::Ok;
 	}
 
-	// Continue code should always be separated by a ';' (but maybe they aren't sometimes? not sure)
-	char actionCode = (cmd[0] == ';' && len >= 2) ? cmd[1] : cmd[0];
-
-	switch (actionCode)
+	switch (cmd[1])
 	{
 	case 'c':
 		stub->RespStr("OK");
@@ -908,7 +905,7 @@ ExecResult GdbStub::Handle_v_Cont(GdbStub* stub, const u8* cmd, ssize_t len)
 		stub->RespStr("OK");
 		return ExecResult::MustBreak;
 	default:
-		printf("invalid continue %c %s\n", actionCode, cmd);
+		printf("invalid continue %c %s\n", cmd[1], cmd);
 		stub->RespStr("E01");
 		return ExecResult::Ok;
 	}


### PR DESCRIPTION
I was attempting to use the gdb stub with lldb (in its gdb-remote mode) and noticed that the debugging session was always abruptly terminated whenever attempting to step or continue after a breakpoint was hit. It turns out that lldb sends the `vCont` packet for these actions, e.g. `vCont;s:1`. This is the correct format for this command as seen in the gdb documentation [here](https://sourceware.org/gdb/current/onlinedocs/gdb.html/Packets.html#vCont-packet) -- specifically, it indicates continue, step, thread 1.

However, the current gdb stub implementation was reading the `;` as the continue action code, assuming it was invalid, and then throwing an error. To me, this just seems like it should have never worked, but I'm also not super familiar with gdb's internals so I've fixed the issue without introducing a breaking change.