### PR TITLE
Basic auto save state functionality

### DIFF
--- a/src/frontend/qt_sdl/Window.cpp
+++ b/src/frontend/qt_sdl/Window.cpp
@@ -368,6 +368,11 @@ MainWindow::MainWindow(int id, EmuInstance* inst, QWidget* parent) :
                 actSaveState[0]->setShortcut(QKeySequence(Qt::ShiftModifier | Qt::Key_F9));
                 actSaveState[0]->setData(QVariant(0));
                 connect(actSaveState[0], &QAction::triggered, this, &MainWindow::onSaveState);
+                
+                actSaveState[9] = submenu->addAction("Auto Slot");
+                actSaveState[9]->setShortcut(QKeySequence(Qt::ShiftModifier | Qt::Key_F10));
+                actSaveState[9]->setData(QVariant(9));
+                connect(actSaveState[9], &QAction::triggered, this, &MainWindow::onSaveState);
             }
             {
                 QMenu * submenu = menu->addMenu("Load state");
@@ -384,6 +389,11 @@ MainWindow::MainWindow(int id, EmuInstance* inst, QWidget* parent) :
                 actLoadState[0]->setShortcut(QKeySequence(Qt::Key_F9));
                 actLoadState[0]->setData(QVariant(0));
                 connect(actLoadState[0], &QAction::triggered, this, &MainWindow::onLoadState);
+
+                actLoadState[9] = submenu->addAction("Auto slot");
+                actLoadState[9]->setShortcut(QKeySequence(Qt::Key_F10));
+                actLoadState[9]->setData(QVariant(9));
+                connect(actLoadState[9], &QAction::triggered, this, &MainWindow::onLoadState);
             }
 
             actUndoStateLoad = menu->addAction("Undo state load");
@@ -661,6 +671,12 @@ MainWindow::MainWindow(int id, EmuInstance* inst, QWidget* parent) :
                 actSavestateSRAMReloc = submenu->addAction("Separate savefiles");
                 actSavestateSRAMReloc->setCheckable(true);
                 connect(actSavestateSRAMReloc, &QAction::triggered, this, &MainWindow::onChangeSavestateSRAMReloc);
+
+                actSavestateAutoSave = submenu->addAction("Save state every 5 minutes");
+                actSavestateAutoSave->setCheckable(true);
+                actSavestateAutoSave->setEnabled(false);
+                connect(actSavestateAutoSave, &QAction::triggered, this,
+                        &MainWindow::onAutoSaveState);
             }
 
             menu->addSeparator();
@@ -723,7 +739,7 @@ MainWindow::MainWindow(int id, EmuInstance* inst, QWidget* parent) :
                 act->setEnabled(false);
         }
 
-        for (int i = 0; i < 9; i++)
+        for (int i = 0; i < 10; i++)
         {
             actSaveState[i]->setEnabled(false);
             actLoadState[i]->setEnabled(false);
@@ -1602,10 +1618,37 @@ void MainWindow::onSaveState()
     }
 }
 
+void MainWindow::autoSave() {
+
+  // static QAction* actSaveState = (QAction *)args;
+  actSaveState[9]->trigger();
+
+  return;
+}
+
+void MainWindow::onAutoSaveState() {
+
+  bool autosave = ((QAction *)sender())->isChecked();
+  if (autosave) {
+
+    autoSaveTimer = new QTimer(this);
+    connect(autoSaveTimer, &QTimer::timeout, this, &MainWindow::autoSave);
+
+    autoSaveTimer->start(5 * 60 * 1000); // 5 min, should be configurable
+    emuInstance->osdAddMessage(0xFFA0A0,
+                               "State autosave started every 5 minutes");
+
+  } else {
+    autoSaveTimer->stop();
+    emuInstance->osdAddMessage(0xFFA0A0, "State autosave stopped");
+  }
+  globalCfg.SetBool("Savestate.AutoSave", autosave);
+}
+
 void MainWindow::onLoadState()
 {
     int slot = ((QAction*)sender())->data().toInt();
-
+    
     QString filename;
     if (slot > 0)
     {
@@ -2246,36 +2289,42 @@ void MainWindow::onScreenEmphasisToggled()
     emit screenLayoutChange();
 }
 
-void MainWindow::onEmuStart()
-{
-    if (!hasMenu) return;
+void MainWindow::onEmuStart() {
+  if (!hasMenu)
+    return;
 
-    for (int i = 1; i < 9; i++)
-    {
-        actSaveState[i]->setEnabled(true);
-        actLoadState[i]->setEnabled(emuInstance->savestateExists(i));
-    }
-    actSaveState[0]->setEnabled(true);
-    actLoadState[0]->setEnabled(true);
-    actUndoStateLoad->setEnabled(false);
+  for (int i = 1; i < 10; i++) {
+    actSaveState[i]->setEnabled(true);
+    actLoadState[i]->setEnabled(emuInstance->savestateExists(i));
+  }
+  actSaveState[0]->setEnabled(true);
+  actLoadState[0]->setEnabled(true);
+  actUndoStateLoad->setEnabled(false);
 
-    actPause->setEnabled(true);
-    actPause->setChecked(false);
-    actReset->setEnabled(true);
-    actStop->setEnabled(true);
-    actFrameStep->setEnabled(true);
+  actPause->setEnabled(true);
+  actPause->setChecked(false);
+  actReset->setEnabled(true);
+  actStop->setEnabled(true);
+  actFrameStep->setEnabled(true);
 
-    actDateTime->setEnabled(false);
-    actPowerManagement->setEnabled(true);
+  actDateTime->setEnabled(false);
+  actPowerManagement->setEnabled(true);
 
-    actTitleManager->setEnabled(false);
+  actTitleManager->setEnabled(false);
+  actSavestateAutoSave->setEnabled(true);
+
+  bool autosave = globalCfg.GetBool("Savestate.AutoSave");
+
+  if (autosave) {
+    actSavestateAutoSave->trigger();
+  }
 }
 
 void MainWindow::onEmuStop()
 {
     if (!hasMenu) return;
 
-    for (int i = 0; i < 9; i++)
+    for (int i = 0; i < 10; i++)
     {
         actSaveState[i]->setEnabled(false);
         actLoadState[i]->setEnabled(false);

--- a/src/frontend/qt_sdl/Window.h
+++ b/src/frontend/qt_sdl/Window.h
@@ -168,6 +168,8 @@ private slots:
     void onInsertGBAAddon();
     void onEjectGBACart();
     void onSaveState();
+    void onAutoSaveState();
+    void autoSave();
     void onLoadState();
     void onUndoStateLoad();
     void onImportSavefile();
@@ -293,8 +295,8 @@ public:
     QList<QAction*> actInsertGBAAddon;
     QAction* actEjectGBACart;
     QAction* actImportSavefile;
-    QAction* actSaveState[9];
-    QAction* actLoadState[9];
+    QAction* actSaveState[10];
+    QAction* actLoadState[10];
     QAction* actUndoStateLoad;
     QAction* actOpenConfig;
     QAction* actQuit;
@@ -331,6 +333,7 @@ public:
     QAction* actPathSettings;
     QAction* actInterfaceSettings;
     QAction* actSavestateSRAMReloc;
+    QAction* actSavestateAutoSave;
     QAction* actScreenSize[4];
     QActionGroup* grpScreenRotation;
     QAction* actScreenRotation[screenRot_MAX];
@@ -353,6 +356,7 @@ public:
     QAction* actAudioSync;
 
     QAction* actAbout;
+    QTimer* autoSaveTimer;
 };
 
 #endif // WINDOW_H


### PR DESCRIPTION
I added a very basic auto save state functionality, adding a 10th slot for the save states and an option under "config > savestate settings" named "Save state every 5 minutes". 

The main drawback this has is that the timer is hardcoded to 5 minutes, but adding a configuration option should be relatively easy (

Original comment:
Added QAction* actSavestateAutoSave for config in GUI 
Added QTimer* autoSaveTimer for peroidic saving
MainWindow::onAutoSaveState() -> function that gets called when the auto savestate option is checked (can only be done when ROM is loaded but works between sessions) MainWindow::autoSave() -> performs a manual savestate on slot 9, called when the timer expires (5 min hardcoded as of right now)
Adjusted number of savestate slots from 9 to 10 to accomodate the auto one (actSaveState, actLoadState)
*Added AutoSave configuration option (*: not in original comment)