### PR TITLE
Screen layout improvements

### DIFF
--- a/src/frontend/qt_sdl/Config.cpp
+++ b/src/frontend/qt_sdl/Config.cpp
@@ -85,6 +85,7 @@ RangeList IntRanges =
     {"Mic.InputType", {0, micInputType_MAX-1}},
     {"Instance*.Window*.ScreenRotation", {0, screenRot_MAX-1}},
     {"Instance*.Window*.ScreenGap", {0, 500}},
+    {"Instance*.Window*.HybridRatio", {0, 960}},
     {"Instance*.Window*.ScreenLayout", {0, screenLayout_MAX-1}},
     {"Instance*.Window*.ScreenSizing", {0, screenSizing_MAX-1}},
     {"Instance*.Window*.ScreenAspectTop", {0, AspectRatiosNum-1}},

--- a/src/frontend/qt_sdl/Config.cpp
+++ b/src/frontend/qt_sdl/Config.cpp
@@ -52,6 +52,7 @@ DefaultList<int> DefaultInts =
     {"Instance*.Joystick", -1},
     {"Instance*.Window*.Width", 256},
     {"Instance*.Window*.Height", 384},
+    {"Instance*.Window*.HybridRatio", 0},
     {"Screen.VSyncInterval", 1},
     {"3D.Renderer", renderer3D_Software},
     {"3D.GL.ScaleFactor", 1},

--- a/src/frontend/qt_sdl/Screen.cpp
+++ b/src/frontend/qt_sdl/Screen.cpp
@@ -122,13 +122,16 @@ void ScreenPanel::loadConfig()
     auto& cfg = mainWindow->getWindowConfig();
     
     screenRotation = cfg.GetInt("ScreenRotation");
-    screenGap = cfg.GetInt("ScreenGap");
     screenLayout = cfg.GetInt("ScreenLayout");
+    screenGap = cfg.GetInt("ScreenGap");
+	hybridRatio = cfg.GetInt("HybridRatio");
     screenSwap = cfg.GetBool("ScreenSwap");
     screenSizing = cfg.GetInt("ScreenSizing");
     integerScaling = cfg.GetBool("IntegerScaling");
     screenAspectTop = cfg.GetInt("ScreenAspectTop");
     screenAspectBot = cfg.GetInt("ScreenAspectBot");
+
+	currentScreenGap = screenLayout != screenLayout_Hybrid ? screenGap : hybridRatio;
 }
 
 void ScreenPanel::setFilter(bool filter)
@@ -172,7 +175,7 @@ void ScreenPanel::setupScreenLayout()
                 static_cast<ScreenLayoutType>(screenLayout),
                 static_cast<ScreenRotation>(screenRotation),
                 static_cast<ScreenSizing>(sizing),
-                screenGap,
+                currentScreenGap,
                 integerScaling != 0,
                 screenSwap != 0,
                 aspectTop,
@@ -187,7 +190,7 @@ QSize ScreenPanel::screenGetMinSize(int factor = 1)
 {
     bool isHori = (screenRotation == screenRot_90Deg
         || screenRotation == screenRot_270Deg);
-    int gap = screenGap * factor;
+    int gap = currentScreenGap * factor;
 
     int w = 256 * factor;
     int h = 192 * factor;

--- a/src/frontend/qt_sdl/Screen.cpp
+++ b/src/frontend/qt_sdl/Screen.cpp
@@ -124,7 +124,7 @@ void ScreenPanel::loadConfig()
     screenRotation = cfg.GetInt("ScreenRotation");
     screenLayout = cfg.GetInt("ScreenLayout");
     screenGap = cfg.GetInt("ScreenGap");
-    hybridRatio = cfg.GetInt("HybridRatio");
+    HybridRatio = cfg.GetInt("HybridRatio");
     screenSwap = cfg.GetBool("ScreenSwap");
     screenSizing = cfg.GetInt("ScreenSizing");
     integerScaling = cfg.GetBool("IntegerScaling");
@@ -133,7 +133,7 @@ void ScreenPanel::loadConfig()
 
     // Hybrid ratios are represented by layout gap values, but use a separate
     // setting so changing the hybrid ratio does not alter the regular gap.
-    currentScreenGap = screenLayout != screenLayout_Hybrid ? screenGap : hybridRatio;
+    CurrentScreenGap = screenLayout != screenLayout_Hybrid ? screenGap : HybridRatio;
 }
 
 void ScreenPanel::setFilter(bool filter)
@@ -196,15 +196,15 @@ void ScreenPanel::setupScreenLayout()
             {
                 // Screens are stacked along the window's Y axis.
                 windowScreenAspect = rotated
-                    ? (192.f / windowAspect - currentScreenGap) / 512.f
-                    : windowAspect * (384.f + currentScreenGap) / 256.f;
+                    ? (192.f / windowAspect - CurrentScreenGap) / 512.f
+                    : windowAspect * (384.f + CurrentScreenGap) / 256.f;
             }
             else
             {
                 // Screens are arranged along the window's X axis.
                 windowScreenAspect = rotated
-                    ? (384.f + currentScreenGap) / (256.f * windowAspect)
-                    : (windowAspect * 192.f - currentScreenGap) / 512.f;
+                    ? (384.f + CurrentScreenGap) / (256.f * windowAspect)
+                    : (windowAspect * 192.f - CurrentScreenGap) / 512.f;
             }
         }
 
@@ -222,7 +222,7 @@ void ScreenPanel::setupScreenLayout()
                 static_cast<ScreenLayoutType>(screenLayout),
                 static_cast<ScreenRotation>(screenRotation),
                 static_cast<ScreenSizing>(sizing),
-                currentScreenGap,
+                CurrentScreenGap,
                 integerScaling != 0,
                 screenSwap != 0,
                 aspectTop,
@@ -237,7 +237,7 @@ QSize ScreenPanel::screenGetMinSize(int factor = 1)
 {
     bool isHori = (screenRotation == screenRot_90Deg
         || screenRotation == screenRot_270Deg);
-    int gap = currentScreenGap * factor;
+    int gap = CurrentScreenGap * factor;
 
     int w = 256 * factor;
     int h = 192 * factor;

--- a/src/frontend/qt_sdl/Screen.cpp
+++ b/src/frontend/qt_sdl/Screen.cpp
@@ -124,14 +124,16 @@ void ScreenPanel::loadConfig()
     screenRotation = cfg.GetInt("ScreenRotation");
     screenLayout = cfg.GetInt("ScreenLayout");
     screenGap = cfg.GetInt("ScreenGap");
-	hybridRatio = cfg.GetInt("HybridRatio");
+    hybridRatio = cfg.GetInt("HybridRatio");
     screenSwap = cfg.GetBool("ScreenSwap");
     screenSizing = cfg.GetInt("ScreenSizing");
     integerScaling = cfg.GetBool("IntegerScaling");
     screenAspectTop = cfg.GetInt("ScreenAspectTop");
     screenAspectBot = cfg.GetInt("ScreenAspectBot");
 
-	currentScreenGap = screenLayout != screenLayout_Hybrid ? screenGap : hybridRatio;
+    // Hybrid ratios are represented by layout gap values, but use a separate
+    // setting so changing the hybrid ratio does not alter the regular gap.
+    currentScreenGap = screenLayout != screenLayout_Hybrid ? screenGap : hybridRatio;
 }
 
 void ScreenPanel::setFilter(bool filter)
@@ -165,11 +167,56 @@ void ScreenPanel::setupScreenLayout()
             aspectBot = ratio.ratio;
     }
 
-    if (aspectTop == 0)
-        aspectTop = ((float) w / h) / (4.f / 3.f);
+    // A zero aspect multiplier represents the "window" option. Calculate the
+    // multiplier from the area available to each screen, rather than from the
+    // entire panel, so a two-screen layout can fill both panel dimensions.
+    if (aspectTop == 0 || aspectBot == 0)
+    {
+        const float windowAspect = static_cast<float>(w) / h;
+        const bool singleScreen = sizing == screenSizing_TopOnly
+            || sizing == screenSizing_BotOnly;
+        const bool rotated = screenRotation == screenRot_90Deg
+            || screenRotation == screenRot_270Deg;
 
-    if (aspectBot == 0)
-        aspectBot = ((float) w / h) / (4.f / 3.f);
+        float windowScreenAspect;
+        if (singleScreen)
+        {
+            // The aspect multiplier is applied before rotation.
+            windowScreenAspect = rotated
+                ? 192.f / (256.f * windowAspect)
+                : windowAspect * 192.f / 256.f;
+        }
+        else
+        {
+            const int layoutDirection = screenLayout == screenLayout_Natural
+                ? screenRotation % 2
+                : screenLayout - 1;
+
+            if (layoutDirection == 0)
+            {
+                // Screens are stacked along the window's Y axis.
+                windowScreenAspect = rotated
+                    ? (192.f / windowAspect - currentScreenGap) / 512.f
+                    : windowAspect * (384.f + currentScreenGap) / 256.f;
+            }
+            else
+            {
+                // Screens are arranged along the window's X axis.
+                windowScreenAspect = rotated
+                    ? (384.f + currentScreenGap) / (256.f * windowAspect)
+                    : (windowAspect * 192.f - currentScreenGap) / 512.f;
+            }
+        }
+
+        // Very large gaps or unusually narrow windows can otherwise produce
+        // a zero or negative width.
+        windowScreenAspect = std::max(windowScreenAspect, 1.f / 256.f);
+
+        if (aspectTop == 0)
+            aspectTop = windowScreenAspect;
+        if (aspectBot == 0)
+            aspectBot = windowScreenAspect;
+    }
 
     layout.Setup(w, h,
                 static_cast<ScreenLayoutType>(screenLayout),

--- a/src/frontend/qt_sdl/Screen.h
+++ b/src/frontend/qt_sdl/Screen.h
@@ -84,11 +84,14 @@ protected:
 
     int screenRotation;
     int screenGap;
+	int hybridRatio;
     int screenLayout;
     bool screenSwap;
     int screenSizing;
     bool integerScaling;
     int screenAspectTop, screenAspectBot;
+
+	int currentScreenGap;
 
     int autoScreenSizing;
 

--- a/src/frontend/qt_sdl/Screen.h
+++ b/src/frontend/qt_sdl/Screen.h
@@ -84,14 +84,14 @@ protected:
 
     int screenRotation;
     int screenGap;
-    int hybridRatio;
+    int HybridRatio;
     int screenLayout;
     bool screenSwap;
     int screenSizing;
     bool integerScaling;
     int screenAspectTop, screenAspectBot;
 
-    int currentScreenGap;
+    int CurrentScreenGap;
 
     int autoScreenSizing;
 

--- a/src/frontend/qt_sdl/Screen.h
+++ b/src/frontend/qt_sdl/Screen.h
@@ -84,14 +84,14 @@ protected:
 
     int screenRotation;
     int screenGap;
-	int hybridRatio;
+    int hybridRatio;
     int screenLayout;
     bool screenSwap;
     int screenSizing;
     bool integerScaling;
     int screenAspectTop, screenAspectBot;
 
-	int currentScreenGap;
+    int currentScreenGap;
 
     int autoScreenSizing;
 

--- a/src/frontend/qt_sdl/Window.cpp
+++ b/src/frontend/qt_sdl/Window.cpp
@@ -483,6 +483,24 @@ MainWindow::MainWindow(int id, EmuInstance* inst, QWidget* parent) :
                 connect(grpScreenGap, &QActionGroup::triggered, this, &MainWindow::onChangeScreenGap);
             }
             {
+                QMenu * submenu = menu->addMenu("Hybrid ratio");
+                grpHybridRatio = new QActionGroup(submenu);
+
+				const char *hybridRatio[] = {"2:1", "3:1", "4:1", "5:1", "6:1", "7:1", "5:2", "7:3", "9:4"};
+                const int screengap[] = {0, 192, 384, 576, 768, 960, 96, 64, 48};
+
+                for (int i = 0; i < 9; i++)
+                {
+                    int screenGapData = screengap[i];
+                    actHybridRatio[i] = submenu->addAction(QString(hybridRatio[i]));
+                    actHybridRatio[i]->setActionGroup(grpHybridRatio);
+                    actHybridRatio[i]->setData(QVariant(screenGapData));
+                    actHybridRatio[i]->setCheckable(true);
+                }
+
+                connect(grpHybridRatio, &QActionGroup::triggered, this, &MainWindow::onChangeHybridRatio);
+            }
+            {
                 QMenu * submenu = menu->addMenu("Screen layout");
                 grpScreenLayout = new QActionGroup(submenu);
 
@@ -707,6 +725,16 @@ MainWindow::MainWindow(int id, EmuInstance* inst, QWidget* parent) :
             if (actScreenGap[i]->data().toInt() == screenGap)
             {
                 actScreenGap[i]->setChecked(true);
+                break;
+            }
+        }
+
+        int hybridRatio = windowCfg.GetInt("HybridRatio");
+        for (int i = 0; i < 9; i++)
+        {
+            if (actHybridRatio[i]->data() == hybridRatio)
+            {
+                actHybridRatio[i]->setChecked(true);
                 break;
             }
         }
@@ -2023,6 +2051,14 @@ void MainWindow::onChangeScreenGap(QAction* act)
 {
     int gap = act->data().toInt();
     windowCfg.SetInt("ScreenGap", gap);
+
+    emit screenLayoutChange();
+}
+
+void MainWindow::onChangeHybridRatio(QAction* act)
+{
+    int gap = act->data().toInt();
+    windowCfg.SetInt("HybridRatio", gap);
 
     emit screenLayoutChange();
 }

--- a/src/frontend/qt_sdl/Window.cpp
+++ b/src/frontend/qt_sdl/Window.cpp
@@ -486,7 +486,10 @@ MainWindow::MainWindow(int id, EmuInstance* inst, QWidget* parent) :
                 QMenu * submenu = menu->addMenu("Hybrid ratio");
                 grpHybridRatio = new QActionGroup(submenu);
 
-				const char *hybridRatio[] = {"2:1", "3:1", "4:1", "5:1", "6:1", "7:1", "5:2", "7:3", "9:4"};
+                // ScreenLayout uses the gap between the two smaller screens
+                // to determine the scale of the large hybrid screen. These
+                // gap values produce the corresponding display ratios.
+                const char *hybridRatio[] = {"2:1", "3:1", "4:1", "5:1", "6:1", "7:1", "5:2", "7:3", "9:4"};
                 const int screengap[] = {0, 192, 384, 576, 768, 960, 96, 64, 48};
 
                 for (int i = 0; i < 9; i++)
@@ -732,7 +735,7 @@ MainWindow::MainWindow(int id, EmuInstance* inst, QWidget* parent) :
         int hybridRatio = windowCfg.GetInt("HybridRatio");
         for (int i = 0; i < 9; i++)
         {
-            if (actHybridRatio[i]->data() == hybridRatio)
+            if (actHybridRatio[i]->data().toInt() == hybridRatio)
             {
                 actHybridRatio[i]->setChecked(true);
                 break;

--- a/src/frontend/qt_sdl/Window.cpp
+++ b/src/frontend/qt_sdl/Window.cpp
@@ -484,24 +484,24 @@ MainWindow::MainWindow(int id, EmuInstance* inst, QWidget* parent) :
             }
             {
                 QMenu * submenu = menu->addMenu("Hybrid ratio");
-                grpHybridRatio = new QActionGroup(submenu);
+                GrpHybridRatio = new QActionGroup(submenu);
 
                 // ScreenLayout uses the gap between the two smaller screens
                 // to determine the scale of the large hybrid screen. These
                 // gap values produce the corresponding display ratios.
-                const char *hybridRatio[] = {"2:1", "3:1", "4:1", "5:1", "6:1", "7:1", "5:2", "7:3", "9:4"};
-                const int screengap[] = {0, 192, 384, 576, 768, 960, 96, 64, 48};
+                const char *hybridRatios[] = {"2:1", "3:1", "4:1", "5:1", "6:1", "7:1", "5:2", "7:3", "9:4"};
+                const int screenGaps[] = {0, 192, 384, 576, 768, 960, 96, 64, 48};
 
                 for (int i = 0; i < 9; i++)
                 {
-                    int screenGapData = screengap[i];
-                    actHybridRatio[i] = submenu->addAction(QString(hybridRatio[i]));
-                    actHybridRatio[i]->setActionGroup(grpHybridRatio);
-                    actHybridRatio[i]->setData(QVariant(screenGapData));
-                    actHybridRatio[i]->setCheckable(true);
+                    int screenGapData = screenGaps[i];
+                    ActHybridRatio[i] = submenu->addAction(QString(hybridRatios[i]));
+                    ActHybridRatio[i]->setActionGroup(GrpHybridRatio);
+                    ActHybridRatio[i]->setData(QVariant(screenGapData));
+                    ActHybridRatio[i]->setCheckable(true);
                 }
 
-                connect(grpHybridRatio, &QActionGroup::triggered, this, &MainWindow::onChangeHybridRatio);
+                connect(GrpHybridRatio, &QActionGroup::triggered, this, &MainWindow::OnChangeHybridRatio);
             }
             {
                 QMenu * submenu = menu->addMenu("Screen layout");
@@ -735,9 +735,9 @@ MainWindow::MainWindow(int id, EmuInstance* inst, QWidget* parent) :
         int hybridRatio = windowCfg.GetInt("HybridRatio");
         for (int i = 0; i < 9; i++)
         {
-            if (actHybridRatio[i]->data().toInt() == hybridRatio)
+            if (ActHybridRatio[i]->data().toInt() == hybridRatio)
             {
-                actHybridRatio[i]->setChecked(true);
+                ActHybridRatio[i]->setChecked(true);
                 break;
             }
         }
@@ -2058,7 +2058,7 @@ void MainWindow::onChangeScreenGap(QAction* act)
     emit screenLayoutChange();
 }
 
-void MainWindow::onChangeHybridRatio(QAction* act)
+void MainWindow::OnChangeHybridRatio(QAction* act)
 {
     int gap = act->data().toInt();
     windowCfg.SetInt("HybridRatio", gap);

--- a/src/frontend/qt_sdl/Window.h
+++ b/src/frontend/qt_sdl/Window.h
@@ -162,6 +162,7 @@ private slots:
     void onChangeScreenSize();
     void onChangeScreenRotation(QAction* act);
     void onChangeScreenGap(QAction* act);
+    void onChangeHybridRatio(QAction* act);
     void onChangeScreenLayout(QAction* act);
     void onChangeScreenSwap(bool checked);
     void onChangeScreenSizing(QAction* act);
@@ -279,6 +280,8 @@ public:
     QAction* actScreenRotation[screenRot_MAX];
     QActionGroup* grpScreenGap;
     QAction* actScreenGap[6];
+    QActionGroup* grpHybridRatio;
+    QAction* actHybridRatio[9];
     QActionGroup* grpScreenLayout;
     QAction* actScreenLayout[screenLayout_MAX];
     QAction* actScreenSwap;

--- a/src/frontend/qt_sdl/Window.h
+++ b/src/frontend/qt_sdl/Window.h
@@ -162,7 +162,7 @@ private slots:
     void onChangeScreenSize();
     void onChangeScreenRotation(QAction* act);
     void onChangeScreenGap(QAction* act);
-    void onChangeHybridRatio(QAction* act);
+    void OnChangeHybridRatio(QAction* act);
     void onChangeScreenLayout(QAction* act);
     void onChangeScreenSwap(bool checked);
     void onChangeScreenSizing(QAction* act);
@@ -280,8 +280,8 @@ public:
     QAction* actScreenRotation[screenRot_MAX];
     QActionGroup* grpScreenGap;
     QAction* actScreenGap[6];
-    QActionGroup* grpHybridRatio;
-    QAction* actHybridRatio[9];
+    QActionGroup* GrpHybridRatio;
+    QAction* ActHybridRatio[9];
     QActionGroup* grpScreenLayout;
     QAction* actScreenLayout[screenLayout_MAX];
     QAction* actScreenSwap;


### PR DESCRIPTION
## Summary

This combines two related screen-layout improvements:

- Incorporates the configurable hybrid-screen ratios from [melonDS PR #2332](https://github.com/melonDS-emu/melonDS/pull/2332);
- Corrects the existing `window` aspect-ratio calculation so two-screen layouts can fill the available window, addressing [melonDS issue #2695](https://github.com/melonDS-emu/melonDS/issues/2695).

## Credit and Authorship

The hybrid-ratio implementation was originally authored by
[@KDOXG](https://github.com/KDOXG) in [melonDS PR #2332](https://github.com/melonDS-emu/melonDS/pull/2332).
Their implementation remains a separate commit, with the original Git author attribution preserved.

Thanks also to [@crashGG](https://github.com/crashGG) for testing the original implementation and providing substantial screen-layout feedback in the [PR #2332 discussion](https://github.com/melonDS-emu/melonDS/pull/2332).

## Hybrid ratios

Adds **View → Hybrid ratio** with the following options:

- 2:1
- 3:1
- 4:1
- 5:1
- 6:1
- 7:1
- 5:2
- 7:3
- 9:4

Hybrid ratios use a separate configuration value, so changing the hybrid ratio
does not modify the regular screen-gap setting. The selected ratio persists
after restarting melonDS.

## Fill-window aspect ratio

The existing `window` aspect-ratio option previously calculated each DS
screen's aspect from the complete emulator panel. This did not account for the
portion of the panel allocated to each screen. For example, two vertically
stacked screens still produced side bars because each screen only occupies half
of the panel height.

The updated calculation accounts for:

- vertical, horizontal, and natural layouts;
- 0°, 90°, 180°, and 270° screen rotations;
- the effective screen gap;
- single-screen modes;
- unusually narrow windows or large gaps.

The existing inverse screen transformation continues to handle touchscreen
coordinates after stretching.

This portion addresses [melonDS issue #2695](https://github.com/melonDS-emu/melonDS/issues/2695).

## Usage

To stretch two vertically stacked screens:

1. Select **View → Screen layout → Vertical**.
2. Select **View → Screen sizing → Even**.
3. Disable **Force integer scaling**.
4. Select **View → Aspect ratio → Top window**.
5. Select **View → Aspect ratio → Bottom window**.
6. Maximize the window or enter fullscreen.

To configure the hybrid layout:

1. Select **View → Screen layout → Hybrid**.
2. Open **View → Hybrid ratio**.
3. Select the desired ratio.

## Testing

Tested on Windows using MSYS2 UCRT64, Qt 6, and GCC 15.2.

- Full debug build completed successfully.
- Portable build launched successfully.
- Hybrid-ratio selection persisted after restarting.
- Fill-window geometry was tested with:
    - vertical and horizontal layouts;
    - rotated layouts;
    - non-zero screen gaps;
    - single-screen modes.
- Touch input remained aligned after stretching.
- Both features were retested after the contribution-guideline naming cleanup.
- `git diff --check` passes.