### PR TITLE
Fix sd controller code to handle more "edge cases" used in new sdmmc driver by profi200

### DIFF
--- a/src/DSi_SD.cpp
+++ b/src/DSi_SD.cpp
@@ -971,8 +971,7 @@ void DSi_MMCStorage::SendCMD(u8 cmd, u32 param)
             RWAddress <<= 9;
             BlockSize = 512;
         }
-        if (cmd == 18)
-            RWCommand = 18;
+        RWCommand = cmd;
         Host->SendResponse(CSR, true);
         RWAddress += ReadBlock(RWAddress);
         SetState(0x05);
@@ -987,8 +986,7 @@ void DSi_MMCStorage::SendCMD(u8 cmd, u32 param)
             RWAddress <<= 9;
             BlockSize = 512;
         }
-        if (cmd == 25)
-            RWCommand = 25;
+        RWCommand = cmd;
         Host->SendResponse(CSR, true);
         RWAddress += WriteBlock(RWAddress);
         SetState(0x04);
@@ -1050,10 +1048,12 @@ void DSi_MMCStorage::ContinueTransfer()
 
     switch (RWCommand)
     {
+    case 17:
     case 18:
         len = ReadBlock(RWAddress);
         break;
 
+    case 24:
     case 25:
         len = WriteBlock(RWAddress);
         break;

--- a/src/DSi_SD.cpp
+++ b/src/DSi_SD.cpp
@@ -839,7 +839,7 @@ void DSi_MMCStorage::Reset()
 
     memset(SSR, 0, 64);
 
-    BlockSize = 0;
+    BlockSize = 512;
     RWAddress = 0;
     RWCommand = 0;
 }


### PR DESCRIPTION
Set the default block size for the sdmmc controller to 512:
 * This is the assumption that profi's sdmmc driver makes, which follows the SD specs and properly behave on hardware, with this, his nand driver (and by extension the one used by blocksds) properly works
https://github.com/profi200/dsi_sdmmc/blob/7d725ee8c873f6ae79988f4aefa043f7e0ce5ec5/arm7/source/mmc/sdmmc.c#L352-L354
Handle single block read/write commands the same way as multi block commands to read/write data:
 * When they were added, they only checked for data availability at the moment of execution, thus making impossible to write data unless it was present in the FIFO beforehand