### PR TITLE
Speedup/slowdown audio filter

### DIFF
--- a/src/frontend/qt_sdl/AudioLowPass.h
+++ b/src/frontend/qt_sdl/AudioLowPass.h
@@ -23,20 +23,16 @@
 #include <cmath>
 #include <cstdint>
 
-// Fourth-order Butterworth low-pass: two cascaded RBJ biquads, stereo with
-// independent state per channel. The cutoff is smoothed rather than jumped, so
-// engaging fast-forward slides the filter shut instead of stepping the
-// coefficients, which would click. At wide open the output is left untouched.
+// fourth-order Butterworth low-pass: two cascaded RBJ biquads, stereo with
+// independent state per channel. the cutoff is smoothed rather than jumped,
+// since stepping the coefficients would click. wide open leaves the output alone.
 class AudioLowPass
 {
 public:
-    // Time constant of the cutoff smoother, in seconds.
-    static constexpr double kSmoothingTau = 0.05;
-    // Fraction of wide-open at which the filter stops touching the output.
-    static constexpr double kBypassThreshold = 0.995;
-    // Section Q's for a fourth-order Butterworth cascade.
+    static constexpr double kSmoothingTau = 0.05;      // cutoff smoother, seconds
+    static constexpr double kBypassThreshold = 0.995;  // fraction of wide-open
+    // section Q's for a fourth-order Butterworth cascade
     static constexpr double kSectionQ[2] = {0.54119610014619698, 1.3065629648763766};
-    // Lowest cutoff the coefficient design will accept.
     static constexpr double kMinCutoff = 20.0;
 
     void Init(double sampleRate)
@@ -55,7 +51,7 @@ public:
     double Cutoff() const { return CurCutoff; }
     bool Bypassed() const { return CurCutoff >= (WideOpen * kBypassThreshold); }
 
-    // Advance the smoothed cutoff by one block, then filter in place.
+    // advance the smoothed cutoff by one block, then filter in place
     void Process(int16_t* samples, int numFrames, double targetHz, double blockSeconds)
     {
         Smooth(targetHz, blockSeconds);
@@ -65,12 +61,23 @@ public:
         {
             for (int ch = 0; ch < 2; ch++)
             {
-                // Runs even when bypassed: its state must stay in step with
-                // the signal, or re-engaging would click.
+                // runs even when bypassed: the state must stay in step with
+                // the signal, or re-engaging would click
                 double y = ProcessSample(samples[(i*2)+ch], ch);
                 if (!bypass) samples[(i*2)+ch] = Saturate(y);
             }
         }
+    }
+
+    // advance the cutoff and the filter state over silence, writing nothing.
+    // used while muted, so unmuting neither steps the coefficients nor dumps
+    // whatever was still ringing in the biquads into a buffer meant to be quiet.
+    void ProcessMuted(int numFrames, double targetHz, double blockSeconds)
+    {
+        Smooth(targetHz, blockSeconds);
+        for (int i = 0; i < numFrames; i++)
+            for (int ch = 0; ch < 2; ch++)
+                ProcessSample(0.0, ch);
     }
 
     void Smooth(double targetHz, double blockSeconds)

--- a/src/frontend/qt_sdl/AudioLowPass.h
+++ b/src/frontend/qt_sdl/AudioLowPass.h
@@ -1,0 +1,143 @@
+/*
+    Copyright 2016-2026 melonDS team
+
+    This file is part of melonDS.
+
+    melonDS is free software: you can redistribute it and/or modify it under
+    the terms of the GNU General Public License as published by the Free
+    Software Foundation, either version 3 of the License, or (at your option)
+    any later version.
+
+    melonDS is distributed in the hope that it will be useful, but WITHOUT ANY
+    WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+    FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with melonDS. If not, see http://www.gnu.org/licenses/.
+*/
+
+#ifndef AUDIOLOWPASS_H
+#define AUDIOLOWPASS_H
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+
+// Fourth-order Butterworth low-pass: two cascaded RBJ biquads, stereo with
+// independent state per channel. The cutoff is smoothed rather than jumped, so
+// engaging fast-forward slides the filter shut instead of stepping the
+// coefficients, which would click. At wide open the output is left untouched.
+class AudioLowPass
+{
+public:
+    // Time constant of the cutoff smoother, in seconds.
+    static constexpr double kSmoothingTau = 0.05;
+    // Fraction of wide-open at which the filter stops touching the output.
+    static constexpr double kBypassThreshold = 0.995;
+    // Section Q's for a fourth-order Butterworth cascade.
+    static constexpr double kSectionQ[2] = {0.54119610014619698, 1.3065629648763766};
+    // Lowest cutoff the coefficient design will accept.
+    static constexpr double kMinCutoff = 20.0;
+
+    void Init(double sampleRate)
+    {
+        SampleRate = sampleRate;
+        WideOpen = std::max(0.45 * sampleRate, kMinCutoff);
+        for (int s = 0; s < 2; s++)
+        {
+            Stages[s].z1[0] = Stages[s].z1[1] = 0.0;
+            Stages[s].z2[0] = Stages[s].z2[1] = 0.0;
+        }
+        SetCutoffNow(WideOpen);
+    }
+
+    double WideOpenCutoff() const { return WideOpen; }
+    double Cutoff() const { return CurCutoff; }
+    bool Bypassed() const { return CurCutoff >= (WideOpen * kBypassThreshold); }
+
+    // Advance the smoothed cutoff by one block, then filter in place.
+    void Process(int16_t* samples, int numFrames, double targetHz, double blockSeconds)
+    {
+        Smooth(targetHz, blockSeconds);
+        bool bypass = Bypassed();
+
+        for (int i = 0; i < numFrames; i++)
+        {
+            for (int ch = 0; ch < 2; ch++)
+            {
+                // Runs even when bypassed: its state must stay in step with
+                // the signal, or re-engaging would click.
+                double y = ProcessSample(samples[(i*2)+ch], ch);
+                if (!bypass) samples[(i*2)+ch] = Saturate(y);
+            }
+        }
+    }
+
+    void Smooth(double targetHz, double blockSeconds)
+    {
+        targetHz = std::clamp(targetHz, kMinCutoff, WideOpen);
+        double a = 1.0 - std::exp(-blockSeconds / kSmoothingTau);
+        SetCutoffNow(CurCutoff + ((targetHz - CurCutoff) * a));
+    }
+
+    void SetCutoffNow(double cutoffHz)
+    {
+        CurCutoff = std::clamp(cutoffHz, kMinCutoff, WideOpen);
+        for (int s = 0; s < 2; s++)
+            Stages[s].Design(CurCutoff, SampleRate, kSectionQ[s]);
+    }
+
+    double ProcessSample(double x, int ch)
+    {
+        double y = x;
+        for (int s = 0; s < 2; s++)
+            y = Stages[s].Run(y, ch);
+        return y;
+    }
+
+private:
+    static int16_t Saturate(double y)
+    {
+        long v = std::lround(y);
+        if (v > 32767) v = 32767;
+        if (v < -32768) v = -32768;
+        return (int16_t)v;
+    }
+
+    struct Biquad
+    {
+        double b0 = 1.0, b1 = 0.0, b2 = 0.0, a1 = 0.0, a2 = 0.0;
+        double z1[2] = {0.0, 0.0};
+        double z2[2] = {0.0, 0.0};
+
+        void Design(double cutoffHz, double sampleRate, double q)
+        {
+            double w0 = 2.0 * M_PI * (cutoffHz / sampleRate);
+            double cw = std::cos(w0);
+            double alpha = std::sin(w0) / (2.0 * q);
+            double a0 = 1.0 + alpha;
+
+            b0 = ((1.0 - cw) * 0.5) / a0;
+            b1 = (1.0 - cw) / a0;
+            b2 = b0;
+            a1 = (-2.0 * cw) / a0;
+            a2 = (1.0 - alpha) / a0;
+        }
+
+        // transposed direct form II
+        double Run(double x, int ch)
+        {
+            double y = (b0 * x) + z1[ch];
+            z1[ch] = (b1 * x) - (a1 * y) + z2[ch];
+            z2[ch] = (b2 * x) - (a2 * y);
+            return y;
+        }
+    };
+
+    double SampleRate = 48000.0;
+    double WideOpen = 21600.0;
+    double CurCutoff = 21600.0;
+    Biquad Stages[2];
+};
+
+#endif // AUDIOLOWPASS_H

--- a/src/frontend/qt_sdl/AudioSettingsDialog.cpp
+++ b/src/frontend/qt_sdl/AudioSettingsDialog.cpp
@@ -47,6 +47,9 @@ AudioSettingsDialog::AudioSettingsDialog(QWidget* parent) : QDialog(parent), ui(
     oldBitDepth = cfg.GetInt("Audio.BitDepth");
     oldVolume = instcfg.GetInt("Audio.Volume");
     oldDSiSync = instcfg.GetBool("Audio.DSiVolumeSync");
+    oldTimeStretch = cfg.GetBool("SpeedUpTimeStretch");
+    oldLowPassEnable = cfg.GetBool("SpeedUpLowPassEnable");
+    oldLowPass = cfg.GetInt("SpeedUpLowPass");
 
     volume = oldVolume;
     dsiSync = oldDSiSync;
@@ -68,6 +71,13 @@ AudioSettingsDialog::AudioSettingsDialog(QWidget* parent) : QDialog(parent), ui(
     ui->slVolume->blockSignals(state);
 
     ui->chkSyncDSiVolume->setChecked(oldDSiSync);
+
+    ui->cbSpeedUpTimeStretch->setChecked(oldTimeStretch);
+    ui->cbSpeedUpLowPass->setChecked(oldLowPassEnable);
+    state = ui->spinSpeedUpLowPass->blockSignals(true);
+    ui->spinSpeedUpLowPass->setValue(oldLowPass);
+    ui->spinSpeedUpLowPass->blockSignals(state);
+    ui->spinSpeedUpLowPass->setEnabled(oldLowPassEnable);
 
     // Setup volume slider accordingly
     if (emuActive && emuInstance->getNDS()->ConsoleType == 1)
@@ -182,6 +192,9 @@ void AudioSettingsDialog::on_AudioSettingsDialog_rejected()
     cfg.SetInt("Audio.BitDepth", oldBitDepth);
     instcfg.SetInt("Audio.Volume", oldVolume);
     instcfg.SetBool("Audio.DSiVolumeSync", oldDSiSync);
+    cfg.SetBool("SpeedUpTimeStretch", oldTimeStretch);
+    cfg.SetBool("SpeedUpLowPassEnable", oldLowPassEnable);
+    cfg.SetInt("SpeedUpLowPass", oldLowPass);
 
     emit updateAudioVolume(oldVolume, oldDSiSync);
     emit updateAudioSettings();
@@ -225,6 +238,25 @@ void AudioSettingsDialog::on_slVolume_valueChanged(int val)
     volume = val;
     cfg.SetInt("Audio.Volume", val);
     emit updateAudioVolume(val, dsiSync);
+}
+
+void AudioSettingsDialog::on_cbSpeedUpTimeStretch_clicked(bool checked)
+{
+    emuInstance->getGlobalConfig().SetBool("SpeedUpTimeStretch", checked);
+    emit updateAudioSettings();
+}
+
+void AudioSettingsDialog::on_cbSpeedUpLowPass_clicked(bool checked)
+{
+    ui->spinSpeedUpLowPass->setEnabled(checked);
+    emuInstance->getGlobalConfig().SetBool("SpeedUpLowPassEnable", checked);
+    emit updateAudioSettings();
+}
+
+void AudioSettingsDialog::on_spinSpeedUpLowPass_valueChanged(int val)
+{
+    emuInstance->getGlobalConfig().SetInt("SpeedUpLowPass", val);
+    emit updateAudioSettings();
 }
 
 void AudioSettingsDialog::on_chkSyncDSiVolume_clicked(bool checked)

--- a/src/frontend/qt_sdl/AudioSettingsDialog.h
+++ b/src/frontend/qt_sdl/AudioSettingsDialog.h
@@ -68,6 +68,9 @@ private slots:
     void on_cbBitDepth_currentIndexChanged(int idx);
     void on_slVolume_valueChanged(int val);
     void on_chkSyncDSiVolume_clicked(bool checked);
+    void on_cbSpeedUpTimeStretch_clicked(bool checked);
+    void on_cbSpeedUpLowPass_clicked(bool checked);
+    void on_spinSpeedUpLowPass_valueChanged(int val);
     void onChangeMicMode(int mode);
     void on_btnMicWavBrowse_clicked();
 
@@ -80,6 +83,9 @@ private:
     int oldBitDepth;
     int oldVolume;
     bool oldDSiSync;
+    bool oldTimeStretch;
+    bool oldLowPassEnable;
+    int oldLowPass;
     QButtonGroup* grpMicMode;
 
     int volume;

--- a/src/frontend/qt_sdl/AudioSettingsDialog.ui
+++ b/src/frontend/qt_sdl/AudioSettingsDialog.ui
@@ -101,6 +101,57 @@
     </widget>
    </item>
    <item>
+    <widget class="QGroupBox" name="groupBox_3">
+     <property name="title">
+      <string>Fast-forward and slow-mo</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_3">
+      <item row="0" column="0" colspan="2">
+       <widget class="QCheckBox" name="cbSpeedUpTimeStretch">
+        <property name="toolTip">
+         <string>Time-stretch fast-forward and slow-mo audio so it keeps its pitch instead of being chopped up.</string>
+        </property>
+        <property name="text">
+         <string>Time-stretch fast-forward/slow-mo</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QCheckBox" name="cbSpeedUpLowPass">
+        <property name="toolTip">
+         <string>Roll the treble off fast-forward audio, which turns harsh when sped up.</string>
+        </property>
+        <property name="text">
+         <string>Low-pass fast-forward</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QSpinBox" name="spinSpeedUpLowPass">
+        <property name="toolTip">
+         <string>Cutoff for fast-forward audio only. Use the highest value that still sounds good sped up; 24000 Hz is the same as unchecking the box.</string>
+        </property>
+        <property name="suffix">
+         <string> Hz</string>
+        </property>
+        <property name="minimum">
+         <number>1000</number>
+        </property>
+        <property name="maximum">
+         <number>24000</number>
+        </property>
+        <property name="singleStep">
+         <number>500</number>
+        </property>
+        <property name="value">
+         <number>24000</number>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
     <widget class="QGroupBox" name="groupBox_2">
      <property name="title">
       <string>Microphone input</string>

--- a/src/frontend/qt_sdl/AudioSpeed.h
+++ b/src/frontend/qt_sdl/AudioSpeed.h
@@ -1,0 +1,105 @@
+/*
+    Copyright 2016-2026 melonDS team
+
+    This file is part of melonDS.
+
+    melonDS is free software: you can redistribute it and/or modify it under
+    the terms of the GNU General Public License as published by the Free
+    Software Foundation, either version 3 of the License, or (at your option)
+    any later version.
+
+    melonDS is distributed in the hope that it will be useful, but WITHOUT ANY
+    WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+    FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with melonDS. If not, see http://www.gnu.org/licenses/.
+*/
+
+#ifndef AUDIOSPEED_H
+#define AUDIOSPEED_H
+
+#include <algorithm>
+#include <cmath>
+
+// The DS's true framerate; a skew of 1.0 emits at the hardware's rate.
+constexpr double INTERNAL_FRAME_RATE = 59.8260982880808;
+
+// Setting value meaning "do not filter at all". An explicit sentinel: without
+// it a 24000 reference would still filter at 12 kHz at 2x.
+constexpr int kSpeedUpLowPassOff = 24000;
+
+// Gain of the FIFO-fill correction on the stretch ratio.
+constexpr double kStretchTrimGain = 0.25;
+
+// Below 1 the stretcher expands (slow-mo), above it compresses (fast-forward).
+constexpr double kMinStretchRatio = 0.25;
+constexpr double kMaxStretchRatio = 32.0;
+
+// Floor on what we hand blip_buf, and it is load-bearing rather than cosmetic.
+// SPU::BufferAudio flushes every 512*128 SPU cycles, which accumulates
+// 65536 * 48000 / (16756991 * skew) ~= 188/skew output samples, and blip_new(512)
+// asserts avail <= 512. Below ~0.37 that overflows the allocation.
+constexpr double kMinOutputSkew = 0.4;
+
+// Emulated speed relative to normal.
+inline double audioSpeedRatio(double curFPS, double targetFPS)
+{
+    if (targetFPS <= 0.0) return 1.0;
+    return curFPS / targetFPS;
+}
+
+inline bool audioIsOffSpeed(double curFPS, double targetFPS)
+{
+    return std::fabs(curFPS - targetFPS) > 0.01;
+}
+
+// Deliberately independent of emulation speed: off-speed audio just arrives
+// faster or slower, and fitting it to the output is the stretcher's job.
+// Deriving this from curFPS instead would resample, shifting pitch.
+inline double audioComputeOutputSkew(double targetFPS)
+{
+    return std::max(targetFPS / INTERNAL_FRAME_RATE, kMinOutputSkew);
+}
+
+// How much input each output frame consumes.
+//
+// Driven by measured arrival rather than the requested speed. The SPU FIFO is
+// polled once per callback and holds 2048 frames, so supply is capped near 4x
+// however fast the emulator runs; asking for the requested ratio above that
+// starves the stretcher, and the trim has nowhere near the authority to close
+// a gap that large. In steady state consumption must equal arrival, so that is
+// the ratio. The FIFO-fill term only steers the level: a larger ratio drains
+// faster, so a full FIFO must raise it.
+inline double audioComputeStretchRatio(double arrivalPerCallback, int outputPerCallback,
+                                       int inputFill, int targetFill)
+{
+    if (outputPerCallback <= 0) return 1.0;
+
+    double ratio = arrivalPerCallback / (double)outputPerCallback;
+
+    if (targetFill > 0)
+    {
+        double err = (inputFill - (double)targetFill) / (double)targetFill;
+        err = std::clamp(err, -1.0, 1.0);
+        ratio *= 1.0 + (kStretchTrimGain * err);
+    }
+
+    return std::clamp(ratio, kMinStretchRatio, kMaxStretchRatio);
+}
+
+// Cutoff for the low-pass, in Hz. wideOpen means transparent; the filter only
+// engages above normal speed, and gets duller the faster the emulator runs.
+inline double audioComputeLowPassCutoff(double curFPS, double targetFPS,
+                                        int reference, double wideOpen)
+{
+    if (wideOpen <= 200.0) return wideOpen;
+
+    double speed = audioSpeedRatio(curFPS, targetFPS);
+    if (speed <= 1.0) return wideOpen;
+    if (reference >= kSpeedUpLowPassOff) return wideOpen;
+
+    return std::clamp(reference / speed, 200.0, wideOpen);
+}
+
+#endif // AUDIOSPEED_H

--- a/src/frontend/qt_sdl/AudioSpeed.h
+++ b/src/frontend/qt_sdl/AudioSpeed.h
@@ -22,27 +22,24 @@
 #include <algorithm>
 #include <cmath>
 
-// The DS's true framerate; a skew of 1.0 emits at the hardware's rate.
+// the DS's true framerate; a skew of 1.0 emits at the hardware's rate
 constexpr double INTERNAL_FRAME_RATE = 59.8260982880808;
 
-// Setting value meaning "do not filter at all". An explicit sentinel: without
-// it a 24000 reference would still filter at 12 kHz at 2x.
+// sentinel value: don't filter at all
 constexpr int kSpeedUpLowPassOff = 24000;
 
-// Gain of the FIFO-fill correction on the stretch ratio.
 constexpr double kStretchTrimGain = 0.25;
 
-// Below 1 the stretcher expands (slow-mo), above it compresses (fast-forward).
-constexpr double kMinStretchRatio = 0.25;
+// below 1 the stretcher expands (slow-mo), above it compresses (fast-forward)
+constexpr double kMinStretchRatio = 1.0 / 32.0;
 constexpr double kMaxStretchRatio = 32.0;
 
-// Floor on what we hand blip_buf, and it is load-bearing rather than cosmetic.
-// SPU::BufferAudio flushes every 512*128 SPU cycles, which accumulates
-// 65536 * 48000 / (16756991 * skew) ~= 188/skew output samples, and blip_new(512)
-// asserts avail <= 512. Below ~0.37 that overflows the allocation.
+// SPU::BufferAudio flushes every 512*128 SPU cycles, accumulating
+// 65536*48000 / (16756991*skew) ~= 188/skew samples, and blip_new(512) asserts
+// avail <= 512. below ~0.37 that overflows the allocation.
 constexpr double kMinOutputSkew = 0.4;
 
-// Emulated speed relative to normal.
+// emulated speed relative to normal
 inline double audioSpeedRatio(double curFPS, double targetFPS)
 {
     if (targetFPS <= 0.0) return 1.0;
@@ -54,23 +51,16 @@ inline bool audioIsOffSpeed(double curFPS, double targetFPS)
     return std::fabs(curFPS - targetFPS) > 0.01;
 }
 
-// Deliberately independent of emulation speed: off-speed audio just arrives
-// faster or slower, and fitting it to the output is the stretcher's job.
-// Deriving this from curFPS instead would resample, shifting pitch.
+// independent of emulation speed: deriving this from curFPS would resample,
+// shifting pitch. fitting off-speed audio to the output is the stretcher's job.
 inline double audioComputeOutputSkew(double targetFPS)
 {
     return std::max(targetFPS / INTERNAL_FRAME_RATE, kMinOutputSkew);
 }
 
-// How much input each output frame consumes.
-//
-// Driven by measured arrival rather than the requested speed. The SPU FIFO is
-// polled once per callback and holds 2048 frames, so supply is capped near 4x
-// however fast the emulator runs; asking for the requested ratio above that
-// starves the stretcher, and the trim has nowhere near the authority to close
-// a gap that large. In steady state consumption must equal arrival, so that is
-// the ratio. The FIFO-fill term only steers the level: a larger ratio drains
-// faster, so a full FIFO must raise it.
+// how much input each output frame consumes. driven by measured arrival rather
+// than the requested speed, which the host may not achieve. the FIFO-fill term
+// only steers the level: a larger ratio drains faster.
 inline double audioComputeStretchRatio(double arrivalPerCallback, int outputPerCallback,
                                        int inputFill, int targetFill)
 {
@@ -88,8 +78,8 @@ inline double audioComputeStretchRatio(double arrivalPerCallback, int outputPerC
     return std::clamp(ratio, kMinStretchRatio, kMaxStretchRatio);
 }
 
-// Cutoff for the low-pass, in Hz. wideOpen means transparent; the filter only
-// engages above normal speed, and gets duller the faster the emulator runs.
+// low-pass cutoff in Hz. wideOpen means transparent; the filter only engages
+// above normal speed, and gets duller the faster the emulator runs.
 inline double audioComputeLowPassCutoff(double curFPS, double targetFPS,
                                         int reference, double wideOpen)
 {

--- a/src/frontend/qt_sdl/AudioTimeStretch.h
+++ b/src/frontend/qt_sdl/AudioTimeStretch.h
@@ -1,0 +1,284 @@
+/*
+    Copyright 2016-2026 melonDS team
+
+    This file is part of melonDS.
+
+    melonDS is free software: you can redistribute it and/or modify it under
+    the terms of the GNU General Public License as published by the Free
+    Software Foundation, either version 3 of the License, or (at your option)
+    any later version.
+
+    melonDS is distributed in the hope that it will be useful, but WITHOUT ANY
+    WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+    FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with melonDS. If not, see http://www.gnu.org/licenses/.
+*/
+
+#ifndef AUDIOTIMESTRETCH_H
+#define AUDIOTIMESTRETCH_H
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <cstring>
+
+// WSOLA time-stretcher: changes playback rate while preserving pitch, by
+// overlap-adding windowed frames picked for waveform similarity so consecutive
+// frames splice on matching phase.
+//
+// kFrameSize and kSearchRadius are tuned, not guessed. The artifact they trade
+// against is amplitude pumping at the synthesis hop rate on noisy material,
+// measured at ratio 3 with the search on versus forced off:
+//
+//   frame 1024   0.139 on / 0.180 off    search buys 1.3x
+//   frame  512   0.071 on / 0.175 off    search buys 2.5x
+//   frame  256   0.036 on / 0.169 off    search buys 4.7x
+//
+// Shorter frames let the search find better matches; off, the figure is flat.
+// Below 256 the window holds barely one cycle of a bass note, so this stops.
+class AudioTimeStretch
+{
+public:
+    static constexpr int kFrameSize = 256;                // analysis window, frames
+    static constexpr int kSynthesisHop = kFrameSize / 2;  // periodic Hann at 50% sums to unity
+    static constexpr int kSearchRadius = 1024;            // frames either side of nominal
+    static constexpr int kCoarseStride = 4;
+    static constexpr int kFineRadius = 3;
+    static constexpr int kInputCapacity = 32768;          // must be a power of two
+    static constexpr int kOutputCapacity = 8192;          // must be a power of two
+
+    // Input the ratio control aims to keep buffered. Absolute, not a multiple
+    // of the window: it absorbs lumpy arrival from the emu thread.
+    static constexpr int kTargetInputFill = 4096;
+
+    AudioTimeStretch()
+    {
+        for (int i = 0; i < kFrameSize; i++)
+            Window[i] = (float)(0.5 * (1.0 - std::cos((2.0 * M_PI * i) / kFrameSize)));
+        Reset();
+    }
+
+    void Reset()
+    {
+        WritePos = 0;
+        AnalysisPos = 0;
+        NaturalPos = 0;
+        OutReadPos = 0;
+        OutWritePos = 0;
+        Primed = false;
+        std::memset(AccL, 0, sizeof(AccL));
+        std::memset(AccR, 0, sizeof(AccR));
+
+        // Belt and braces: the search is already bounded to written frames, but
+        // this makes any future bound slip degrade to silence rather than noise.
+        std::memset(InL, 0, sizeof(InL));
+        std::memset(InR, 0, sizeof(InR));
+        std::memset(InMono, 0, sizeof(InMono));
+    }
+
+    int InputFill() const
+    {
+        int64_t pending = WritePos - AnalysisPos;
+        if (pending < 0) return 0;
+        if (pending > kInputCapacity) return kInputCapacity;
+        return (int)pending;
+    }
+
+    int OutputFill() const { return (int)(OutWritePos - OutReadPos); }
+
+    // Append interleaved stereo frames.
+    int Write(const int16_t* samples, int numFrames)
+    {
+        for (int i = 0; i < numFrames; i++)
+        {
+            int idx = (int)(WritePos & (kInputCapacity - 1));
+            int16_t l = samples[(i*2)+0];
+            int16_t r = samples[(i*2)+1];
+            InL[idx] = l;
+            InR[idx] = r;
+            InMono[idx] = 0.5f * ((float)l + (float)r);
+            WritePos++;
+        }
+
+        // Producer outran us and overwrote frames we still wanted: skip forward
+        // rather than read whatever landed on top of them.
+        int64_t floor = (WritePos - kInputCapacity) + kSearchRadius + kFrameSize;
+        if (AnalysisPos < floor)
+        {
+            AnalysisPos = floor;
+            NaturalPos = floor;
+            Primed = false;
+        }
+
+        return numFrames;
+    }
+
+    // Emit up to numFrames of interleaved stereo, synthesising as needed.
+    int Read(int16_t* samples, int numFrames, double ratio)
+    {
+        while ((OutputFill() < numFrames) && CanSynthesise())
+            SynthesiseHop(ratio);
+
+        int n = std::min(numFrames, OutputFill());
+        for (int i = 0; i < n; i++)
+        {
+            int idx = (int)(OutReadPos & (kOutputCapacity - 1));
+            samples[(i*2)+0] = OutL[idx];
+            samples[(i*2)+1] = OutR[idx];
+            OutReadPos++;
+        }
+        return n;
+    }
+
+private:
+    static int16_t Saturate(float v)
+    {
+        long s = std::lround(v);
+        if (s > 32767) s = 32767;
+        if (s < -32768) s = -32768;
+        return (int16_t)s;
+    }
+
+    bool CanSynthesise() const
+    {
+        if ((kOutputCapacity - OutputFill()) < kSynthesisHop) return false;
+
+        // Only the frame itself and the natural-continuation reference need to
+        // be present; the search clamps to whatever else is available. Demanding
+        // the full radius here would emit no output at all on a short FIFO.
+        int64_t frameEnd = AnalysisPos + kFrameSize;
+        int64_t naturalEnd = NaturalPos + kSynthesisHop;
+        return (WritePos >= frameEnd) && (WritePos >= naturalEnd);
+    }
+
+    void SynthesiseHop(double ratio)
+    {
+        int hop = (int)std::lround(kSynthesisHop * ratio);
+        if (hop < 1) hop = 1;
+
+        int64_t chosen = Primed ? FindBestOffset() : AnalysisPos;
+        Primed = true;
+
+        for (int i = 0; i < kFrameSize; i++)
+        {
+            int idx = (int)((chosen + i) & (kInputCapacity - 1));
+            float w = Window[i];
+            AccL[i] += w * (float)InL[idx];
+            AccR[i] += w * (float)InR[idx];
+        }
+
+        for (int i = 0; i < kSynthesisHop; i++)
+        {
+            int idx = (int)(OutWritePos & (kOutputCapacity - 1));
+            OutL[idx] = Saturate(AccL[i]);
+            OutR[idx] = Saturate(AccR[i]);
+            OutWritePos++;
+        }
+
+        std::memmove(AccL, AccL + kSynthesisHop, kSynthesisHop * sizeof(float));
+        std::memmove(AccR, AccR + kSynthesisHop, kSynthesisHop * sizeof(float));
+        std::memset(AccL + kSynthesisHop, 0, kSynthesisHop * sizeof(float));
+        std::memset(AccR + kSynthesisHop, 0, kSynthesisHop * sizeof(float));
+
+        // The nominal pointer advances by hop alone; the search only picks which
+        // frame to window. Advancing from chosen instead would make consumption
+        // hop + E[bestK], which the caller's ratio control cannot see.
+        NaturalPos = chosen + kSynthesisHop;
+        AnalysisPos += hop;
+    }
+
+    int64_t FindBestOffset() const
+    {
+        int64_t oldest = std::max<int64_t>(0, WritePos - kInputCapacity);
+
+        // NaturalPos trails AnalysisPos by up to hop + kSearchRadius - kSynthesisHop,
+        // which at a high ratio on a near-full ring can fall off the back. The
+        // reference would then be overwritten frames, so search nothing instead.
+        if (NaturalPos < oldest) return AnalysisPos;
+
+        double refEnergy = Energy(NaturalPos);
+
+        // Full radius regardless of hop: expansion needs the reach, since the
+        // natural continuation sits |kSynthesisHop - hop| ahead of the nominal.
+        const int radius = kSearchRadius;
+
+        // Masking a negative position wraps it into frames we never wrote.
+        int lowestK = -radius;
+        if ((AnalysisPos + lowestK) < oldest)
+            lowestK = (int)(oldest - AnalysisPos);
+
+        // Clamp to what has arrived, so a short FIFO narrows the search.
+        int highestK = radius;
+        int64_t latest = WritePos - kFrameSize;
+        if ((AnalysisPos + highestK) > latest)
+            highestK = (int)(latest - AnalysisPos);
+        if (highestK < lowestK) highestK = lowestK;
+
+        int bestK = std::min(std::max(lowestK, 0), highestK);
+        double bestScore = -1.0e30;
+
+        for (int k = lowestK; k <= highestK; k += kCoarseStride)
+        {
+            double s = Score(AnalysisPos + k, refEnergy);
+            if (s > bestScore) { bestScore = s; bestK = k; }
+        }
+
+        int lo = std::max(lowestK, bestK - kFineRadius);
+        int hi = std::min(highestK, bestK + kFineRadius);
+        for (int k = lo; k <= hi; k++)
+        {
+            double s = Score(AnalysisPos + k, refEnergy);
+            if (s > bestScore) { bestScore = s; bestK = k; }
+        }
+
+        return AnalysisPos + bestK;
+    }
+
+    double Energy(int64_t pos) const
+    {
+        double e = 0.0;
+        for (int i = 0; i < kSynthesisHop; i++)
+        {
+            double v = InMono[(int)((pos + i) & (kInputCapacity - 1))];
+            e += v * v;
+        }
+        return e;
+    }
+
+    // Normalised so the search doesn't just latch onto the loudest candidate.
+    double Score(int64_t pos, double refEnergy) const
+    {
+        double dot = 0.0;
+        double energy = 0.0;
+        for (int i = 0; i < kSynthesisHop; i++)
+        {
+            double a = InMono[(int)((pos + i) & (kInputCapacity - 1))];
+            double b = InMono[(int)((NaturalPos + i) & (kInputCapacity - 1))];
+            dot += a * b;
+            energy += a * a;
+        }
+        return dot / std::sqrt((energy * refEnergy) + 1.0e-9);
+    }
+
+    float Window[kFrameSize];
+
+    int16_t InL[kInputCapacity];
+    int16_t InR[kInputCapacity];
+    float InMono[kInputCapacity];
+    int64_t WritePos = 0;
+    int64_t AnalysisPos = 0;
+    int64_t NaturalPos = 0;
+    bool Primed = false;
+
+    float AccL[kFrameSize];
+    float AccR[kFrameSize];
+
+    int16_t OutL[kOutputCapacity];
+    int16_t OutR[kOutputCapacity];
+    int64_t OutReadPos = 0;
+    int64_t OutWritePos = 0;
+};
+
+#endif // AUDIOTIMESTRETCH_H

--- a/src/frontend/qt_sdl/AudioTimeStretch.h
+++ b/src/frontend/qt_sdl/AudioTimeStretch.h
@@ -20,24 +20,18 @@
 #define AUDIOTIMESTRETCH_H
 
 #include <algorithm>
+#include <atomic>
 #include <cmath>
 #include <cstdint>
 #include <cstring>
 
 // WSOLA time-stretcher: changes playback rate while preserving pitch, by
-// overlap-adding windowed frames picked for waveform similarity so consecutive
+// overlap-adding windowed frames picked for waveform similarity, so consecutive
 // frames splice on matching phase.
 //
-// kFrameSize and kSearchRadius are tuned, not guessed. The artifact they trade
-// against is amplitude pumping at the synthesis hop rate on noisy material,
-// measured at ratio 3 with the search on versus forced off:
-//
-//   frame 1024   0.139 on / 0.180 off    search buys 1.3x
-//   frame  512   0.071 on / 0.175 off    search buys 2.5x
-//   frame  256   0.036 on / 0.169 off    search buys 4.7x
-//
-// Shorter frames let the search find better matches; off, the figure is flat.
-// Below 256 the window holds barely one cycle of a bass note, so this stops.
+// single producer/single consumer. the emu thread calls Write and BeginSession;
+// the audio thread calls Read, InputFill, OutputFill and TotalWritten. Reset is
+// neither, and needs both stopped.
 class AudioTimeStretch
 {
 public:
@@ -49,9 +43,23 @@ public:
     static constexpr int kInputCapacity = 32768;          // must be a power of two
     static constexpr int kOutputCapacity = 8192;          // must be a power of two
 
-    // Input the ratio control aims to keep buffered. Absolute, not a multiple
-    // of the window: it absorbs lumpy arrival from the emu thread.
-    static constexpr int kTargetInputFill = 4096;
+    // floor on how much input the ratio control keeps buffered
+    static constexpr int kMinTargetInputFill = 4096;
+
+    // how much input to keep buffered. a fixed figure starves the stretcher at
+    // high speed, where one callback consumes more than the target.
+    static int TargetInputFill(double arrivalPerCallback)
+    {
+        // leave half the ring free, or a large hop squeezes Write down to nothing
+        const double cap = kInputCapacity / 2;
+
+        double need = (2.0 * arrivalPerCallback) + kSearchRadius + kFrameSize;
+        // clamped as a double: a TargetFPS of 0.0001 seeds an arrival estimate
+        // around 2.5e9, and casting that to int is UB
+        if (!(need > kMinTargetInputFill)) need = kMinTargetInputFill;
+        if (need > cap) need = cap;
+        return (int)need;
+    }
 
     AudioTimeStretch()
     {
@@ -60,9 +68,14 @@ public:
         Reset();
     }
 
+    // not thread-safe: call only with both sides stopped
     void Reset()
     {
-        WritePos = 0;
+        WritePos.store(0, std::memory_order_relaxed);
+        Generation.store(0, std::memory_order_relaxed);
+        ConsumerFloor.store(0, std::memory_order_relaxed);
+        SeenWrite = 0;
+        SeenGeneration = 0;
         AnalysisPos = 0;
         NaturalPos = 0;
         OutReadPos = 0;
@@ -71,8 +84,8 @@ public:
         std::memset(AccL, 0, sizeof(AccL));
         std::memset(AccR, 0, sizeof(AccR));
 
-        // Belt and braces: the search is already bounded to written frames, but
-        // this makes any future bound slip degrade to silence rather than noise.
+        // the search is already bounded to written frames; this only degrades
+        // a future bound slip to silence rather than noise
         std::memset(InL, 0, sizeof(InL));
         std::memset(InR, 0, sizeof(InR));
         std::memset(InMono, 0, sizeof(InMono));
@@ -80,7 +93,7 @@ public:
 
     int InputFill() const
     {
-        int64_t pending = WritePos - AnalysisPos;
+        int64_t pending = WritePos.load(std::memory_order_acquire) - AnalysisPos;
         if (pending < 0) return 0;
         if (pending > kInputCapacity) return kInputCapacity;
         return (int)pending;
@@ -88,23 +101,60 @@ public:
 
     int OutputFill() const { return (int)(OutWritePos - OutReadPos); }
 
-    // Append interleaved stereo frames.
+    // append interleaved stereo frames, returning how many were accepted.
+    // writing is refused rather than allowed to lap the consumer.
     int Write(const int16_t* samples, int numFrames)
     {
+        int64_t w = WritePos.load(std::memory_order_relaxed);
+
+        int64_t floor = ConsumerFloor.load(std::memory_order_acquire);
+        int64_t space = kInputCapacity - (w - floor);
+        if (space < 0) space = 0;
+        if (numFrames > space) numFrames = (int)space;
+        if (numFrames <= 0) return 0;
+
         for (int i = 0; i < numFrames; i++)
         {
-            int idx = (int)(WritePos & (kInputCapacity - 1));
+            int idx = (int)((w + i) & (kInputCapacity - 1));
             int16_t l = samples[(i*2)+0];
             int16_t r = samples[(i*2)+1];
             InL[idx] = l;
             InR[idx] = r;
             InMono[idx] = 0.5f * ((float)l + (float)r);
-            WritePos++;
         }
 
-        // Producer outran us and overwrote frames we still wanted: skip forward
-        // rather than read whatever landed on top of them.
-        int64_t floor = (WritePos - kInputCapacity) + kSearchRadius + kFrameSize;
+        // release: the frames must be visible before the count advertising them
+        WritePos.store(w + numFrames, std::memory_order_release);
+        return numFrames;
+    }
+
+    // marks a discontinuity: the consumer resyncs rather than splicing across it
+    void BeginSession()
+    {
+        Generation.fetch_add(1, std::memory_order_release);
+    }
+
+    int64_t TotalWritten() const { return WritePos.load(std::memory_order_acquire); }
+
+    // emit up to numFrames of interleaved stereo, synthesising as needed. works
+    // off one snapshot of the producer's count, so the bounds can't shift.
+    int Read(int16_t* samples, int numFrames, double ratio)
+    {
+        // generation first, then WritePos. the other order lets a session that
+        // starts between the two loads resync against a stale SeenWrite, and
+        // then never resync again.
+        uint32_t gen = Generation.load(std::memory_order_acquire);
+        SeenWrite = WritePos.load(std::memory_order_acquire);
+
+        if (gen != SeenGeneration)
+        {
+            SeenGeneration = gen;
+            ResyncToLive();
+        }
+
+        // the producer outran us: skip forward rather than read what landed
+        // on top of the frames we wanted
+        int64_t floor = (SeenWrite - kInputCapacity) + kSearchRadius + kFrameSize;
         if (AnalysisPos < floor)
         {
             AnalysisPos = floor;
@@ -112,12 +162,6 @@ public:
             Primed = false;
         }
 
-        return numFrames;
-    }
-
-    // Emit up to numFrames of interleaved stereo, synthesising as needed.
-    int Read(int16_t* samples, int numFrames, double ratio)
-    {
         while ((OutputFill() < numFrames) && CanSynthesise())
             SynthesiseHop(ratio);
 
@@ -129,6 +173,8 @@ public:
             samples[(i*2)+1] = OutR[idx];
             OutReadPos++;
         }
+
+        PublishFloor();
         return n;
     }
 
@@ -141,16 +187,39 @@ private:
         return (int16_t)s;
     }
 
+    // publish the oldest frame we might still look at, so the producer stops
+    // short of it. NaturalPos can sit well below AnalysisPos - kSearchRadius.
+    void PublishFloor()
+    {
+        int64_t floorNow = std::min(AnalysisPos - kSearchRadius, NaturalPos);
+        if (floorNow < 0) floorNow = 0;
+        ConsumerFloor.store(floorNow, std::memory_order_release);
+    }
+
+    // drop whatever is stale and pick up at live data. the published floor can
+    // decrease here, but the dip is bounded by kFrameSize + kSearchRadius, far
+    // short of kInputCapacity, so the producer can't reach the re-exposed region.
+    void ResyncToLive()
+    {
+        AnalysisPos = std::max<int64_t>(0, SeenWrite - kFrameSize);
+        NaturalPos = AnalysisPos;
+        Primed = false;
+        PublishFloor();
+        OutReadPos = 0;
+        OutWritePos = 0;
+        std::memset(AccL, 0, sizeof(AccL));
+        std::memset(AccR, 0, sizeof(AccR));
+    }
+
     bool CanSynthesise() const
     {
         if ((kOutputCapacity - OutputFill()) < kSynthesisHop) return false;
 
-        // Only the frame itself and the natural-continuation reference need to
-        // be present; the search clamps to whatever else is available. Demanding
-        // the full radius here would emit no output at all on a short FIFO.
+        // only the frame and the natural-continuation reference need to be
+        // present; demanding the full search radius would starve a short FIFO
         int64_t frameEnd = AnalysisPos + kFrameSize;
         int64_t naturalEnd = NaturalPos + kSynthesisHop;
-        return (WritePos >= frameEnd) && (WritePos >= naturalEnd);
+        return (SeenWrite >= frameEnd) && (SeenWrite >= naturalEnd);
     }
 
     void SynthesiseHop(double ratio)
@@ -182,42 +251,41 @@ private:
         std::memset(AccL + kSynthesisHop, 0, kSynthesisHop * sizeof(float));
         std::memset(AccR + kSynthesisHop, 0, kSynthesisHop * sizeof(float));
 
-        // The nominal pointer advances by hop alone; the search only picks which
-        // frame to window. Advancing from chosen instead would make consumption
-        // hop + E[bestK], which the caller's ratio control cannot see.
+        // the nominal pointer advances by hop alone; advancing from chosen would
+        // make consumption hop + E[bestK], which the ratio control can't see
         NaturalPos = chosen + kSynthesisHop;
         AnalysisPos += hop;
     }
 
     int64_t FindBestOffset() const
     {
-        int64_t oldest = std::max<int64_t>(0, WritePos - kInputCapacity);
+        int64_t oldest = std::max<int64_t>(0, SeenWrite - kInputCapacity);
 
-        // NaturalPos trails AnalysisPos by up to hop + kSearchRadius - kSynthesisHop,
-        // which at a high ratio on a near-full ring can fall off the back. The
-        // reference would then be overwritten frames, so search nothing instead.
+        // at a high ratio on a near-full ring NaturalPos can fall off the back.
+        // the reference would then be overwritten frames, so don't search.
         if (NaturalPos < oldest) return AnalysisPos;
 
         double refEnergy = Energy(NaturalPos);
 
-        // Full radius regardless of hop: expansion needs the reach, since the
-        // natural continuation sits |kSynthesisHop - hop| ahead of the nominal.
+        // full radius regardless of hop: expansion needs the reach
         const int radius = kSearchRadius;
 
-        // Masking a negative position wraps it into frames we never wrote.
+        // masking a negative position wraps it into frames we never wrote
         int lowestK = -radius;
         if ((AnalysisPos + lowestK) < oldest)
             lowestK = (int)(oldest - AnalysisPos);
 
-        // Clamp to what has arrived, so a short FIFO narrows the search.
+        // clamp to what has arrived, so a short FIFO narrows the search
         int highestK = radius;
-        int64_t latest = WritePos - kFrameSize;
+        int64_t latest = SeenWrite - kFrameSize;
         if ((AnalysisPos + highestK) > latest)
             highestK = (int)(latest - AnalysisPos);
         if (highestK < lowestK) highestK = lowestK;
 
+        // seeded from the nominal offset, so ties keep it rather than sliding
+        // to the bottom of the window (every score is 0 on digital silence)
         int bestK = std::min(std::max(lowestK, 0), highestK);
-        double bestScore = -1.0e30;
+        double bestScore = Score(AnalysisPos + bestK, refEnergy);
 
         for (int k = lowestK; k <= highestK; k += kCoarseStride)
         {
@@ -247,7 +315,7 @@ private:
         return e;
     }
 
-    // Normalised so the search doesn't just latch onto the loudest candidate.
+    // normalised, so the search doesn't just latch onto the loudest candidate
     double Score(int64_t pos, double refEnergy) const
     {
         double dot = 0.0;
@@ -267,7 +335,12 @@ private:
     int16_t InL[kInputCapacity];
     int16_t InR[kInputCapacity];
     float InMono[kInputCapacity];
-    int64_t WritePos = 0;
+    std::atomic<int64_t> WritePos{0};      // producer writes, consumer reads
+    std::atomic<uint32_t> Generation{0};   // producer writes, consumer reads
+    std::atomic<int64_t> ConsumerFloor{0}; // consumer writes, producer reads
+
+    int64_t SeenWrite = 0;                 // consumer's snapshot of WritePos
+    uint32_t SeenGeneration = 0;
     int64_t AnalysisPos = 0;
     int64_t NaturalPos = 0;
     bool Primed = false;

--- a/src/frontend/qt_sdl/Config.cpp
+++ b/src/frontend/qt_sdl/Config.cpp
@@ -66,6 +66,7 @@ DefaultList<int> DefaultInts =
     {"Instance*.Audio.Volume", 256},
     {"Mic.InputType", 1},
     {"Mouse.HideSeconds", 5},
+    {"SpeedUpLowPass", 24000},
     {"Instance*.DSi.Battery.Level", 0xF},
 #ifdef GDBSTUB_ENABLED
     {"Instance*.Gdb.ARM7.Port", 3334},
@@ -90,6 +91,7 @@ RangeList IntRanges =
     {"Instance*.Window*.ScreenAspectTop", {0, AspectRatiosNum-1}},
     {"Instance*.Window*.ScreenAspectBot", {0, AspectRatiosNum-1}},
     {"MP.AudioMode", {0, 2}},
+    {"SpeedUpLowPass", {1000, 24000}},
     {"LAN.HostNumPlayers", {2, 16}},
 };
 
@@ -111,6 +113,8 @@ DefaultList<bool> DefaultBools =
 #endif
 #endif
     {"DSi.DSP.HLE", true},
+    {"SpeedUpTimeStretch", true},
+    {"SpeedUpLowPassEnable", true},
     {"Instance*.RTC.SyncToHost", true},
 };
 

--- a/src/frontend/qt_sdl/EmuInstance.h
+++ b/src/frontend/qt_sdl/EmuInstance.h
@@ -21,6 +21,8 @@
 
 #include <SDL2/SDL.h>
 
+#include <atomic>
+
 #include "Platform.h"
 #include "main.h"
 #include "NDS.h"
@@ -28,8 +30,14 @@
 #include "Window.h"
 #include "Config.h"
 #include "SaveManager.h"
+#include "AudioLowPass.h"
+#include "AudioTimeStretch.h"
 
 const int kMaxWindows = 4;
+
+// Upper bound on frames drained from the SPU FIFO per callback, and the size of
+// the staging buffer that receives them.
+const int kAudioDrainMax = 2048;
 
 enum
 {
@@ -229,14 +237,17 @@ private:
     void updateFastForwardMute(bool fastForward);
     void audioSync();
     void audioUpdateSettings();
+    void audioUpdateSpeedUpSettings();
 
     void micOpen();
     void micClose();
     void micLoadWav(const std::string& name);
     void setupMicInputData();
 
-    int audioGetNumSamplesOut(int outlen);
     static void audioCallback(void* data, Uint8* stream, int len);
+    void audioDirectRead(melonDS::s16* stream, int len);
+    void audioStretchedRead(melonDS::s16* stream, int len);
+    void audioFinishBuffer(melonDS::s16* stream, int len, int num_in);
 
     int micGetNumSamplesIn(int inlen);
     void micResample(melonDS::s16* inbuf, int inlen);
@@ -316,7 +327,19 @@ private:
     SDL_AudioDeviceID audioDevice;
     int audioFreq;
     int audioBufSize;
-    float audioSampleFrac;
+    // Written from the Qt thread when the settings dialog is accepted, read on
+    // the audio thread. The emu thread is paused for that, but the audio device
+    // is not, so the callback really is running concurrently. The two enables
+    // are independent, so they need no ordering between them.
+    std::atomic<int> audioSpeedUpLowPass;
+    std::atomic<bool> audioTimeStretchEnable;
+    std::atomic<bool> audioLowPassEnable;
+    AudioLowPass audioLowPass;
+    AudioTimeStretch audioTimeStretch;
+    bool audioStretchEngaged;
+    melonDS::s16 audioStretchTemp[kAudioDrainMax * 2];
+    melonDS::u32 audioLastFrame;
+    double audioArrivalAvg;
     bool audioMutedToggle;
     bool audioMutedByFastForward;
     bool audioMutedByWindowFocus;

--- a/src/frontend/qt_sdl/EmuInstance.h
+++ b/src/frontend/qt_sdl/EmuInstance.h
@@ -30,13 +30,16 @@
 #include "Window.h"
 #include "Config.h"
 #include "SaveManager.h"
+#include "AudioSpeed.h"
 #include "AudioLowPass.h"
 #include "AudioTimeStretch.h"
 
 const int kMaxWindows = 4;
 
-// Upper bound on frames drained from the SPU FIFO per callback, and the size of
-// the staging buffer that receives them.
+// upper bound on frames drained from the SPU FIFO per emulated frame, and the
+// size of the staging buffer that receives them. tied to kMinOutputSkew: at a
+// skew of 0.4 the SPU emits 802.3/0.4 ~= 2006 frames per emulated frame, so
+// lowering that floor means raising this too.
 const int kAudioDrainMax = 2048;
 
 enum
@@ -175,6 +178,15 @@ public:
     void micStop();
     int micReadInput(melonDS::s16* data, int maxlength);
 
+    // called from the emu thread every frame: it, not the audio callback,
+    // drains the SPU while off-speed
+    void audioDrainSPU();
+    bool audioOffSpeed() const;
+    // emu thread. call when the stream jumps - savestate load, undo
+    void audioMarkDiscontinuity();
+    // emu thread. the achieved frame rate, for the low-pass only
+    void audioSetMeasuredFPS(double fps);
+
     QMutex renderLock;
 
 private:
@@ -238,12 +250,15 @@ private:
     void audioSync();
     void audioUpdateSettings();
     void audioUpdateSpeedUpSettings();
+    void audioUpdateOutputSkew();
 
     void micOpen();
     void micClose();
     void micLoadWav(const std::string& name);
     void setupMicInputData();
 
+    int audioGetNumSamplesOut(int outlen);
+    double audioLowPassCutoff() const;
     static void audioCallback(void* data, Uint8* stream, int len);
     void audioDirectRead(melonDS::s16* stream, int len);
     void audioStretchedRead(melonDS::s16* stream, int len);
@@ -309,7 +324,8 @@ public:
     std::unique_ptr<SaveManager> firmwareSave;
 
     bool doLimitFPS;
-    double curFPS;
+    // the emu thread writes this, the audio thread reads it
+    std::atomic<double> curFPS;
     double targetFPS;
     double fastForwardFPS;
     double slowmoFPS;
@@ -327,19 +343,29 @@ private:
     SDL_AudioDeviceID audioDevice;
     int audioFreq;
     int audioBufSize;
-    // Written from the Qt thread when the settings dialog is accepted, read on
-    // the audio thread. The emu thread is paused for that, but the audio device
-    // is not, so the callback really is running concurrently. The two enables
-    // are independent, so they need no ordering between them.
-    std::atomic<int> audioSpeedUpLowPass;
-    std::atomic<bool> audioTimeStretchEnable;
-    std::atomic<bool> audioLowPassEnable;
+    // written from the Qt thread with the emu thread and the audio device
+    // paused, read on both while running. atomic so a slip in that pausing
+    // degrades to a stale read; they are independent and need no ordering.
+    std::atomic<int> audioSpeedUpLowPass{kSpeedUpLowPassOff};
+    std::atomic<bool> audioTimeStretchEnable{false};
+    std::atomic<bool> audioLowPassEnable{false};
+    // the rate actually achieved, published by the emu thread. curFPS is only
+    // the frame limiter's setpoint, and with an uncapped fast-forward target it
+    // is nowhere near the truth.
+    std::atomic<double> audioMeasuredFPS{0.0};
+    // frames handed to the stretcher, accepted or not. the audio thread derives
+    // the arrival rate from this: counting only accepted frames would read a
+    // saturated ring as silence and stretch the wrong way.
+    std::atomic<melonDS::s64> audioOfferedFrames{0};
     AudioLowPass audioLowPass;
     AudioTimeStretch audioTimeStretch;
     bool audioStretchEngaged;
-    melonDS::s16 audioStretchTemp[kAudioDrainMax * 2];
     melonDS::u32 audioLastFrame;
     double audioArrivalAvg;
+    melonDS::s64 audioLastOffered;
+    double audioSampleFrac;
+    melonDS::s16 audioDrainTemp[kAudioDrainMax * 2];
+    bool audioDrainEngaged;
     bool audioMutedToggle;
     bool audioMutedByFastForward;
     bool audioMutedByWindowFocus;

--- a/src/frontend/qt_sdl/EmuInstanceAudio.cpp
+++ b/src/frontend/qt_sdl/EmuInstanceAudio.cpp
@@ -22,11 +22,11 @@
 #include "Platform.h"
 #include "main.h"
 
+#include "AudioSpeed.h"
+
 #include "mic_blow.h"
 
 using namespace melonDS;
-
-#define INTERNAL_FRAME_RATE 59.8260982880808f
 
 // --- AUDIO OUTPUT -----------------------------------------------------------
 
@@ -43,7 +43,12 @@ void EmuInstance::audioInit()
     audioSyncLock = SDL_CreateMutex();
 
     audioFreq = 48000; // TODO: make both of these configurable?
-    audioBufSize = 512;
+    // 256 rather than 512: the callback is what drains the SPU's 2048-frame
+    // output ring, so the period sets the ceiling on how fast the emulator can
+    // run before that ring overflows - 2047/256 is ~8x against ~4x at 512. It
+    // also halves output latency. The cost is less scheduling slack per
+    // callback, so a heavily loaded host glitches sooner.
+    audioBufSize = 256;
 
     SDL_AudioSpec whatIwant, whatIget;
     memset(&whatIwant, 0, sizeof(SDL_AudioSpec));
@@ -67,7 +72,14 @@ void EmuInstance::audioInit()
         SDL_PauseAudioDevice(audioDevice, 1);
     }
 
-    audioSampleFrac = 0;
+    audioSpeedUpLowPass.store(globalCfg.GetInt("SpeedUpLowPass"), std::memory_order_relaxed);
+    audioTimeStretchEnable.store(globalCfg.GetBool("SpeedUpTimeStretch"), std::memory_order_relaxed);
+    audioLowPassEnable.store(globalCfg.GetBool("SpeedUpLowPassEnable"), std::memory_order_relaxed);
+    audioLowPass.Init(audioFreq);
+    audioTimeStretch.Reset();
+    audioStretchEngaged = false;
+    audioLastFrame = 0;
+    audioArrivalAvg = 0.0;
 
     micStarted = false;
     micDevice = 0;
@@ -149,51 +161,125 @@ void EmuInstance::audioSync()
     }
 }
 
-int EmuInstance::audioGetNumSamplesOut(int outlen)
-{
-    float f_len_in = outlen * (curFPS/targetFPS);
-    f_len_in += audioSampleFrac;
-    int len_in = (int)floor(f_len_in);
-    audioSampleFrac = f_len_in - len_in;
-
-    return len_in;
-}
-
 void EmuInstance::audioCallback(void* data, Uint8* stream, int len)
 {
     EmuInstance* inst = (EmuInstance*)data;
     len /= (sizeof(s16) * 2);
 
-    double skew = std::max(inst->targetFPS / INTERNAL_FRAME_RATE, 0.5);
-    inst->nds->SPU.SetOutputSkew(skew);
+    // Pitch-correct regardless of speed; the stretcher fits the audio to the
+    // output. A skew derived from curFPS would resample and shift pitch.
+    inst->nds->SPU.SetOutputSkew(audioComputeOutputSkew(inst->targetFPS));
 
-    int len_in = inst->audioGetNumSamplesOut(len);
-    if (len_in > inst->audioBufSize) len_in = inst->audioBufSize;
+    bool offSpeed = inst->audioTimeStretchEnable.load(std::memory_order_relaxed)
+                    && audioIsOffSpeed(inst->curFPS, inst->targetFPS);
 
-    SDL_LockMutex(inst->audioSyncLock);
-    int num_in = inst->nds->SPU.ReadOutput((s16*) stream, len_in);
-    SDL_CondSignal(inst->audioSyncCond);
-    SDL_UnlockMutex(inst->audioSyncLock);
-
-    if ((num_in < 1) || inst->audioMutedByWindowFocus || inst->audioMutedToggle || inst->audioMutedByFastForward)
+    if (!offSpeed)
     {
-        memset(stream, 0, len*sizeof(s16)*2);
+        // Normal speed gets its own branch, so it cannot regress.
+        if (inst->audioStretchEngaged)
+        {
+            inst->audioTimeStretch.Reset();
+            inst->audioStretchEngaged = false;
+        }
+        inst->audioDirectRead((s16*) stream, len);
         return;
     }
 
-    if (inst->audioVolume < 256)
+    if (!inst->audioStretchEngaged)
     {
-        s16* samples = (s16*) stream;
-        for (int i = 0; i < num_in * 2; i++)
-            samples[i] = ((s32) samples[i] * inst->audioVolume) >> 8;
+        inst->audioStretchEngaged = true;
+        inst->audioArrivalAvg = len * audioSpeedRatio(inst->curFPS, inst->targetFPS);
+    }
+    inst->audioStretchedRead((s16*) stream, len);
+}
+
+void EmuInstance::audioDirectRead(s16* stream, int len)
+{
+    SDL_LockMutex(audioSyncLock);
+    int num_in = nds->SPU.ReadOutput(stream, len);
+    SDL_CondSignal(audioSyncCond);
+    SDL_UnlockMutex(audioSyncLock);
+
+    audioFinishBuffer(stream, len, num_in);
+}
+
+void EmuInstance::audioStretchedRead(s16* stream, int len)
+{
+    SDL_LockMutex(audioSyncLock);
+    int avail = nds->SPU.GetOutputSize();
+    if (avail > kAudioDrainMax) avail = kAudioDrainMax;
+    int got = (avail > 0) ? nds->SPU.ReadOutput(audioStretchTemp, avail) : 0;
+    SDL_CondSignal(audioSyncCond);
+    SDL_UnlockMutex(audioSyncLock);
+
+    if (got > 0)
+        audioTimeStretch.Write(audioStretchTemp, got);
+
+    // Arrival is lumpy - the emu thread delivers in bursts - so smooth it before
+    // using it as the rate.
+    audioArrivalAvg += (got - audioArrivalAvg) * 0.05;
+
+    double ratio = audioComputeStretchRatio(audioArrivalAvg, len,
+                                            audioTimeStretch.InputFill(),
+                                            AudioTimeStretch::kTargetInputFill);
+    int num_in = audioTimeStretch.Read(stream, len, ratio);
+
+    audioFinishBuffer(stream, len, num_in);
+}
+
+void EmuInstance::audioFinishBuffer(s16* stream, int len, int num_in)
+{
+    if (audioMutedByWindowFocus || audioMutedToggle || audioMutedByFastForward)
+    {
+        memset(stream, 0, len*sizeof(s16)*2);
+        audioLastFrame = 0;
+        return;
     }
 
-    if (num_in < len_in)
+    if (num_in < 1)
+    {
+        if (!audioStretchEngaged)
+        {
+            memset(stream, 0, len*sizeof(s16)*2);
+            audioLastFrame = 0;
+            return;
+        }
+
+        // Fade the last frame out across this buffer. Cutting straight to
+        // silence reads as a hard dropout, but holding it would sit on a DC
+        // offset for as long as the stall lasts.
+        s16 l = (s16)(audioLastFrame & 0xFFFF);
+        s16 r = (s16)(audioLastFrame >> 16);
+        for (int i = 0; i < len; i++)
+        {
+            int gain = ((len - i) << 8) / len;
+            stream[(i*2)+0] = (s16)(((s32)l * gain) >> 8);
+            stream[(i*2)+1] = (s16)(((s32)r * gain) >> 8);
+        }
+        audioLastFrame = 0;
+    }
+    else if (num_in < len)
     {
         int last = num_in-1;
 
-        for (int i = num_in; i < len_in; i++)
+        for (int i = num_in; i < len; i++)
             ((u32*)stream)[i] = ((u32*)stream)[last];
+    }
+
+    int lowPassRef = audioLowPassEnable.load(std::memory_order_relaxed)
+                     ? audioSpeedUpLowPass.load(std::memory_order_relaxed)
+                     : kSpeedUpLowPassOff;
+    double cutoff = audioComputeLowPassCutoff(curFPS, targetFPS, lowPassRef,
+                                              audioLowPass.WideOpenCutoff());
+    audioLowPass.Process((int16_t*) stream, len, cutoff, len / (double)audioFreq);
+
+    // Pre-volume, so the fade path above can be re-scaled consistently.
+    if (len > 0) audioLastFrame = ((u32*)stream)[len-1];
+
+    if (audioVolume < 256)
+    {
+        for (int i = 0; i < len * 2; i++)
+            stream[i] = ((s32) stream[i] * audioVolume) >> 8;
     }
 }
 
@@ -494,6 +580,15 @@ void EmuInstance::micCallback(void* data, Uint8* stream, int len)
 
 
 
+// atomics, so the audio settings dialog can apply these live with everything
+// running - which is what lets the cutoff be set by ear during fast-forward
+void EmuInstance::audioUpdateSpeedUpSettings()
+{
+    audioSpeedUpLowPass.store(globalCfg.GetInt("SpeedUpLowPass"), std::memory_order_relaxed);
+    audioTimeStretchEnable.store(globalCfg.GetBool("SpeedUpTimeStretch"), std::memory_order_relaxed);
+    audioLowPassEnable.store(globalCfg.GetBool("SpeedUpLowPassEnable"), std::memory_order_relaxed);
+}
+
 void EmuInstance::audioUpdateSettings()
 {
     if (micStarted) micClose();
@@ -504,12 +599,21 @@ void EmuInstance::audioUpdateSettings()
         nds->SPU.SetInterpolation(static_cast<AudioInterpolation>(audiointerp));
     }
 
+    audioUpdateSpeedUpSettings();
+
     setupMicInputData();
     if (micStarted) micOpen();
 }
 
 void EmuInstance::audioEnable()
 {
+    // Covers emulator reset and savestate load, which bracket with
+    // audioDisable/audioEnable - otherwise pre-reset audio splices into post.
+    audioTimeStretch.Reset();
+    audioStretchEngaged = false;
+    audioLastFrame = 0;
+    audioArrivalAvg = 0.0;
+
     if (audioDevice) SDL_PauseAudioDevice(audioDevice, 0);
     if (micStarted) micOpen();
 }

--- a/src/frontend/qt_sdl/EmuInstanceAudio.cpp
+++ b/src/frontend/qt_sdl/EmuInstanceAudio.cpp
@@ -43,11 +43,8 @@ void EmuInstance::audioInit()
     audioSyncLock = SDL_CreateMutex();
 
     audioFreq = 48000; // TODO: make both of these configurable?
-    // 256 rather than 512: the callback is what drains the SPU's 2048-frame
-    // output ring, so the period sets the ceiling on how fast the emulator can
-    // run before that ring overflows - 2047/256 is ~8x against ~4x at 512. It
-    // also halves output latency. The cost is less scheduling slack per
-    // callback, so a heavily loaded host glitches sooner.
+    // 256 rather than 512, for the halved output latency. this used to also cap
+    // emulation speed, back when the callback drained the SPU ring.
     audioBufSize = 256;
 
     SDL_AudioSpec whatIwant, whatIget;
@@ -72,14 +69,17 @@ void EmuInstance::audioInit()
         SDL_PauseAudioDevice(audioDevice, 1);
     }
 
-    audioSpeedUpLowPass.store(globalCfg.GetInt("SpeedUpLowPass"), std::memory_order_relaxed);
-    audioTimeStretchEnable.store(globalCfg.GetBool("SpeedUpTimeStretch"), std::memory_order_relaxed);
-    audioLowPassEnable.store(globalCfg.GetBool("SpeedUpLowPassEnable"), std::memory_order_relaxed);
+    audioUpdateSpeedUpSettings();
     audioLowPass.Init(audioFreq);
     audioTimeStretch.Reset();
     audioStretchEngaged = false;
     audioLastFrame = 0;
     audioArrivalAvg = 0.0;
+    audioLastOffered = 0;
+    audioOfferedFrames.store(0, std::memory_order_relaxed);
+    audioMeasuredFPS.store(0.0, std::memory_order_relaxed);
+    audioSampleFrac = 0.0;
+    audioDrainEngaged = false;
 
     micStarted = false;
     micDevice = 0;
@@ -147,6 +147,58 @@ void EmuInstance::updateFastForwardMute(bool fastForward)
     audioMutedByFastForward = fastForward && globalCfg.GetBool("MuteFastForward");
 }
 
+bool EmuInstance::audioOffSpeed() const
+{
+    // both threads decide through here which of them owns the SPU FIFO. they
+    // can disagree for one buffer across a speed change; it self-corrects.
+    if (!audioTimeStretchEnable.load(std::memory_order_relaxed)) return false;
+    return audioIsOffSpeed(curFPS, targetFPS);
+}
+
+void EmuInstance::audioDrainSPU()
+{
+    // draining here rather than from the audio callback is what removes the
+    // speed ceiling: the callback could only take one ring's worth per period
+    if (!audioDevice || !audioOffSpeed())
+    {
+        audioDrainEngaged = false;
+        return;
+    }
+
+    if (!audioDrainEngaged)
+    {
+        audioDrainEngaged = true;
+        audioTimeStretch.BeginSession();
+    }
+
+    SDL_LockMutex(audioSyncLock);
+    int avail = nds->SPU.GetOutputSize();
+    if (avail > kAudioDrainMax) avail = kAudioDrainMax;
+    int got = (avail > 0) ? nds->SPU.ReadOutput(audioDrainTemp, avail) : 0;
+    SDL_CondSignal(audioSyncCond);
+    SDL_UnlockMutex(audioSyncLock);
+
+    if (got > 0)
+    {
+        audioOfferedFrames.fetch_add(got, std::memory_order_release);
+
+        // frames are already out of the SPU FIFO, so a short accept loses them.
+        // mark the discontinuity so it resyncs rather than splicing.
+        if (audioTimeStretch.Write(audioDrainTemp, got) < got)
+            audioTimeStretch.BeginSession();
+    }
+}
+
+void EmuInstance::audioMarkDiscontinuity()
+{
+    audioTimeStretch.BeginSession();
+}
+
+void EmuInstance::audioSetMeasuredFPS(double fps)
+{
+    audioMeasuredFPS.store(fps, std::memory_order_relaxed);
+}
+
 void EmuInstance::audioSync()
 {
     if (audioDevice)
@@ -166,21 +218,11 @@ void EmuInstance::audioCallback(void* data, Uint8* stream, int len)
     EmuInstance* inst = (EmuInstance*)data;
     len /= (sizeof(s16) * 2);
 
-    // Pitch-correct regardless of speed; the stretcher fits the audio to the
-    // output. A skew derived from curFPS would resample and shift pitch.
-    inst->nds->SPU.SetOutputSkew(audioComputeOutputSkew(inst->targetFPS));
-
-    bool offSpeed = inst->audioTimeStretchEnable.load(std::memory_order_relaxed)
-                    && audioIsOffSpeed(inst->curFPS, inst->targetFPS);
-
-    if (!offSpeed)
+    if (!inst->audioOffSpeed())
     {
-        // Normal speed gets its own branch, so it cannot regress.
-        if (inst->audioStretchEngaged)
-        {
-            inst->audioTimeStretch.Reset();
-            inst->audioStretchEngaged = false;
-        }
+        // no Reset() here: this is the audio thread, and the emu thread can
+        // still be inside Write. re-engaging resyncs via BeginSession anyway.
+        inst->audioStretchEngaged = false;
         inst->audioDirectRead((s16*) stream, len);
         return;
     }
@@ -193,10 +235,28 @@ void EmuInstance::audioCallback(void* data, Uint8* stream, int len)
     inst->audioStretchedRead((s16*) stream, len);
 }
 
+// how much input one output buffer is worth at the current speed. without this
+// the direct path consumes faster than the SPU fills and gates to silence.
+int EmuInstance::audioGetNumSamplesOut(int outlen)
+{
+    double f_len_in = (outlen * audioSpeedRatio(curFPS, targetFPS)) + audioSampleFrac;
+
+    // capped before the cast: targetFPS goes down to 0.0001, which would
+    // otherwise make this far too large for an int
+    if (f_len_in > outlen) f_len_in = outlen;
+    if (f_len_in < 0.0) f_len_in = 0.0;
+
+    int len_in = (int)f_len_in;
+    audioSampleFrac = f_len_in - len_in;
+    return len_in;
+}
+
 void EmuInstance::audioDirectRead(s16* stream, int len)
 {
+    int len_in = audioGetNumSamplesOut(len);
+
     SDL_LockMutex(audioSyncLock);
-    int num_in = nds->SPU.ReadOutput(stream, len);
+    int num_in = nds->SPU.ReadOutput(stream, len_in);
     SDL_CondSignal(audioSyncCond);
     SDL_UnlockMutex(audioSyncLock);
 
@@ -205,26 +265,41 @@ void EmuInstance::audioDirectRead(s16* stream, int len)
 
 void EmuInstance::audioStretchedRead(s16* stream, int len)
 {
-    SDL_LockMutex(audioSyncLock);
-    int avail = nds->SPU.GetOutputSize();
-    if (avail > kAudioDrainMax) avail = kAudioDrainMax;
-    int got = (avail > 0) ? nds->SPU.ReadOutput(audioStretchTemp, avail) : 0;
-    SDL_CondSignal(audioSyncCond);
-    SDL_UnlockMutex(audioSyncLock);
+    // the emu thread fills the stretcher; what it has offered gives us the
+    // arrival rate, which is lumpy, so smooth it before using it as a rate
+    melonDS::s64 offered = audioOfferedFrames.load(std::memory_order_acquire);
+    melonDS::s64 delta = offered - audioLastOffered;
+    if (delta < 0) delta = 0;
+    audioLastOffered = offered;
 
-    if (got > 0)
-        audioTimeStretch.Write(audioStretchTemp, got);
-
-    // Arrival is lumpy - the emu thread delivers in bursts - so smooth it before
-    // using it as the rate.
-    audioArrivalAvg += (got - audioArrivalAvg) * 0.05;
+    audioArrivalAvg += (delta - audioArrivalAvg) * 0.05;
 
     double ratio = audioComputeStretchRatio(audioArrivalAvg, len,
                                             audioTimeStretch.InputFill(),
-                                            AudioTimeStretch::kTargetInputFill);
+                                            AudioTimeStretch::TargetInputFill(audioArrivalAvg));
     int num_in = audioTimeStretch.Read(stream, len, ratio);
 
     audioFinishBuffer(stream, len, num_in);
+}
+
+double EmuInstance::audioLowPassCutoff() const
+{
+    int ref = audioLowPassEnable.load(std::memory_order_relaxed)
+              ? audioSpeedUpLowPass.load(std::memory_order_relaxed)
+              : kSpeedUpLowPassOff;
+
+    // the setpoint decides whether we are off-speed at all, so that normal
+    // speed stays exactly transparent and measurement jitter can't engage the
+    // filter. how far off-speed comes from the achieved rate: curFPS is 1000
+    // for an uncapped fast-forward and would over-filter by the shortfall.
+    double fps = curFPS;
+    if (audioIsOffSpeed(curFPS, targetFPS))
+    {
+        double measured = audioMeasuredFPS.load(std::memory_order_relaxed);
+        if (measured > 0.0) fps = measured;
+    }
+
+    return audioComputeLowPassCutoff(fps, targetFPS, ref, audioLowPass.WideOpenCutoff());
 }
 
 void EmuInstance::audioFinishBuffer(s16* stream, int len, int num_in)
@@ -233,6 +308,9 @@ void EmuInstance::audioFinishBuffer(s16* stream, int len, int num_in)
     {
         memset(stream, 0, len*sizeof(s16)*2);
         audioLastFrame = 0;
+        // keep the cutoff smoother moving while muted, or re-engaging clicks.
+        // with MuteFastForward on, this path is the fast-forward case.
+        audioLowPass.ProcessMuted(len, audioLowPassCutoff(), len / (double)audioFreq);
         return;
     }
 
@@ -245,9 +323,8 @@ void EmuInstance::audioFinishBuffer(s16* stream, int len, int num_in)
             return;
         }
 
-        // Fade the last frame out across this buffer. Cutting straight to
-        // silence reads as a hard dropout, but holding it would sit on a DC
-        // offset for as long as the stall lasts.
+        // fade the last frame out across this buffer. cutting straight to
+        // silence reads as a dropout, holding it sits on a DC offset.
         s16 l = (s16)(audioLastFrame & 0xFFFF);
         s16 r = (s16)(audioLastFrame >> 16);
         for (int i = 0; i < len; i++)
@@ -256,7 +333,6 @@ void EmuInstance::audioFinishBuffer(s16* stream, int len, int num_in)
             stream[(i*2)+0] = (s16)(((s32)l * gain) >> 8);
             stream[(i*2)+1] = (s16)(((s32)r * gain) >> 8);
         }
-        audioLastFrame = 0;
     }
     else if (num_in < len)
     {
@@ -266,14 +342,10 @@ void EmuInstance::audioFinishBuffer(s16* stream, int len, int num_in)
             ((u32*)stream)[i] = ((u32*)stream)[last];
     }
 
-    int lowPassRef = audioLowPassEnable.load(std::memory_order_relaxed)
-                     ? audioSpeedUpLowPass.load(std::memory_order_relaxed)
-                     : kSpeedUpLowPassOff;
-    double cutoff = audioComputeLowPassCutoff(curFPS, targetFPS, lowPassRef,
-                                              audioLowPass.WideOpenCutoff());
-    audioLowPass.Process((int16_t*) stream, len, cutoff, len / (double)audioFreq);
+    audioLowPass.Process((int16_t*) stream, len, audioLowPassCutoff(),
+                         len / (double)audioFreq);
 
-    // Pre-volume, so the fade path above can be re-scaled consistently.
+    // pre-volume, so the fade path above can be re-scaled consistently
     if (len > 0) audioLastFrame = ((u32*)stream)[len-1];
 
     if (audioVolume < 256)
@@ -589,6 +661,7 @@ void EmuInstance::audioUpdateSpeedUpSettings()
     audioLowPassEnable.store(globalCfg.GetBool("SpeedUpLowPassEnable"), std::memory_order_relaxed);
 }
 
+// from the audio settings dialog, which does not pause the emu thread
 void EmuInstance::audioUpdateSettings()
 {
     if (micStarted) micClose();
@@ -605,14 +678,35 @@ void EmuInstance::audioUpdateSettings()
     if (micStarted) micOpen();
 }
 
+// from the interface settings dialog, and it has to stay there: SetOutputSkew
+// reaches blip_set_rates, which the emu thread reads with no lock, and that
+// dialog is the only settings path that pauses.
+void EmuInstance::audioUpdateOutputSkew()
+{
+    if (nds != nullptr) nds->SPU.SetOutputSkew(audioComputeOutputSkew(targetFPS));
+}
+
 void EmuInstance::audioEnable()
 {
-    // Covers emulator reset and savestate load, which bracket with
-    // audioDisable/audioEnable - otherwise pre-reset audio splices into post.
+    // covers emulator reset, which brackets with audioDisable/audioEnable,
+    // else pre-reset audio splices into post. savestate load does not come
+    // through here at all - see audioMarkDiscontinuity. Reset clears state the
+    // audio thread owns, so hold the device lock.
+    if (audioDevice) SDL_LockAudioDevice(audioDevice);
     audioTimeStretch.Reset();
     audioStretchEngaged = false;
     audioLastFrame = 0;
     audioArrivalAvg = 0.0;
+    audioLastOffered = 0;
+    audioOfferedFrames.store(0, std::memory_order_relaxed);
+    audioSampleFrac = 0.0;
+    audioDrainEngaged = false;
+    if (audioDevice) SDL_UnlockAudioDevice(audioDevice);
+
+    // the skew depends only on targetFPS, so it doesn't belong in the audio
+    // callback, where it raced SPU::Reset through blip_set_rates. here and in
+    // audioUpdateOutputSkew covers every time it can change.
+    if (nds != nullptr) nds->SPU.SetOutputSkew(audioComputeOutputSkew(targetFPS));
 
     if (audioDevice) SDL_PauseAudioDevice(audioDevice, 0);
     if (micStarted) micOpen();

--- a/src/frontend/qt_sdl/EmuThread.cpp
+++ b/src/frontend/qt_sdl/EmuThread.cpp
@@ -376,6 +376,8 @@ void EmuThread::run()
                 emuInstance->audioVolume = volumeLevel * (256.0 / 31.0);
             }
 
+            emuInstance->audioDrainSPU();
+
             if (emuInstance->doAudioSync && !(fastforward || slowmo))
                 emuInstance->audioSync();
 
@@ -412,6 +414,7 @@ void EmuThread::run()
                 lastMeasureTime = time;
 
                 u32 fps = round(nframes / dt);
+                if (dt > 0.0) emuInstance->audioSetMeasuredFPS(nframes / dt);
                 nframes = 0;
 
                 float fpstarget = 1.0/frametimeStep;
@@ -428,6 +431,7 @@ void EmuThread::run()
         else
         {
             // paused
+            emuInstance->audioSetMeasuredFPS(0.0);
             nframes = 0;
             lastTime = SDL_GetPerformanceCounter() * perfCountsSec;
             lastMeasureTime = lastTime;
@@ -622,10 +626,12 @@ void EmuThread::handleMessages()
 
         case msg_LoadState:
             msgResult = emuInstance->loadState(msg.param.value<QString>().toStdString());
+            emuInstance->audioMarkDiscontinuity();
             break;
 
         case msg_UndoStateLoad:
             emuInstance->undoStateLoad();
+            emuInstance->audioMarkDiscontinuity();
             msgResult = 1;
             break;
 

--- a/src/frontend/qt_sdl/Window.cpp
+++ b/src/frontend/qt_sdl/Window.cpp
@@ -751,7 +751,7 @@ MainWindow::MainWindow(int id, EmuInstance* inst, QWidget* parent) :
     }
 
     QObject::connect(qApp, &QApplication::applicationStateChanged, this, &MainWindow::onAppStateChanged);
-    onUpdateInterfaceSettings();
+    applyInterfaceSettings();
 
     updateMPInterface(MPInterface::GetType());
 }
@@ -1993,6 +1993,16 @@ void MainWindow::onOpenInterfaceSettings()
 }
 
 void MainWindow::onUpdateInterfaceSettings()
+{
+    applyInterfaceSettings();
+
+    // only from the settings dialog, which pauses first: this reaches
+    // blip_set_rates, which is not safe against a running emu thread. opening
+    // a new window must not come through here.
+    emuInstance->audioUpdateOutputSkew();
+}
+
+void MainWindow::applyInterfaceSettings()
 {
     pauseOnLostFocus = globalCfg.GetBool("PauseLostFocus");
     emuInstance->targetFPS = globalCfg.GetDouble("TargetFPS");

--- a/src/frontend/qt_sdl/Window.cpp
+++ b/src/frontend/qt_sdl/Window.cpp
@@ -1930,6 +1930,9 @@ void MainWindow::onUpdateAudioVolume(int vol, int dsisync)
 
 void MainWindow::onUpdateAudioSettings()
 {
+    // before the emuIsActive check: these are atomics and need no console
+    emuInstance->audioUpdateSpeedUpSettings();
+
     if (!emuThread->emuIsActive()) return;
     assert(emuInstance->nds != nullptr);
 

--- a/src/frontend/qt_sdl/Window.h
+++ b/src/frontend/qt_sdl/Window.h
@@ -188,6 +188,10 @@ private slots:
 private:
     virtual void closeEvent(QCloseEvent* event) override;
 
+    // the part of the interface settings a new window has to pick up. kept out
+    // of the slot because that one also touches audio, which needs a pause.
+    void applyInterfaceSettings();
+
     QStringList currentROM;
     QStringList currentGBAROM;
     QList<QString> recentFileList;

--- a/tools/audiobench.cpp
+++ b/tools/audiobench.cpp
@@ -1,0 +1,314 @@
+/*
+    Copyright 2016-2026 melonDS team
+
+    This file is part of melonDS.
+
+    melonDS is free software: you can redistribute it and/or modify it under
+    the terms of the GNU General Public License as published by the Free
+    Software Foundation, either version 3 of the License, or (at your option)
+    any later version.
+
+    melonDS is distributed in the hope that it will be useful, but WITHOUT ANY
+    WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+    FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with melonDS. If not, see http://www.gnu.org/licenses/.
+*/
+
+// measurement tool for the off-speed audio path. not part of the build.
+//
+//   g++ -std=c++17 -O2 -pthread -I src/frontend/qt_sdl -o build/audiobench tools/audiobench.cpp
+//   ./build/audiobench
+//
+// rebuild with -O1 -g -fsanitize=thread for the race check; the stress section
+// is what exercises the producer/consumer boundary.
+//
+// three sections:
+//   pipeline  where audio is lost, and to what, at each speed and drain mode
+//   cost      CPU the stretcher and filter actually consume
+//   stress    two real threads across the SPSC ring, with a tearing detector
+//
+// the tearing detector compares L against R, so it catches a torn read of
+// InL/InR. it is blind to InMono, which only steers which offset gets picked.
+
+#include <atomic>
+#include <chrono>
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <thread>
+#include <vector>
+
+#include "AudioTimeStretch.h"
+#include "AudioSpeed.h"
+#include "AudioLowPass.h"
+
+static constexpr double kFs = 48000.0;
+
+// mirrors of constants owned elsewhere, so this tool stays standalone
+static constexpr int kSpuFifo = 2048;    // SPU::InitOutput -> OutputBufferSize
+static constexpr int kDrainMax = 2048;   // kAudioDrainMax in EmuInstance.h
+static constexpr double kInternalFps = 59.8260982880808;
+
+// ---------------------------------------------------------------- pipeline --
+
+struct PipeResult
+{
+    long long callbacks, underruns, silent;
+    double meanFill, realFrac, survived;
+};
+
+// drainPerEmuFrame: the emu thread drains after every emulated frame. otherwise
+// only the callback drains, capping speed at roughly kSpuFifo / audioBufSize.
+static PipeResult pipeline(double speed, int audioBufSize, bool drainPerEmuFrame,
+                           double seconds)
+{
+    AudioTimeStretch ts;
+    ts.Reset();
+
+    const int len = audioBufSize;
+    const double callbackPeriod = len / kFs;
+    const double emuFramePeriod = 1.0 / (kInternalFps * speed);
+    const double framesPerEmuFrame = kFs / kInternalFps;
+
+    std::vector<int16_t> in(kDrainMax * 2), out(len * 2);
+    double carry = 0.0;
+    int spuPending = 0;
+    long long totalMade = 0, totalGot = 0, realFrames = 0;
+    double fillSum = 0.0;
+    double arrivalAvg = len * speed;
+    long long lastWritten = 0;
+    double tEmu = 0.0, tCb = 0.0;
+    PipeResult r{0, 0, 0, 0.0, 0.0, 0.0};
+
+    auto ingest = [&](int n) {
+        if (n <= 0) return;
+        for (int i = 0; i < n; i++) { in[(i*2)+0] = (int16_t)i; in[(i*2)+1] = (int16_t)i; }
+        ts.Write(in.data(), n);
+    };
+
+    auto drain = [&]() {
+        int got = spuPending;
+        if (got > kDrainMax) got = kDrainMax;
+        spuPending -= got;
+        totalGot += got;
+        ingest(got);
+    };
+
+    while (tCb < seconds)
+    {
+        // advance emulated frames up to the next callback
+        while (tEmu + emuFramePeriod <= tCb + callbackPeriod)
+        {
+            tEmu += emuFramePeriod;
+            carry += framesPerEmuFrame;
+            int made = (int)carry; carry -= made;
+            spuPending += made;
+            totalMade += made;
+            if (spuPending > kSpuFifo) spuPending = kSpuFifo;  // BufferAudio discards
+            if (drainPerEmuFrame) drain();
+        }
+
+        tCb += callbackPeriod;
+        if (!drainPerEmuFrame) drain();
+
+        long long written = ts.TotalWritten();
+        long long delta = written - lastWritten;
+        if (delta < 0) delta = 0;
+        lastWritten = written;
+        arrivalAvg += (delta - arrivalAvg) * 0.05;
+
+        int fill = ts.InputFill();
+        double ratio = audioComputeStretchRatio(arrivalAvg, len, fill,
+                                                AudioTimeStretch::TargetInputFill(arrivalAvg));
+        int n = ts.Read(out.data(), len, ratio);
+
+        r.callbacks++;
+        if (n < len) r.underruns++;
+        if (n < 1) r.silent++;
+        fillSum += fill;
+        realFrames += n;
+    }
+
+    r.meanFill = fillSum / r.callbacks;
+    r.realFrac = realFrames / (double)(r.callbacks * len);
+    r.survived = totalMade ? (totalGot / (double)totalMade) : 1.0;
+    return r;
+}
+
+static void runPipeline()
+{
+    printf("== pipeline ==\n");
+    printf("output%% is how much of each buffer was real audio rather than padding.\n"
+           "input%% is how much of what the SPU generated survived its ring.\n\n");
+
+    const double speeds[] = {0.5, 1.5, 2.0, 3.0, 4.0, 8.0, 16.7};
+    for (int bufSize : {512, 256})
+    {
+        for (int mode = 0; mode < 2; mode++)
+        {
+            bool emuDrain = (mode == 1);
+            printf("audioBufSize %3d, drained by %s:\n", bufSize,
+                   emuDrain ? "emu thread " : "callback   ");
+            for (double s : speeds)
+            {
+                PipeResult r = pipeline(s, bufSize, emuDrain, 8.0);
+                printf("  %5.1fx  underruns %5.1f%%  output %5.1f%%  input %5.1f%%\n",
+                       s, 100.0 * r.underruns / r.callbacks,
+                       100.0 * r.realFrac, 100.0 * r.survived);
+            }
+            printf("\n");
+        }
+    }
+}
+
+// -------------------------------------------------------------------- cost --
+
+static volatile long long g_sink = 0;
+
+static void runCost()
+{
+    printf("== cost ==\n");
+    printf("Noise input, the worst case for the similarity search.\n\n");
+
+    const int len = 256;
+    const double seconds = 15.0;
+    const int callbacks = (int)(seconds * kFs / len);
+    const int poolFrames = 1 << 20;
+
+    std::vector<int16_t> pool(poolFrames * 2);
+    srand(7);
+    double y = 0.0;
+    for (int i = 0; i < poolFrames; i++)
+    {
+        double n = ((rand() / (double)RAND_MAX) * 2.0 - 1.0) * 9000.0;
+        y = (0.6 * y) + (0.4 * n);
+        int16_t q = (int16_t)std::lround(y);
+        pool[(i*2)+0] = q; pool[(i*2)+1] = q;
+    }
+
+    for (double ratio : {1.0, 2.0, 3.0, 4.0, 8.0})
+    {
+        AudioTimeStretch ts; ts.Reset();
+        AudioLowPass lp; lp.Init(kFs);
+        std::vector<int16_t> out(len * 2);
+        double carry = 0.0;
+        int pos = 0;
+
+        auto t0 = std::chrono::steady_clock::now();
+        for (int c = 0; c < callbacks; c++)
+        {
+            carry += len * ratio;
+            int got = (int)carry; carry -= got;
+            if (got > kDrainMax) got = kDrainMax;
+            if (pos + got > poolFrames) pos = 0;
+            ts.Write(&pool[pos*2], got);
+            pos += got;
+            int n = ts.Read(out.data(), len, ratio);
+            lp.Process(out.data(), len, 6000.0, len / kFs);
+            g_sink += n + out[0];
+        }
+        auto t1 = std::chrono::steady_clock::now();
+
+        double ms = std::chrono::duration<double, std::milli>(t1 - t0).count();
+        printf("  ratio %4.1f : %6.1f ms per %.0f s audio = %.2f%% of one core\n",
+               ratio, ms, seconds, 100.0 * (ms / 1000.0) / seconds);
+    }
+    printf("\n");
+}
+
+// ------------------------------------------------------------------ stress --
+
+static AudioTimeStretch g_ts;
+static std::atomic<bool> g_stop{false};
+static std::atomic<long long> g_written{0}, g_read{0}, g_refused{0};
+static std::atomic<long long> g_torn{0}, g_outOfRange{0}, g_sessions{0};
+static constexpr int kAmp = 9000;
+
+// per-thread state: rand() is neither reentrant nor reproducible when two
+// threads share it, and an unreplayable stress test is worth less
+static uint32_t nextRand(uint32_t& st)
+{
+    st = (st * 1664525u) + 1013904223u;
+    return st >> 16;
+}
+
+static void producer()
+{
+    std::vector<int16_t> buf(kDrainMax * 2);
+    uint32_t rng = 0xA5A5A5A5u;
+    long long t = 0;
+    int spin = 0;
+    while (!g_stop.load(std::memory_order_relaxed))
+    {
+        int n = 64 + (nextRand(rng) % 1900);
+        for (int i = 0; i < n; i++)
+        {
+            double v = kAmp * std::sin(2.0 * M_PI * 440.0 * ((t + i) / kFs));
+            int16_t s = (int16_t)std::lround(v);
+            buf[(i*2)+0] = s;
+            buf[(i*2)+1] = s;              // L == R, always
+        }
+        t += n;
+        int took = g_ts.Write(buf.data(), n);
+        g_written.fetch_add(took, std::memory_order_relaxed);
+        if (took < n) g_refused.fetch_add(n - took, std::memory_order_relaxed);
+        if (++spin % 500 == 0) { g_ts.BeginSession(); g_sessions.fetch_add(1, std::memory_order_relaxed); }
+        if ((spin % 7) == 0) std::this_thread::yield();
+    }
+}
+
+static void consumer()
+{
+    const int len = 256;
+    uint32_t rng = 0x5A5A5A5Au;
+    std::vector<int16_t> out(len * 2);
+    while (!g_stop.load(std::memory_order_relaxed))
+    {
+        double ratio = 0.5 + ((nextRand(rng) % 700) / 100.0);
+        int n = g_ts.Read(out.data(), len, ratio);
+        g_read.fetch_add(n, std::memory_order_relaxed);
+        for (int i = 0; i < n; i++)
+        {
+            // input frames all have L == R and both channels get the same
+            // window and offset, so a difference means a torn read
+            if (out[(i*2)+0] != out[(i*2)+1]) g_torn.fetch_add(1, std::memory_order_relaxed);
+            if (std::abs((int)out[(i*2)]) > kAmp + 2000) g_outOfRange.fetch_add(1, std::memory_order_relaxed);
+        }
+        std::this_thread::yield();
+    }
+}
+
+static int runStress(int seconds)
+{
+    printf("== stress ==\n");
+    srand(12345);
+    g_ts.Reset();
+
+    std::thread p(producer), c(consumer);
+    std::this_thread::sleep_for(std::chrono::seconds(seconds));
+    g_stop.store(true, std::memory_order_relaxed);
+    p.join(); c.join();
+
+    printf("  %ds: written %lld, read %lld, refused %lld, sessions %lld\n",
+           seconds, g_written.load(), g_read.load(), g_refused.load(), g_sessions.load());
+    printf("  torn frames (L != R): %lld\n", g_torn.load());
+    printf("  out-of-range samples: %lld\n", g_outOfRange.load());
+
+    bool ok = (g_torn.load() == 0) && (g_outOfRange.load() == 0)
+              && (g_written.load() > 0) && (g_read.load() > 0);
+    printf("  %s\n\n", ok ? "PASS" : "FAIL");
+    return ok ? 0 : 1;
+}
+
+int main(int argc, char** argv)
+{
+    int stressSeconds = (argc > 1) ? atoi(argv[1]) : 5;
+    runPipeline();
+    runCost();
+    int rc = runStress(stressSeconds);
+    if (g_sink == 0x7fffffff) printf("unreachable\n");
+    return rc;
+}


### PR DESCRIPTION
After working on [this other PR for sound settings](https://github.com/melonDS-emu/melonDS/pull/2736), I realized there were probably better audio enhancements that could be made when doing ff and slow-mo, so I worked on a two-part audio filter that applies when the game is fast-forwarded (or unbound FPS) and slo-mo'd. The PR is split into 3 commits, with the last 2 able to be dropped if not desired.

<img width="577" height="540" alt="image" src="https://github.com/user-attachments/assets/147304b9-6a48-4efa-8ac6-deae0163e285" />

The first commit is the audio filter itself, and should work properly at up to 8x speedup. There's both a WSOLA stretcher to preserve pitch when stretching, and a Butterworth low pass filter to help cut some of the crunchier noises at fast speeds. This also adds a menu item so you can toggle the feature on/off and decide the frequency cutoff for the low-pass filter.

The second commit is some threading code to make this actually work "correctly" at higher than 8x speed. At more than 8x speedup, the audio output actually skips, though in practice this is kind of hard to hear. I tested this using the tsan build though the emulator runs very slow under these conditions, so it's hard to exactly make sure everything is correct, though I think the theory is right. It deserves some review though.

The last commit is some benchmarking which helped me figure out some of the original implementation details and why the emu-thread implementation was actually needed at all for correctness, though this can be dropped or wired into the CMake build if desired.

Overall I think even just the first commit which is basically pure algorithm implementations help a lot when playing games at speedup, especially the common case of playing pokemon games fast for grinding or whatnot. I'm happy to make adjustments where needed to improve this.

### License Provenance
I'm working on this same feature in RetroArch as well. [It's more involved](https://github.com/libretro/RetroArch/pull/19512) however the core is the same WSOLA and butterworth filters.