### PR TITLE
`sockaddr_in` is a forward declaration on OpenBSD, explicitly `#include` the correct header for it.

### DIFF
--- a/src/debug/GdbStub.cpp
+++ b/src/debug/GdbStub.cpp
@@ -18,6 +18,7 @@
 #include <poll.h>
 #include <signal.h>
 #include <arpa/inet.h>
+#include <netinet/in.h>
 #include <netinet/tcp.h>
 #endif
 


### PR DESCRIPTION
When updating my OpenBSD port to the 1.0 release, I noticed on OpenBSD, not including `<netinet/in.h>` explicitly means `sockaddr_in` stays a forward declaration, and results in this compile-time error:

```
/usr/ports/mystuff/emulators/melonds git:(main) $ make            
===>  Building for melonds-1.0
Change Dir: '/usr/ports/pobj/melonds-1.0/build-amd64'

Run Build Command(s): /usr/local/bin/ninja -v -j 1
[1/115] /usr/ports/pobj/melonds-1.0/bin/c++ -DARCHITECTURE_x86_64=1 -DGDBSTUB_ENABLED -DMELONDS_GL_HEADER=\"frontend/glad/glad.h\" -DOGLRENDERER_ENABLED -I/usr/ports/pobj/melonds-1.0/build-amd64/src -I/usr/ports/pobj/melonds-1.0/melonDS-1.0/src/teakra/src/../include -O2 -pipe -g -DNDEBUG -std=gnu++17 -flto=thin -fPIC -fwrapv -Wno-invalid-offsetof -MD -MT src/CMakeFiles/core.dir/debug/GdbStub.cpp.o -MF src/CMakeFiles/core.dir/debug/GdbStub.cpp.o.d -o src/CMakeFiles/core.dir/debug/GdbStub.cpp.o -c /usr/ports/pobj/melonds-1.0/melonDS-1.0/src/debug/GdbStub.cpp
FAILED: src/CMakeFiles/core.dir/debug/GdbStub.cpp.o 
/usr/ports/pobj/melonds-1.0/bin/c++ -DARCHITECTURE_x86_64=1 -DGDBSTUB_ENABLED -DMELONDS_GL_HEADER=\"frontend/glad/glad.h\" -DOGLRENDERER_ENABLED -I/usr/ports/pobj/melonds-1.0/build-amd64/src -I/usr/ports/pobj/melonds-1.0/melonDS-1.0/src/teakra/src/../include -O2 -pipe -g -DNDEBUG -std=gnu++17 -flto=thin -fPIC -fwrapv -Wno-invalid-offsetof -MD -MT src/CMakeFiles/core.dir/debug/GdbStub.cpp.o -MF src/CMakeFiles/core.dir/debug/GdbStub.cpp.o.d -o src/CMakeFiles/core.dir/debug/GdbStub.cpp.o -c /usr/ports/pobj/melonds-1.0/melonDS-1.0/src/debug/GdbStub.cpp
/usr/ports/pobj/melonds-1.0/melonDS-1.0/src/debug/GdbStub.cpp:58:24: error: allocation of incomplete type 'struct sockaddr_in'
   58 |         , ServerSA((void*)new struct sockaddr_in())
      |                               ^~~~~~~~~~~~~~~~~~
/usr/ports/pobj/melonds-1.0/melonDS-1.0/src/debug/GdbStub.cpp:58:31: note: forward declaration of 'sockaddr_in'
   58 |         , ServerSA((void*)new struct sockaddr_in())
      |                                      ^
/usr/ports/pobj/melonds-1.0/melonDS-1.0/src/debug/GdbStub.cpp:59:24: error: allocation of incomplete type 'struct sockaddr_in'
   59 |         , ClientSA((void*)new struct sockaddr_in())
      |                               ^~~~~~~~~~~~~~~~~~
/usr/ports/pobj/melonds-1.0/melonDS-1.0/src/debug/GdbStub.cpp:58:31: note: forward declaration of 'sockaddr_in'
   58 |         , ServerSA((void*)new struct sockaddr_in())
      |                                      ^
/usr/ports/pobj/melonds-1.0/melonDS-1.0/src/debug/GdbStub.cpp:118:8: error: member access into incomplete type 'struct sockaddr_in'
  118 |         server->sin_family = AF_INET;
      |               ^
/usr/ports/pobj/melonds-1.0/melonDS-1.0/src/debug/GdbStub.cpp:92:9: note: forward declaration of 'sockaddr_in'
   92 |         struct sockaddr_in* server = (struct sockaddr_in*)ServerSA;
      |                ^
/usr/ports/pobj/melonds-1.0/melonDS-1.0/src/debug/GdbStub.cpp:119:8: error: member access into incomplete type 'struct sockaddr_in'
  119 |         server->sin_addr.s_addr = htonl(INADDR_ANY);
      |               ^
/usr/ports/pobj/melonds-1.0/melonDS-1.0/src/debug/GdbStub.cpp:92:9: note: forward declaration of 'sockaddr_in'
   92 |         struct sockaddr_in* server = (struct sockaddr_in*)ServerSA;
      |                ^
/usr/ports/pobj/melonds-1.0/melonDS-1.0/src/debug/GdbStub.cpp:119:34: error: use of undeclared identifier 'INADDR_ANY'
  119 |         server->sin_addr.s_addr = htonl(INADDR_ANY);
      |                                         ^
/usr/ports/pobj/melonds-1.0/melonDS-1.0/src/debug/GdbStub.cpp:119:34: error: use of undeclared identifier 'INADDR_ANY'
/usr/ports/pobj/melonds-1.0/melonDS-1.0/src/debug/GdbStub.cpp:119:34: error: use of undeclared identifier 'INADDR_ANY'
/usr/ports/pobj/melonds-1.0/melonDS-1.0/src/debug/GdbStub.cpp:119:34: error: use of undeclared identifier 'INADDR_ANY'
/usr/ports/pobj/melonds-1.0/melonDS-1.0/src/debug/GdbStub.cpp:119:34: error: use of undeclared identifier 'INADDR_ANY'
/usr/ports/pobj/melonds-1.0/melonDS-1.0/src/debug/GdbStub.cpp:119:34: error: use of undeclared identifier 'INADDR_ANY'
/usr/ports/pobj/melonds-1.0/melonDS-1.0/src/debug/GdbStub.cpp:120:8: error: member access into incomplete type 'struct sockaddr_in'
  120 |         server->sin_port = htons(Port);
      |               ^
/usr/ports/pobj/melonds-1.0/melonDS-1.0/src/debug/GdbStub.cpp:92:9: note: forward declaration of 'sockaddr_in'
   92 |         struct sockaddr_in* server = (struct sockaddr_in*)ServerSA;
      |                ^
/usr/ports/pobj/melonds-1.0/melonDS-1.0/src/debug/GdbStub.cpp:122:50: error: invalid application of 'sizeof' to an incomplete type 'struct sockaddr_in'
  122 |         r = bind(SockFd, (const sockaddr*)server, sizeof(*server));
      |                                                         ^~~~~~~~~
/usr/ports/pobj/melonds-1.0/melonDS-1.0/src/debug/GdbStub.cpp:92:9: note: forward declaration of 'sockaddr_in'
   92 |         struct sockaddr_in* server = (struct sockaddr_in*)ServerSA;
      |                ^
/usr/ports/pobj/melonds-1.0/melonDS-1.0/src/debug/GdbStub.cpp:168:2: warning: deleting pointer to incomplete type 'struct sockaddr_in' is incompatible with C++2c and may cause undefined behavior [-Wdelete-incomplete]
  168 |         delete (struct sockaddr_in*)ServerSA;
      |         ^      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/ports/pobj/melonds-1.0/melonDS-1.0/src/debug/GdbStub.cpp:168:17: note: forward declaration of 'sockaddr_in'
  168 |         delete (struct sockaddr_in*)ServerSA;
      |                        ^
/usr/ports/pobj/melonds-1.0/melonDS-1.0/src/debug/GdbStub.cpp:169:2: warning: deleting pointer to incomplete type 'struct sockaddr_in' is incompatible with C++2c and may cause undefined behavior [-Wdelete-incomplete]
  169 |         delete (struct sockaddr_in*)ClientSA;
      |         ^      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/ports/pobj/melonds-1.0/melonDS-1.0/src/debug/GdbStub.cpp:168:17: note: forward declaration of 'sockaddr_in'
  168 |         delete (struct sockaddr_in*)ServerSA;
      |                        ^
/usr/ports/pobj/melonds-1.0/melonDS-1.0/src/debug/GdbStub.cpp:303:25: error: invalid application of 'sizeof' to an incomplete type 'struct sockaddr_in'
  303 |                 socklen_t len = sizeof(*client);
      |                                       ^~~~~~~~~
/usr/ports/pobj/melonds-1.0/melonDS-1.0/src/debug/GdbStub.cpp:302:10: note: forward declaration of 'sockaddr_in'
  302 |                 struct sockaddr_in* client = (struct sockaddr_in*)ClientSA;
      |                        ^
2 warnings and 13 errors generated.
ninja: build stopped: subcommand failed.

*** Error 1 in . (/usr/ports/devel/cmake/cmake.port.mk:50 'do-build': @cd /usr/ports/pobj/melonds-1.0/build-amd64 && exec /usr/bin/env -i MO...)
*** Error 2 in . (/usr/ports/infrastructure/mk/bsd.port.mk:3065 '/usr/ports/pobj/melonds-1.0/build-amd64/.build_done': @cd /usr/ports/mystuf...)
*** Error 2 in /usr/ports/mystuff/emulators/melonds (/usr/ports/infrastructure/mk/bsd.port.mk:2712 'all': @lock=melonds-1.0;  export _LOCKS_...)
```

This is a simple fix that adds this `#include` to fix compat on OpenBSD.