### PR TITLE
Fixed 8-bit NO$GBA debug register write.

### DIFF
--- a/src/NDS.cpp
+++ b/src/NDS.cpp
@@ -3279,6 +3279,9 @@ void NDS::ARM9IOWrite8(u32 addr, u8 val)
         if (PostFlag9 & 0x01) val |= 0x01;
         PostFlag9 = val & 0x03;
         return;
+
+    // NO$GBA debug register "Char Out"
+        case 0x04FFFA1C: Log(LogLevel::Debug, "%c", char(val)); return;
     }
 
     if (addr >= 0x04000000 && addr < 0x04000060)


### PR DESCRIPTION
Fixed 8-bit NO$GBA debug register write.

[GBATEK](https://problemkaputt.de/gbatek.htm#dsdebugregistersemulatordevkits) mentions nothing about the width (in contrast with Ensata Emulator Pseudo I/O Ports in the same section), but at least 8-bit should be supported for "Char out".

Current devkitARM uses 8-bit write for NO$GBA debug output. There may be [other split register write problem](https://github.com/devkitPro/calico/issues/3) leading to compatibility problems to emulators due to changes in calico, but this one is purely for debugging and it should have no impact on the real machine.

This should also fix #2374.
