### PR TITLE
Add support for wider range of screen gaps

### DIFF
--- a/src/frontend/qt_sdl/Window.cpp
+++ b/src/frontend/qt_sdl/Window.cpp
@@ -520,7 +520,26 @@ MainWindow::MainWindow(int id, EmuInstance* inst, QWidget* parent) :
                     actScreenGap[i]->setData(QVariant(data));
                     actScreenGap[i]->setCheckable(true);
                 }
+                
+                submenu->addSeparator();
 
+                actScreenGap[6] = submenu->addAction(QString("Custom"));
+                actScreenGap[6]->setActionGroup(grpScreenGap);
+                actScreenGap[6]->setCheckable(true);
+
+                actScreenGapTextbox = new QLineEdit(QString("0"), submenu);
+                actScreenGapTextbox->setValidator(new QIntValidator(screengap[0], screengap[5]));
+                
+                auto customGapWidget = new QWidgetAction(submenu);
+                customGapWidget->setDefaultWidget(actScreenGapTextbox);
+                submenu->addAction(customGapWidget);
+                
+                // connect(actScreenGapTextbox, &QLineEdit::returnPressed, this, &MainWindow::onChangeScreenGap);
+                connect(actScreenGapTextbox, &QLineEdit::returnPressed, [&]() {
+                    actScreenGap[6]->setData(QVariant(actScreenGapTextbox->text().toInt()));
+                    onChangeScreenGap(actScreenGap[6]);
+                    submenu->close();
+                });
                 connect(grpScreenGap, &QActionGroup::triggered, this, &MainWindow::onChangeScreenGap);
             }
             {
@@ -753,12 +772,16 @@ MainWindow::MainWindow(int id, EmuInstance* inst, QWidget* parent) :
         actScreenRotation[windowCfg.GetInt("ScreenRotation")]->setChecked(true);
 
         int screenGap = windowCfg.GetInt("ScreenGap");
-        for (int i = 0; i < 6; i++)
+
+        if (!actScreenGap[6]->isChecked()) 
         {
-            if (actScreenGap[i]->data().toInt() == screenGap)
+            for (int i = 0; i < 6; i++)
             {
-                actScreenGap[i]->setChecked(true);
-                break;
+                if (actScreenGap[i]->data().toInt() == screenGap)
+                {
+                    actScreenGap[i]->setChecked(true);
+                    break;
+                }
             }
         }
 
@@ -2075,6 +2098,10 @@ void MainWindow::onChangeScreenRotation(QAction* act)
 void MainWindow::onChangeScreenGap(QAction* act)
 {
     int gap = act->data().toInt();
+    // if (actScreenGap[6]->isChecked())
+    // {
+    //     gap = actScreenGapTextbox->text().toInt();
+    // }
     windowCfg.SetInt("ScreenGap", gap);
 
     emit screenLayoutChange();

--- a/src/frontend/qt_sdl/Window.cpp
+++ b/src/frontend/qt_sdl/Window.cpp
@@ -526,19 +526,23 @@ MainWindow::MainWindow(int id, EmuInstance* inst, QWidget* parent) :
                 actScreenGap[6] = submenu->addAction(QString("Custom"));
                 actScreenGap[6]->setActionGroup(grpScreenGap);
                 actScreenGap[6]->setCheckable(true);
-
+                
                 actScreenGapTextbox = new QLineEdit(QString("0"), submenu);
                 actScreenGapTextbox->setValidator(new QIntValidator(screengap[0], screengap[5]));
-                
-                auto customGapWidget = new QWidgetAction(submenu);
+                actScreenGapTextbox->setFixedWidth(submenu->width());
+
+                QWidgetAction* customGapWidget = new QWidgetAction(submenu);
                 customGapWidget->setDefaultWidget(actScreenGapTextbox);
                 submenu->addAction(customGapWidget);
-                
-                // connect(actScreenGapTextbox, &QLineEdit::returnPressed, this, &MainWindow::onChangeScreenGap);
-                connect(actScreenGapTextbox, &QLineEdit::returnPressed, [&]() {
-                    actScreenGap[6]->setData(QVariant(actScreenGapTextbox->text().toInt()));
-                    onChangeScreenGap(actScreenGap[6]);
-                    submenu->close();
+
+                connect(actScreenGapTextbox, &QLineEdit::editingFinished, [&]()
+                {
+                    if (!actScreenGapTextbox->text().isEmpty()) 
+                    {
+                        const int customGap = actScreenGapTextbox->text().toInt();
+                        actScreenGap[6]->setData(QVariant(customGap));
+                        onChangeScreenGap(actScreenGap[6]);
+                    }
                 });
                 connect(grpScreenGap, &QActionGroup::triggered, this, &MainWindow::onChangeScreenGap);
             }
@@ -2098,10 +2102,6 @@ void MainWindow::onChangeScreenRotation(QAction* act)
 void MainWindow::onChangeScreenGap(QAction* act)
 {
     int gap = act->data().toInt();
-    // if (actScreenGap[6]->isChecked())
-    // {
-    //     gap = actScreenGapTextbox->text().toInt();
-    // }
     windowCfg.SetInt("ScreenGap", gap);
 
     emit screenLayoutChange();

--- a/src/frontend/qt_sdl/Window.cpp
+++ b/src/frontend/qt_sdl/Window.cpp
@@ -541,6 +541,7 @@ MainWindow::MainWindow(int id, EmuInstance* inst, QWidget* parent) :
                     {
                         const int customGap = actScreenGapTextbox->text().toInt();
                         actScreenGap[6]->setData(QVariant(customGap));
+                        actScreenGap[6]->setChecked(true);
                         onChangeScreenGap(actScreenGap[6]);
                     }
                 });
@@ -777,7 +778,7 @@ MainWindow::MainWindow(int id, EmuInstance* inst, QWidget* parent) :
 
         int screenGap = windowCfg.GetInt("ScreenGap");
 
-        if (!actScreenGap[6]->isChecked()) 
+        if (!actScreenGap[6]->isChecked())
         {
             for (int i = 0; i < 6; i++)
             {

--- a/src/frontend/qt_sdl/Window.h
+++ b/src/frontend/qt_sdl/Window.h
@@ -32,6 +32,8 @@
 #include <QMutex>
 #include <QScreen>
 #include <QCloseEvent>
+#include <QWidgetAction>
+#include <QLineEdit>
 
 #include "Screen.h"
 #include "Config.h"
@@ -335,7 +337,8 @@ public:
     QActionGroup* grpScreenRotation;
     QAction* actScreenRotation[screenRot_MAX];
     QActionGroup* grpScreenGap;
-    QAction* actScreenGap[6];
+    QAction* actScreenGap[7];
+    QLineEdit* actScreenGapTextbox;
     QActionGroup* grpScreenLayout;
     QAction* actScreenLayout[screenLayout_MAX];
     QAction* actScreenSwap;


### PR DESCRIPTION
Addresses https://github.com/melonDS-emu/melonDS/issues/2432

this PR give users the option to specify a custom gap value, ranging from 0 to 128 pixels

<img width="303" height="326" alt="image" src="https://github.com/user-attachments/assets/64215e23-b7f1-4633-bd77-cc9bb8b38c2d" />
