### PR TITLE
Increase the maximum for the internal resolution to 22x (5632x4224)

### DIFF
--- a/src/frontend/qt_sdl/Config.cpp
+++ b/src/frontend/qt_sdl/Config.cpp
@@ -79,7 +79,7 @@ RangeList IntRanges =
     {"Emu.ConsoleType", {0, 1}},
     {"3D.Renderer", {0, renderer3D_Max-1}},
     {"Screen.VSyncInterval", {1, 20}},
-    {"3D.GL.ScaleFactor", {1, 16}},
+    {"3D.GL.ScaleFactor", {1, 22}},
     {"Audio.Interpolation", {0, 4}},
     {"Instance*.Audio.Volume", {0, 256}},
     {"Mic.InputType", {0, micInputType_MAX-1}},

--- a/src/frontend/qt_sdl/VideoSettingsDialog.cpp
+++ b/src/frontend/qt_sdl/VideoSettingsDialog.cpp
@@ -93,7 +93,7 @@ VideoSettingsDialog::VideoSettingsDialog(QWidget* parent) : QDialog(parent), ui(
 
     ui->cbSoftwareThreaded->setChecked(oldSoftThreaded);
 
-    for (int i = 1; i <= 16; i++)
+    for (int i = 1; i <= 22; i++)
         ui->cbxGLResolution->addItem(QString("%1x native (%2x%3)").arg(i).arg(256*i).arg(192*i));
     ui->cbxGLResolution->setCurrentIndex(oldGLScale-1);
 
@@ -204,7 +204,7 @@ void VideoSettingsDialog::on_cbSoftwareThreaded_stateChanged(int state)
 void VideoSettingsDialog::on_cbxGLResolution_currentIndexChanged(int idx)
 {
     // prevent a spurious change
-    if (ui->cbxGLResolution->count() < 16) return;
+    if (ui->cbxGLResolution->count() < 22) return;
 
     auto& cfg = emuInstance->getGlobalConfig();
     cfg.SetInt("3D.GL.ScaleFactor", idx+1);


### PR DESCRIPTION
22x internal resolution (5632x4224) is useful for playing games in a large fullscreen-view with exactly 4x supersampling on 4K-screens (3840x2160); by enabling "Screen filtering"[^1] and integer-scaling, and using one of the layout-options with which a game-view uses almost the entire height of the screen (2112 pixels), such as "Top/Bottom only", or "Horizontal" with "Emphasize top/bottom".

I only tested this shortly, with 4 games, so far; the games seemed to work normally.

<details><summary>Image-comparison (Mario Kart)</summary>

11x (2816 x 2112) - matches the resolution the game is displayed with:
<img width="2816" height="2160" alt="11x" src="https://github.com/user-attachments/assets/7e1d0ebf-aa3e-43ca-9c6f-8ff1706de7a4" />

16x (4096 x 3072):
<img width="2816" height="2160" alt="16x" src="https://github.com/user-attachments/assets/7d849a10-192d-4a89-bd04-2cfbd2016ce9" />

22x (5632 x 4224) - 4x supersampling:
<img width="2816" height="2160" alt="22x" src="https://github.com/user-attachments/assets/b8117057-dafd-4d9d-a569-65b4466821ed" />

</details>

GPU: Radeon RX 6750 XT

[^1]: While "Screen filtering" is enabled, using an internal resolution of up to twice the displayed resolution per dimension effectively applies supersampling.