### PR TITLE
don't hardcode a version suffix in the libwayland-egl dlopen

### DIFF
--- a/src/frontend/duckstation/gl/context_egl_wayland.cpp
+++ b/src/frontend/duckstation/gl/context_egl_wayland.cpp
@@ -4,7 +4,7 @@
 Log_SetChannel(ContextEGLWayland);
 
 namespace GL {
-static const char* WAYLAND_EGL_MODNAME = "libwayland-egl.so.1";
+static const char* WAYLAND_EGL_MODNAME = "libwayland-egl.so";
 
 ContextEGLWayland::ContextEGLWayland(const WindowInfo& wi) : ContextEGL(wi) {}
 ContextEGLWayland::~ContextEGLWayland()


### PR DESCRIPTION
This bug was discovered by thfr on the OpenBSD ports mailing list. Hardcoding this is not very portable. Shouldn't break other *NIX platforms like Darwin or Linux.