### PR TITLE
feat: create hotkey for reloading the most recent rom

### DIFF
--- a/src/frontend/qt_sdl/Config.cpp
+++ b/src/frontend/qt_sdl/Config.cpp
@@ -174,6 +174,7 @@ LegacyEntry LegacyFile[] =
     {"HKKey_GuitarGripRed",       0, "Keyboard.HK_GuitarGripRed", true},
     {"HKKey_GuitarGripYellow",    0, "Keyboard.HK_GuitarGripYellow", true},
     {"HKKey_GuitarGripBlue",      0, "Keyboard.HK_GuitarGripBlue", true},
+    {"HKKey_Reload",              0, "Keyboard.HK_Reload", true},
 
     {"HKJoy_Lid",                 0, "Joystick.HK_Lid", true},
     {"HKJoy_Mic",                 0, "Joystick.HK_Mic", true},
@@ -194,6 +195,7 @@ LegacyEntry LegacyFile[] =
     {"HKJoy_GuitarGripRed",       0, "Joystick.HK_GuitarGripRed", true},
     {"HKJoy_GuitarGripYellow",    0, "Joystick.HK_GuitarGripYellow", true},
     {"HKJoy_GuitarGripBlue",      0, "Joystick.HK_GuitarGripBlue", true},
+    {"HKJoy_Reload",              0, "Joystick.HK_Reload", true},
 
     {"JoystickID", 0, "JoystickID", true},
 

--- a/src/frontend/qt_sdl/EmuInstance.h
+++ b/src/frontend/qt_sdl/EmuInstance.h
@@ -55,6 +55,7 @@ enum
     HK_GuitarGripRed,
     HK_GuitarGripYellow,
     HK_GuitarGripBlue,
+    HK_Reload,
     HK_MAX
 };
 

--- a/src/frontend/qt_sdl/EmuInstanceInput.cpp
+++ b/src/frontend/qt_sdl/EmuInstanceInput.cpp
@@ -66,7 +66,8 @@ const char* EmuInstance::hotkeyNames[HK_MAX] =
     "HK_GuitarGripGreen",
     "HK_GuitarGripRed",
     "HK_GuitarGripYellow",
-    "HK_GuitarGripBlue"
+    "HK_GuitarGripBlue",
+	"HK_Reload"
 };
 
 std::shared_ptr<SDL_mutex> EmuInstance::joyMutexGlobal = nullptr;

--- a/src/frontend/qt_sdl/EmuThread.cpp
+++ b/src/frontend/qt_sdl/EmuThread.cpp
@@ -78,6 +78,7 @@ void EmuThread::attachWindow(MainWindow* window)
     connect(this, SIGNAL(autoScreenSizingChange(int)), window->panel, SLOT(onAutoScreenSizingChanged(int)));
     connect(this, SIGNAL(windowFullscreenToggle()), window, SLOT(onFullscreenToggled()));
     connect(this, SIGNAL(screenEmphasisToggle()), window, SLOT(onScreenEmphasisToggled()));
+    connect(this, SIGNAL(reloadMostRecentROM()), window, SLOT(onReloadMostRecentROM()));
 
     if (window->winHasMenu())
     {
@@ -96,6 +97,7 @@ void EmuThread::detachWindow(MainWindow* window)
     disconnect(this, SIGNAL(autoScreenSizingChange(int)), window->panel, SLOT(onAutoScreenSizingChanged(int)));
     disconnect(this, SIGNAL(windowFullscreenToggle()), window, SLOT(onFullscreenToggled()));
     disconnect(this, SIGNAL(screenEmphasisToggle()), window, SLOT(onScreenEmphasisToggled()));
+    disconnect(this, SIGNAL(reloadMostRecentROM()), window, SLOT(onReloadMostRecentROM()));
 
     if (window->winHasMenu())
     {
@@ -157,6 +159,8 @@ void EmuThread::run()
             MPInterface::Get().Process();
 
         emuInstance->inputProcess();
+
+        if (emuInstance->hotkeyPressed(HK_Reload)) emit reloadMostRecentROM();
 
         if (emuInstance->hotkeyPressed(HK_FrameLimitToggle)) emit windowLimitFPSChange();
 

--- a/src/frontend/qt_sdl/EmuThread.h
+++ b/src/frontend/qt_sdl/EmuThread.h
@@ -84,6 +84,7 @@ public:
         msg_ImportSavefile,
 
         msg_EnableCheats,
+		msg_EmuReload,
     };
 
     struct Message
@@ -157,6 +158,7 @@ signals:
     void autoScreenSizingChange(int sizing);
 
     void windowFullscreenToggle();
+	void reloadMostRecentROM();
 
     void swapScreensToggle();
     void screenEmphasisToggle();

--- a/src/frontend/qt_sdl/InputConfig/InputConfigDialog.h
+++ b/src/frontend/qt_sdl/InputConfig/InputConfigDialog.h
@@ -67,7 +67,8 @@ static constexpr std::initializer_list<int> hk_general =
     HK_SwapScreenEmphasis,
     HK_PowerButton,
     HK_VolumeUp,
-    HK_VolumeDown
+    HK_VolumeDown,
+	HK_Reload
 };
 
 static constexpr std::initializer_list<const char*> hk_general_labels =
@@ -87,7 +88,8 @@ static constexpr std::initializer_list<const char*> hk_general_labels =
     "Swap screen emphasis",
     "DSi Power button",
     "DSi Volume up",
-    "DSi Volume down"
+    "DSi Volume down",
+	"Reload current ROM"
 };
 
 static_assert(hk_general.size() == hk_general_labels.size());

--- a/src/frontend/qt_sdl/Window.cpp
+++ b/src/frontend/qt_sdl/Window.cpp
@@ -1495,6 +1495,32 @@ void MainWindow::onClickRecentFile()
     updateCartInserted(false);
 }
 
+void MainWindow::onReloadMostRecentROM()
+{
+	Log(LogLevel::Debug, "Reloading most recent ROM");
+    QString filename = globalCfg.GetArray("RecentROM").GetQString(0);
+
+    if (!verifySetup())
+        return;
+
+    const QStringList file = splitArchivePath(filename, true);
+    if (file.isEmpty())
+        return;
+
+    QString errorstr;
+    if (!emuThread->bootROM(file, errorstr))
+    {
+        QMessageBox::critical(this, "melonDS", errorstr);
+        return;
+    }
+
+    recentFileList.removeAll(filename);
+    recentFileList.prepend(filename);
+    updateRecentFilesMenu();
+
+    updateCartInserted(false);
+}
+
 void MainWindow::onBootFirmware()
 {
     if (!verifySetup())

--- a/src/frontend/qt_sdl/Window.h
+++ b/src/frontend/qt_sdl/Window.h
@@ -172,6 +172,7 @@ private slots:
     void onUndoStateLoad();
     void onImportSavefile();
     void onQuit();
+	void onReloadMostRecentROM();
 
     void onPause(bool checked);
     void onReset();


### PR DESCRIPTION
So, I was developing a homebrew game, but the inability to reload the whole ROM with a hotkey was making the iteration time slower that it could have been, so I implemented it. Since there was already an open issue about this, I didn't feel the need to ask for further instructions.

If any changes are needed, would be happy to make them

closes #1660 