### PR TITLE
Qt: improve multi-window fullscreen behavior

### DIFF
--- a/src/frontend/qt_sdl/Window.cpp
+++ b/src/frontend/qt_sdl/Window.cpp
@@ -2174,7 +2174,9 @@ void MainWindow::toggleFullscreen()
 
 void MainWindow::onFullscreenToggled()
 {
-    toggleFullscreen();
+    // Fullscreen state is independent for each window, so only toggle the active window.
+    if (isActiveWindow())
+        toggleFullscreen();
 }
 
 void MainWindow::onScreenEmphasisToggled()

--- a/src/frontend/qt_sdl/main.cpp
+++ b/src/frontend/qt_sdl/main.cpp
@@ -421,7 +421,14 @@ int main(int argc, char** argv)
         win->preloadROMs(dsfile, gbafile, options->boot);
 
         if (options->fullscreen)
-            win->toggleFullscreen();
+        {
+            // Apply the startup option to every window restored from the configuration.
+            emuInstances[0]->doOnAllWindows([](MainWindow* window)
+            {
+                if (!window->isFullScreen())
+                    window->toggleFullscreen();
+            });
+        }
     }
 
     int ret = melon.exec();


### PR DESCRIPTION
## Summary

This improves fullscreen behavior when an emulation instance uses multiple display windows:

- The fullscreen hotkey now toggles only the active window, allowing each window to remain independently fullscreen or windowed.
- The `-f` / `--fullscreen` command-line option now applies to every window restored at startup instead of only the main window.

Fixes #2685.
Fixes #2734.

## Implementation

The fullscreen signal is still delivered to each display window, but only the active window responds to an interactive toggle. This uses Qt's active-window state rather than melonDS's cached focus flag.

For command-line startup, melonDS iterates over all restored windows and enters fullscreen only when a window is not already fullscreen.

## Testing

Tested on Windows using MSYS2 UCRT64 and Qt 6.

- Full debug build completed successfully.
- Portable build launched successfully with its required runtime libraries.
- With two windows open, sending the fullscreen hotkey to window 1 changed it from 784x448 to 1920x1080 while window 2 remained 272x448.
- Starting the same two-window configuration with `-f` produced two 1920x1080 fullscreen windows.
- `git diff --check` passes.