### PR TITLE
Look for `MakeEmbed.cmake` in the correct location even if melonDS is included in subprojects

### DIFF
--- a/src/OpenGL_shaders/CMakeLists.txt
+++ b/src/OpenGL_shaders/CMakeLists.txt
@@ -37,7 +37,7 @@ foreach(SH_INPUT ${OPENGL_SHADER_FILES})
             -D INPUT_FILE=${SH_INPUT}
             -D OUTPUT_FILE=${SH_OUTPUT}
             -D VAR_NAME=${SH_NAME}
-            -P "${CMAKE_SOURCE_DIR}/cmake/MakeEmbed.cmake"
+            -P "${CMAKE_CURRENT_LIST_DIR}/../../cmake/MakeEmbed.cmake"
         WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
     )
     list(APPEND OPENGL_SHADER_OUT ${SH_OUTPUT})


### PR DESCRIPTION
https://github.com/melonDS-emu/melonDS/commit/ba317e2e122e10cd48b500506aacc51b94f33e2f broke the ability to embed melonDS in other CMake projects (like mine), because the path used to search for `MakeEmbed.cmake` would only be correct when building standalone melonDS. This PR fixes that.