### PR TITLE
Added '--config/-c' flag. Can be used to pass the path of a .toml config file.

### DIFF
--- a/src/frontend/qt_sdl/CLI.cpp
+++ b/src/frontend/qt_sdl/CLI.cpp
@@ -42,6 +42,7 @@ CommandLineOptions* ManageArgs(QApplication& melon)
     parser.addPositionalArgument("gba", "GBA ROM (or an archive file which contains it) to load into Slot-2");
 
     parser.addOption(QCommandLineOption({"b", "boot"}, "Whether to boot firmware on startup. Defaults to \"auto\" (boot if NDS rom given)", "auto/always/never", "auto"));
+    parser.addOption(QCommandLineOption({"c", "config"}, "toml config file used for session", "default"));
     parser.addOption(QCommandLineOption({"f", "fullscreen"}, "Start melonDS in fullscreen mode"));
 
 #ifdef ARCHIVE_SUPPORT_ENABLED
@@ -71,7 +72,7 @@ CommandLineOptions* ManageArgs(QApplication& melon)
     QString bootMode = parser.value("boot");
     if (bootMode == "auto")
     {
-        options->boot = !posargs.empty();
+        options->boot = (options->dsRomPath || options->gbaRomPath);
     }
     else if (bootMode == "always")
     {
@@ -85,6 +86,14 @@ CommandLineOptions* ManageArgs(QApplication& melon)
     {
         Log(LogLevel::Error, "ERROR: -b/--boot only accepts auto/always/never as arguments\n");
         exit(1);
+    }
+
+    if (parser.value("config") == "default")
+    { options->configPath = std::nullopt; }
+    else
+    {
+        options->configPath = parser.value("config");
+        // options->configPath = "C:\\User\\Dagai\\Desktop\\ds-emu\\config.toml";
     }
 
 #ifdef ARCHIVE_SUPPORT_ENABLED

--- a/src/frontend/qt_sdl/CLI.h
+++ b/src/frontend/qt_sdl/CLI.h
@@ -32,6 +32,7 @@ struct CommandLineOptions
     std::optional<QString> dsRomArchivePath;
     std::optional<QString> gbaRomPath;
     std::optional<QString> gbaRomArchivePath;
+    std::optional<QString> configPath;
     bool fullscreen;
     bool boot;
 };

--- a/src/frontend/qt_sdl/Config.cpp
+++ b/src/frontend/qt_sdl/Config.cpp
@@ -40,6 +40,7 @@ using namespace melonDS;
 
 
 const char* kConfigFile = "melonDS.toml";
+QString qConfigPath;
 
 const char* kLegacyConfigFile = "melonDS.ini";
 const char* kLegacyUniqueConfigFile = "melonDS.%d.ini";
@@ -782,9 +783,17 @@ bool LoadLegacy()
     return true;
 }
 
+void SetCfgPath(std::optional<QString>const& newpath)
+{
+    if(newpath == std::nullopt)
+    { qConfigPath = QString::fromStdString(Platform::GetLocalFilePath(kConfigFile)); return; }
+
+    qConfigPath = *newpath;
+}
+
 bool Load()
 {
-    auto cfgpath = Platform::GetLocalFilePath(kConfigFile);
+    const auto cfgpath = qConfigPath.toStdString();
 
     if (!Platform::CheckFileWritable(cfgpath))
         return false;
@@ -808,7 +817,8 @@ bool Load()
 
 void Save()
 {
-    auto cfgpath = Platform::GetLocalFilePath(kConfigFile);
+    const auto cfgpath = qConfigPath.toStdString();
+
     if (!Platform::CheckFileWritable(cfgpath))
         return;
 

--- a/src/frontend/qt_sdl/Config.h
+++ b/src/frontend/qt_sdl/Config.h
@@ -19,6 +19,7 @@
 #ifndef CONFIG_H
 #define CONFIG_H
 
+#include <optional>
 #include <variant>
 #include <string>
 #include <QString>
@@ -129,7 +130,7 @@ private:
     template<typename T> T FindDefault(const std::string& path, T def, DefaultList<T> list);
 };
 
-
+void SetCfgPath(std::optional<QString>const& newpath);
 bool Load();
 void Save();
 

--- a/src/frontend/qt_sdl/main.cpp
+++ b/src/frontend/qt_sdl/main.cpp
@@ -21,6 +21,7 @@
 #include <stdio.h>
 #include <string.h>
 
+#include <iostream>
 #include <optional>
 #include <string>
 
@@ -295,6 +296,10 @@ int main(int argc, char** argv)
     pathInit();
 
     CLI::CommandLineOptions* options = CLI::ManageArgs(melon);
+
+    // Now Config::SetCfgPath needs to be called before any Save/Load functions are called
+    // can be called with std::optional::nullopt passed in so that the default path can be set like before
+    Config::SetCfgPath(*options->configPath);
 
     // http://stackoverflow.com/questions/14543333/joystick-wont-work-using-sdl
     SDL_SetHint(SDL_HINT_JOYSTICK_ALLOW_BACKGROUND_EVENTS, "1");


### PR DESCRIPTION

I wanted to be able to switch between config files for different games. I ran the exes using a shell script, so I made it so that I can run one game at start with horizontal view, another with single screen, etc...