### PR TITLE
progress for netplay

### DIFF
--- a/src/frontend/qt_sdl/EmuInstance.h
+++ b/src/frontend/qt_sdl/EmuInstance.h
@@ -74,7 +74,8 @@ int getEventKeyVal(QKeyEvent* event);
 class EmuInstance
 {
 public:
-    EmuInstance(int inst);
+    EmuInstance(int inst, bool createMainWindow = true);
+
     ~EmuInstance();
 
     int getInstanceID() { return instanceID; }
@@ -135,6 +136,11 @@ public:
     void setJoystick(int id);
     int getJoystickID() { return joystickID; }
     SDL_Joystick* getJoystick() { return joystick; }
+    bool IsHeadless() { return headless; }
+    void RegisterNetplayDS(int id) { netplayID = id; }
+
+    void releaseScreen();
+    void touchScreen(int x, int y);
 
 private:
     static int lastSep(const std::string& path);
@@ -220,6 +226,9 @@ private:
     bool hotkeyReleased(int id) { return hotkeyRelease & (1<<id); }
 
     bool deleting;
+
+    bool headless;
+    int netplayID; // -1 is none, 0 >= is the netplay DS number
 
     int instanceID;
 
@@ -307,6 +316,9 @@ private:
     melonDS::u32 hotkeyPress, hotkeyRelease;
 
     melonDS::u32 inputMask;
+
+    bool isTouching;
+    melonDS::u16 touchX, touchY;
 
     friend class EmuThread;
     friend class MainWindow;

--- a/src/frontend/qt_sdl/EmuInstanceAudio.cpp
+++ b/src/frontend/qt_sdl/EmuInstanceAudio.cpp
@@ -270,6 +270,8 @@ void EmuInstance::micLoadWav(const std::string& name)
 
 void EmuInstance::micProcess()
 {
+    if (IsHeadless()) return;
+
     int type = micInputType;
     bool cmd = hotkeyDown(HK_Mic);
 
@@ -368,6 +370,8 @@ void EmuInstance::setupMicInputData()
 
 void EmuInstance::audioInit()
 {
+    if (IsHeadless()) return;
+
     audioVolume = localCfg.GetInt("Audio.Volume");
     audioDSiVolumeSync = localCfg.GetBool("Audio.DSiVolumeSync");
 

--- a/src/frontend/qt_sdl/EmuInstanceInput.cpp
+++ b/src/frontend/qt_sdl/EmuInstanceInput.cpp
@@ -62,6 +62,8 @@ const char* EmuInstance::hotkeyNames[HK_MAX] =
 
 void EmuInstance::inputInit()
 {
+    if (IsHeadless()) return;
+
     keyInputMask = 0xFFF;
     joyInputMask = 0xFFF;
     inputMask = 0xFFF;
@@ -312,6 +314,8 @@ bool EmuInstance::joystickButtonDown(int val)
 
 void EmuInstance::inputProcess()
 {
+    if (IsHeadless()) return;
+
     SDL_JoystickUpdate();
 
     if (joystick)
@@ -349,4 +353,16 @@ void EmuInstance::inputProcess()
     hotkeyPress = hotkeyMask & ~lastHotkeyMask;
     hotkeyRelease = lastHotkeyMask & ~hotkeyMask;
     lastHotkeyMask = hotkeyMask;
+}
+
+void EmuInstance::touchScreen(int x, int y)
+{
+    touchX = x;
+    touchY = y;
+    isTouching = true;
+}
+
+void EmuInstance::releaseScreen()
+{
+    isTouching = false;
 }

--- a/src/frontend/qt_sdl/NetplayDialog.h
+++ b/src/frontend/qt_sdl/NetplayDialog.h
@@ -98,6 +98,9 @@ protected:
     void timerEvent(QTimerEvent* event) override;
 
 private slots:
+    void on_btnStartGame_clicked();
+    void on_btnLeaveGame_clicked();
+    void on_spnInputBufferSize_valueChanged(int value);
     void done(int r);
 
     void doUpdatePlayerList();

--- a/src/frontend/qt_sdl/NetplayDialog.ui
+++ b/src/frontend/qt_sdl/NetplayDialog.ui
@@ -11,15 +11,62 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>NETPLAY SHITO</string>
+   <string>Netplay game - melonDS</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout_2">
+  <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <widget class="QLabel" name="lblStatus">
-     <property name="text">
-      <string>STATUS PLACEHOLDER</string>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <property name="leftMargin">
+      <number>0</number>
      </property>
-    </widget>
+     <item>
+      <widget class="QPushButton" name="btnLeaveGame">
+       <property name="text">
+        <string>Leave game</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="btnStartGame">
+       <property name="text">
+        <string>Start game</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="0">
+      <widget class="QLabel" name="lblInputBufferSize">
+       <property name="text">
+        <string>Input Buffer size:</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QSpinBox" name="spnInputBufferSize">
+       <property name="minimum">
+         <number>0</number>
+       </property>
+       <property name="maximum">
+        <number>60</number>
+       </property>
+       <property name="value">
+        <number>4</number>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Orientation::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+    </layout>
    </item>
    <item>
     <widget class="QTreeView" name="tvPlayerList"/>

--- a/src/frontend/qt_sdl/Screen.cpp
+++ b/src/frontend/qt_sdl/Screen.cpp
@@ -77,7 +77,7 @@ ScreenPanel::ScreenPanel(QWidget* parent) : QWidget(parent)
 
     osdEnabled = false;
     osdID = 1;
-    
+
     loadConfig();
     setFilter(mainWindow->getWindowConfig().GetBool("ScreenFilter"));
 }
@@ -91,7 +91,7 @@ ScreenPanel::~ScreenPanel()
 void ScreenPanel::loadConfig()
 {
     auto& cfg = mainWindow->getWindowConfig();
-    
+
     screenRotation = cfg.GetInt("ScreenRotation");
     screenGap = cfg.GetInt("ScreenGap");
     screenLayout = cfg.GetInt("ScreenLayout");
@@ -231,7 +231,7 @@ void ScreenPanel::mousePressEvent(QMouseEvent* event)
     {
         touching = true;
         assert(emuInstance->getNDS() != nullptr);
-        emuInstance->getNDS()->TouchScreen(x, y);
+        emuInstance->touchScreen(x, y);
     }
 }
 
@@ -244,7 +244,7 @@ void ScreenPanel::mouseReleaseEvent(QMouseEvent* event)
     {
         touching = false;
         assert(emuInstance->getNDS() != nullptr);
-        emuInstance->getNDS()->ReleaseScreen();
+        emuInstance->releaseScreen();
     }
 }
 
@@ -263,7 +263,7 @@ void ScreenPanel::mouseMoveEvent(QMouseEvent* event)
     if (layout.GetTouchCoords(x, y, true))
     {
         assert(emuInstance->getNDS() != nullptr);
-        emuInstance->getNDS()->TouchScreen(x, y);
+        emuInstance->touchScreen(x, y);
     }
 }
 
@@ -288,7 +288,7 @@ void ScreenPanel::tabletEvent(QTabletEvent* event)
             {
                 touching = true;
                 assert(emuInstance->getNDS() != nullptr);
-                emuInstance->getNDS()->TouchScreen(x, y);
+                emuInstance->touchScreen(x, y);
             }
         }
         break;
@@ -296,7 +296,7 @@ void ScreenPanel::tabletEvent(QTabletEvent* event)
         if (touching)
         {
             assert(emuInstance->getNDS() != nullptr);
-            emuInstance->getNDS()->ReleaseScreen();
+            emuInstance->releaseScreen();
             touching = false;
         }
         break;
@@ -334,7 +334,7 @@ void ScreenPanel::touchEvent(QTouchEvent* event)
             {
                 touching = true;
                 assert(emuInstance->getNDS() != nullptr);
-                emuInstance->getNDS()->TouchScreen(x, y);
+                emuInstance->touchScreen(x, y);
             }
         }
         break;
@@ -342,7 +342,7 @@ void ScreenPanel::touchEvent(QTouchEvent* event)
         if (touching)
         {
             assert(emuInstance->getNDS() != nullptr);
-            emuInstance->getNDS()->ReleaseScreen();
+            emuInstance->releaseScreen();
             touching = false;
         }
         break;

--- a/src/net/Netplay.h
+++ b/src/net/Netplay.h
@@ -26,9 +26,12 @@
 #include "types.h"
 #include "Platform.h"
 #include "LocalMP.h"
+#include "NDS.h"
 
 namespace melonDS
 {
+
+extern std::function<void()> OnStartEmulatorThread;
 
 // since netplay relies on local MP comm locally,
 // we extend the LocalMP class to reuse its functionality
@@ -51,26 +54,45 @@ public:
         Player_Disconnected,    // player disconnected
     };
 
+    enum InputDelayMode {
+        InputDelayMode_Fair, // Attempt to make everyone's input delay the same
+        InputDelayMode_Golf, // Make one specific player have the least delay
+    };
+
     struct Player
     {
         int ID;
         char Name[32];
-        int Status; // 0=no player 1=normal 2=host 3=connecting
+        PlayerStatus Status;
         u32 Address;
+        u16 Port;
         bool IsLocalPlayer;
+        u32 Ping;
+        u32 LastCompletedFrame;
     };
+
+    InputDelayMode NetworkMode = InputDelayMode_Fair;
+    int GolfModePlayerID;
+    bool StallFrame;
 
     bool StartHost(const char* player, int port);
     bool StartClient(const char* player, const char* host, int port);
     void EndSession();
+
+    void SetInputBufferSize(int value);
 
     void StartGame();
 
     std::vector<Player> GetPlayerList();
     int GetNumPlayers() { return NumPlayers; }
     int GetMaxPlayers() { return MaxPlayers; }
+    bool GetHostStatus() { return IsHost; }
+    Player GetMyPlayer() { return MyPlayer; }
 
     void Process(int inst) override;
+
+    void ProcessInput(int netplayID, NDS *nds, u32 inputMask, bool isTouching, u16 touchX, u16 touchY);
+    void ApplyInput(int netplayID, NDS *nds);
 
 private:
     bool Inited;
@@ -87,13 +109,21 @@ private:
 
     Player MyPlayer;
     u32 HostAddress;
-    bool Lag;
+    bool ReceivedInputThisFrame[16];
 
     int NumMirrorClients;
 
     // maps to convert between player IDs and local instance IDs
     int PlayerToInstance[16];
     int InstanceToPlayer[16];
+    std::unordered_map<u16, u8> PortToPlayerIndex;
+
+    struct NetworkSettings
+    {
+        u32 Delay;
+    };
+
+    NetworkSettings Settings;
 
     struct InputFrame
     {
@@ -103,12 +133,41 @@ private:
         u32 TouchX, TouchY;
     };
 
-    std::queue<InputFrame> InputQueue;
+#pragma pack(push, 1)
+    struct InputReport {
+        u8 stallFrame;
+        u32 frameIndex;
+        u32 lastCompleteFrame; // The last frame index that we have everyone's inputs for
+    };
+#pragma pack(pop)
+
+    std::map<u32, InputFrame> InputHistory[16];
+
+    struct WaitingFrame
+    {
+        bool Active;
+        u32 FrameNum;
+        Savestate *SavestateBuffer[16];
+    };
+    WaitingFrame PendingFrame;
+
+    void SyncClients();
+
+    void SendNetworkSettings();
 
     void StartLocal();
     void ProcessHost();
     void ProcessClient();
     void ProcessFrame(int inst);
+
+    int GetPlayerIndexFromPort(u16 port);
+    InputFrame *GetInputFrame(u16 playerID, u32 frameNum);
+
+
+    void ReceiveInputs(ENetEvent &event);
+
+    bool SendBlobToMirrorClients(int type, u32 len, u8* data);
+    void RecvBlobFromMirrorHost(ENetPeer* peer, ENetPacket* pkt);
 };
 
 }


### PR DESCRIPTION
Hi, I wanted to see netplay working on a DS emulator, so I thought I'd try to build upon the efforts that have been made for melonds.
There is no functioning version available right now so this is only of interest to other devs, sorry!

I'm aiming for the same system that was proposed previously by other folks, which I believe is like this:
Each computer running melonDS emulates every DS that's connected to deal with the strict timing requirements of DS local multiplayer. Then, some sort of deterministic netplay would be implemented, streaming inputs across the network rather than the game's packets. 

So far this is just re-implementing the mirror prototype, to focus on perfecting the input syncing. 
I've hacked together a lot of this, and so I apologise for the mess I have made.
It uses an input history, where we send a short history of the last few frames of input over the network. Only after we've confirmed that every player on the network has seen that input do we stop sending it in each packet.

I'm a little sceptical on whether to use save states or lag to deal with inputs not arriving on time (there is an option to change the input delay of course), but I tried to use save states so far; if we don't get an input for a frame from any player, we save a state and run that frame anyway to avoid lag.
If we get the frame later, load the save state and re-apply all the inputs up to the present frame.

I've never made a netplay system of this sort before, and this is also my first time working on an emulator project.
So please, I'd love feedback!