### PR TITLE
fix scfg_ext_7 handling with direct boot

### DIFF
--- a/src/DSi.cpp
+++ b/src/DSi.cpp
@@ -732,7 +732,7 @@ void DSi::SetupDirectBoot()
     else
     {
         SCFG_EXT[0] = 0x8307F100;
-        SCFG_EXT[1] = 0x93FBFB06 | (header.DSiPermissions[1] & 0x80040407);
+        SCFG_EXT[1] = 0x13FBFB00 | (header.DSiPermissions[1] & 0x80040407);
     }
 
     ARM9.CP15Write(0x100, 0x00056078);

--- a/src/DSi.cpp
+++ b/src/DSi.cpp
@@ -732,7 +732,7 @@ void DSi::SetupDirectBoot()
     else
     {
         SCFG_EXT[0] = 0x8307F100;
-        SCFG_EXT[1] = 0x93FBFB06;
+        SCFG_EXT[1] = 0x93FBFB06 | (header.DSiPermissions[1] & 0x80040407);
     }
 
     ARM9.CP15Write(0x100, 0x00056078);

--- a/src/DSi.cpp
+++ b/src/DSi.cpp
@@ -733,6 +733,15 @@ void DSi::SetupDirectBoot()
     {
         SCFG_EXT[0] = 0x8307F100;
         SCFG_EXT[1] = 0x13FBFB00 | (header.DSiPermissions[1] & 0x80040407);
+
+        ARM7Write32(0x380FFC4, SCFG_EXT[1] | 0x80000000);
+        /* read SCFG_OP */
+        u32 bios_flags = 0 & 0xFF;
+        bios_flags |= (SCFG_BIOS & 3) << 2;
+        bios_flags |= (SCFG_BIOS >> 8 & 6) << 4;
+        /* read SCFG_WL */
+        bios_flags |= (0 & 1) << 7;
+        ARM7Write8(0x380FFC8, bios_flags);
     }
 
     ARM9.CP15Write(0x100, 0x00056078);


### PR DESCRIPTION
With the scfg permissions update, melonds changed the default scfg flags when direct booting, but as default it disabled access to the scmc registers, breaking direct booting homebrews and software that required nand access.
Properly handle this case by using the appropriate dsi header field in the rom containing the arm7 scfg settings (as stated on gbatek, only bit 0,1,2,10,18 and 31 are to be considered).