### PR TITLE
Accept .srm save file extension

### DIFF
--- a/src/frontend/qt_sdl/CMakeLists.txt
+++ b/src/frontend/qt_sdl/CMakeLists.txt
@@ -26,6 +26,7 @@ set(SOURCES_QT_SDL
     AudioSettingsDialog.cpp
     FirmwareSettingsDialog.cpp
     PathSettingsDialog.cpp
+    SaveConversionDialog.cpp
     MPSettingsDialog.cpp
     WifiSettingsDialog.cpp
     InterfaceSettingsDialog.cpp

--- a/src/frontend/qt_sdl/Config.cpp
+++ b/src/frontend/qt_sdl/Config.cpp
@@ -112,13 +112,15 @@ DefaultList<bool> DefaultBools =
 #endif
     {"DSi.DSP.HLE", true},
     {"Instance*.RTC.SyncToHost", true},
+    {"ShowSaveExtWarning", true},
 };
 
 DefaultList<std::string> DefaultStrings =
 {
     {"DLDI.ImagePath",                  "dldi.bin"},
     {"DSi.SD.ImagePath",                "dsisd.bin"},
-    {"Instance*.Firmware.Username",     "melonDS"}
+    {"Instance*.Firmware.Username",     "melonDS"},
+    {"Instance*.SaveFileExtension",     ".sav"}
 };
 
 DefaultList<double> DefaultDoubles =

--- a/src/frontend/qt_sdl/EmuInstance.cpp
+++ b/src/frontend/qt_sdl/EmuInstance.cpp
@@ -489,6 +489,88 @@ string EmuInstance::getAssetPath(bool gba, const string& configpath, const strin
     return result;
 }
 
+// .srm is what RetroArch writes; the contents are byte-identical to .sav
+static const char* const kSaveExtensions[2] = { ".sav", ".srm" };
+
+std::string EmuInstance::getSaveFileExtension()
+{
+    std::string ext = localCfg.GetString("SaveFileExtension");
+    for (const char* e : kSaveExtensions)
+        if (ext == e) return ext;
+
+    // don't build save paths out of an arbitrary hand-edited string
+    return kSaveExtensions[0];
+}
+
+std::string EmuInstance::getSaveFilePath(bool gba)
+{
+    return getAssetPath(gba, localCfg.GetString("SaveFilePath"), getSaveFileExtension())
+           + instanceFileSuffix();
+}
+
+// Writes always use the configured extension. Reads take the first existing of
+// <configured><suffix>, <configured>, <other><suffix>, <other>, so the configured
+// extension wins when both are present.
+EmuInstance::SavePathInfo EmuInstance::resolveSaveFilePaths(bool gba)
+{
+    SavePathInfo info;
+
+    std::string cfgpath = localCfg.GetString("SaveFilePath");
+    std::string ext = getSaveFileExtension();
+    std::string suffix = instanceFileSuffix();
+
+    info.writePath = getAssetPath(gba, cfgpath, ext) + suffix;
+    info.writeExt = ext;
+
+    std::string other = (ext == kSaveExtensions[0]) ? kSaveExtensions[1] : kSaveExtensions[0];
+    const std::string order[2] = { ext, other };
+
+    for (const std::string& e : order)
+    {
+        std::string base = getAssetPath(gba, cfgpath, e);
+
+        if (!suffix.empty() && Platform::FileExists(base + suffix))
+            info.readPath = base + suffix;
+        else if (Platform::FileExists(base))
+            info.readPath = base;
+        else
+            continue;
+
+        info.readExt = e;
+        info.extFallback = (e != ext);
+        break;
+    }
+
+    return info;
+}
+
+std::string EmuInstance::saveOverwrittenBySettings(const std::string& cfgpath, const std::string& ext)
+{
+    std::string suffix = instanceFileSuffix();
+
+    for (bool gba : {false, true})
+    {
+        SaveManager* mgr = gba ? gbaSave.get() : ndsSave.get();
+        if (!mgr) continue;
+
+        std::string newpath = getAssetPath(gba, cfgpath, ext) + suffix;
+        if (newpath != mgr->GetPath() && Platform::FileExists(newpath))
+            return newpath;
+    }
+
+    return "";
+}
+
+bool EmuInstance::takeSaveExtFallback(bool gba, SavePathInfo& out)
+{
+    SavePathInfo& fb = gba ? gbaSaveFallback : ndsSaveFallback;
+    if (!fb.extFallback) return false;
+
+    out = fb;
+    fb = SavePathInfo();
+    return true;
+}
+
 
 QString EmuInstance::verifyDSBIOS()
 {
@@ -1405,8 +1487,7 @@ void EmuInstance::reset()
     if ((cartType != -1) && ndsSave)
     {
         std::string oldsave = ndsSave->GetPath();
-        std::string newsave = getAssetPath(false, localCfg.GetString("SaveFilePath"), ".sav");
-        newsave += instanceFileSuffix();
+        std::string newsave = getSaveFilePath(false);
         if (oldsave != newsave)
             ndsSave->SetPath(newsave, false);
     }
@@ -1414,8 +1495,7 @@ void EmuInstance::reset()
     if ((gbaCartType != -1) && gbaSave)
     {
         std::string oldsave = gbaSave->GetPath();
-        std::string newsave = getAssetPath(true, localCfg.GetString("SaveFilePath"), ".sav");
-        newsave += instanceFileSuffix();
+        std::string newsave = getSaveFilePath(true);
         if (oldsave != newsave)
             gbaSave->SetPath(newsave, false);
     }
@@ -1883,26 +1963,21 @@ bool EmuInstance::loadROM(QStringList filepath, bool reset, QString& errorstr)
     u32 savelen = 0;
     std::unique_ptr<u8[]> savedata = nullptr;
 
-    std::string savname = getAssetPath(false, localCfg.GetString("SaveFilePath"), ".sav");
-    std::string origsav = savname;
-    savname += instanceFileSuffix();
+    SavePathInfo savepaths = resolveSaveFilePaths(false);
+    std::string savname = savepaths.writePath;
 
-    FileHandle* sav = Platform::OpenFile(savname, FileMode::Read);
-    if (!sav)
-    {
-        if (!Platform::CheckFileWritable(origsav))
-        {
-            errorstr = getSavErrorString(origsav, false);
-            return false;
-        }
+    // only set once the load succeeds, or a failed load leaves a stale record
+    ndsSaveFallback = SavePathInfo();
 
-        sav = Platform::OpenFile(origsav, FileMode::Read);
-    }
-    else if (!Platform::CheckFileWritable(savname))
+    if (!Platform::CheckFileWritable(savname))
     {
         errorstr = getSavErrorString(savname, false);
         return false;
     }
+
+    FileHandle* sav = savepaths.readPath.empty()
+        ? nullptr
+        : Platform::OpenFile(savepaths.readPath, FileMode::Read);
 
     if (sav)
     {
@@ -1969,6 +2044,7 @@ bool EmuInstance::loadROM(QStringList filepath, bool reset, QString& errorstr)
 
     cartType = 0;
     ndsSave = std::make_unique<SaveManager>(savname);
+    ndsSaveFallback = savepaths;
 
     return true; // success
 }
@@ -1976,6 +2052,7 @@ bool EmuInstance::loadROM(QStringList filepath, bool reset, QString& errorstr)
 void EmuInstance::ejectCart()
 {
     ndsSave = nullptr;
+    ndsSaveFallback = SavePathInfo();
 
     if (emuIsActive())
     {
@@ -2042,26 +2119,21 @@ bool EmuInstance::loadGBAROM(QStringList filepath, QString& errorstr)
     u32 savelen = 0;
     std::unique_ptr<u8[]> savedata = nullptr;
 
-    std::string savname = getAssetPath(true, localCfg.GetString("SaveFilePath"), ".sav");
-    std::string origsav = savname;
-    savname += instanceFileSuffix();
+    SavePathInfo savepaths = resolveSaveFilePaths(true);
+    std::string savname = savepaths.writePath;
 
-    FileHandle* sav = Platform::OpenFile(savname, FileMode::Read);
-    if (!sav)
-    {
-        if (!Platform::CheckFileWritable(origsav))
-        {
-            errorstr = getSavErrorString(origsav, true);
-            return false;
-        }
+    // only set once the load succeeds; see loadROM
+    gbaSaveFallback = SavePathInfo();
 
-        sav = Platform::OpenFile(origsav, FileMode::Read);
-    }
-    else if (!Platform::CheckFileWritable(savname))
+    if (!Platform::CheckFileWritable(savname))
     {
         errorstr = getSavErrorString(savname, true);
         return false;
     }
+
+    FileHandle* sav = savepaths.readPath.empty()
+        ? nullptr
+        : Platform::OpenFile(savepaths.readPath, FileMode::Read);
 
     if (sav)
     {
@@ -2095,6 +2167,8 @@ bool EmuInstance::loadGBAROM(QStringList filepath, QString& errorstr)
         changeGBACart = true;
     }
 
+    gbaSaveFallback = savepaths;
+
     return true;
 }
 
@@ -2120,6 +2194,7 @@ void EmuInstance::loadGBAAddon(int type, QString& errorstr)
     }
 
     gbaSave = nullptr;
+    gbaSaveFallback = SavePathInfo();
     gbaCartType = type;
     baseGBAROMDir = "";
     baseGBAROMName = "";
@@ -2129,6 +2204,7 @@ void EmuInstance::loadGBAAddon(int type, QString& errorstr)
 void EmuInstance::ejectGBACart()
 {
     gbaSave = nullptr;
+    gbaSaveFallback = SavePathInfo();
 
     if (emuIsActive())
     {

--- a/src/frontend/qt_sdl/EmuInstance.h
+++ b/src/frontend/qt_sdl/EmuInstance.h
@@ -87,6 +87,26 @@ public:
     EmuInstance(int inst);
     ~EmuInstance();
 
+    // Where cart save data is read from and written to. writePath always uses the
+    // configured extension; readPath may use the other one (see resolveSaveFilePaths).
+    struct SavePathInfo
+    {
+        std::string writePath;
+        std::string readPath;      // empty when no save file exists yet
+        std::string writeExt;      // the configured extension, used by writePath
+        std::string readExt;       // extension of readPath; empty when readPath is empty
+        bool extFallback = false;  // readExt differs from the configured extension
+    };
+
+    // Returns true and clears the pending record if the last load of this cart type
+    // read its save data from a file with the non-configured extension.
+    bool takeSaveExtFallback(bool gba, SavePathInfo& out);
+
+    // A loaded cart's save file that switching to these settings would start writing
+    // over, or empty if none would be. Retargeting a live SaveManager flushes the
+    // in-memory save to the new path, truncating whatever is already there.
+    std::string saveOverwrittenBySettings(const std::string& cfgpath, const std::string& ext);
+
     int getInstanceID() { return instanceID; }
     int getConsoleType() { return consoleType; }
     EmuThread* getEmuThread() { return emuThread; }
@@ -172,6 +192,9 @@ public:
 private:
     static int lastSep(const std::string& path);
     std::string getAssetPath(bool gba, const std::string& configpath, const std::string& ext, const std::string& file);
+    std::string getSaveFileExtension();
+    std::string getSaveFilePath(bool gba);
+    SavePathInfo resolveSaveFilePaths(bool gba);
 
     QString verifyDSBIOS();
     QString verifyDSiBIOS();
@@ -309,6 +332,9 @@ private:
 
     std::unique_ptr<melonDS::Savestate> backupState;
     bool savestateLoaded;
+
+    SavePathInfo ndsSaveFallback;
+    SavePathInfo gbaSaveFallback;
 
     std::unique_ptr<melonDS::ARCodeFile> cheatFile;
     bool cheatsOn;

--- a/src/frontend/qt_sdl/PathSettingsDialog.cpp
+++ b/src/frontend/qt_sdl/PathSettingsDialog.cpp
@@ -31,6 +31,7 @@
 #include "main.h"
 
 #include "PathSettingsDialog.h"
+#include "SaveConversionDialog.h"
 #include "ui_PathSettingsDialog.h"
 
 using namespace melonDS::Platform;
@@ -89,7 +90,8 @@ void PathSettingsDialog::done(int r)
         return;
     }
     
-    needsReset = false;
+    // a conversion moved files, so re-resolve even if this is a cancel
+    needsReset = savesConverted;
 
     if (r == QDialog::Accepted)
     {
@@ -209,4 +211,69 @@ bool PathSettingsDialog::confirmSaveOverwrite(const QString& dir, const QString&
     return QMessageBox::warning(this, "melonDS", msg,
                                 QMessageBox::Yes|QMessageBox::No,
                                 QMessageBox::No) == QMessageBox::Yes;
+}
+
+void PathSettingsDialog::on_btnOpenSaveDir_clicked()
+{
+    QString dir = ui->txtSaveFilePath->text();
+    if (dir.isEmpty())
+    {
+        QMessageBox::information(this, "melonDS",
+            "There is no save files path set.\n\nWith a blank path, saves are kept next "
+            "to each ROM rather than in one directory.");
+        return;
+    }
+
+    if (!QFileInfo(dir).isDir())
+    {
+        QMessageBox::warning(this, "melonDS", "That save files path does not exist.");
+        return;
+    }
+
+    QDesktopServices::openUrl(QUrl::fromLocalFile(dir));
+}
+
+void PathSettingsDialog::on_btnConvertSaves_clicked()
+{
+    QString dir = ui->txtSaveFilePath->text();
+    if (dir.isEmpty())
+    {
+        QMessageBox::information(this, "melonDS",
+            "Set a save files path first.\n\nWith a blank path, saves are kept next to "
+            "each ROM rather than in one directory, so there is no single place to convert.");
+        return;
+    }
+
+    if (!QFileInfo(dir).isDir())
+    {
+        QMessageBox::warning(this, "melonDS", "That save files path does not exist.");
+        return;
+    }
+
+    // both from the combobox, so an unrecognised stored value can't build a target
+    int idx = ui->cbxSaveFileExtension->currentIndex();
+    QString toext = ui->cbxSaveFileExtension->itemText(idx);
+    QString fromext = ui->cbxSaveFileExtension->itemText(idx == 0 ? 1 : 0);
+
+    // asked before anything is renamed, since renaming cannot be undone
+    if (!confirmSaveOverwrite(dir, toext))
+        return;
+
+    SaveConversionDialog dlg(this, dir, fromext, toext, emuInstance->emuIsActive());
+    dlg.exec();
+
+    if (dlg.renamedCount() > 0)
+    {
+        // the rename cannot be undone, so the setting has to be saved with it or
+        // Cancel would leave the config and the files on different extensions
+        auto& cfg = emuInstance->getLocalConfig();
+        cfg.SetQString("SaveFilePath", dir);
+        cfg.SetQString("SaveFileExtension", toext);
+        Config::Save();
+
+        ui->txtSaveFilePath->setProperty("user_originalValue", dir);
+        ui->cbxSaveFileExtension->setProperty("user_originalValue", idx);
+
+        savesConverted = true;
+    }
 }

--- a/src/frontend/qt_sdl/PathSettingsDialog.cpp
+++ b/src/frontend/qt_sdl/PathSettingsDialog.cpp
@@ -17,9 +17,13 @@
 */
 
 #include <stdio.h>
+#include <QComboBox>
+#include <QDesktopServices>
 #include <QFileDialog>
+#include <QFileInfo>
 #include <QMessageBox>
 #include <QTemporaryFile>
+#include <QUrl>
 
 #include "types.h"
 #include "Config.h"
@@ -50,6 +54,11 @@ PathSettingsDialog::PathSettingsDialog(QWidget* parent) : QDialog(parent), ui(ne
     ui->txtSavestatePath->setText(cfg.GetQString("SavestatePath"));
     ui->txtCheatFilePath->setText(cfg.GetQString("CheatFilePath"));
 
+    ui->cbxSaveFileExtension->addItem(".sav");
+    ui->cbxSaveFileExtension->addItem(".srm");
+    int extidx = ui->cbxSaveFileExtension->findText(cfg.GetQString("SaveFileExtension"));
+    ui->cbxSaveFileExtension->setCurrentIndex(extidx < 0 ? 0 : extidx);
+
     int inst = emuInstance->getInstanceID();
     if (inst > 0)
         ui->lblInstanceNum->setText(QString("Configuring paths for instance %1").arg(inst+1));
@@ -61,6 +70,7 @@ PathSettingsDialog::PathSettingsDialog(QWidget* parent) : QDialog(parent), ui(ne
         w->setProperty("user_originalValue", w->val());
 
     SET_ORIGVAL(QLineEdit, text);
+    SET_ORIGVAL(QComboBox, currentIndex);
 
 #undef SET_ORIGVAL
 }
@@ -97,6 +107,7 @@ void PathSettingsDialog::done(int r)
         }
 
         CHECK_ORIGVAL(QLineEdit, text);
+        CHECK_ORIGVAL(QComboBox, currentIndex);
 
 #undef CHECK_ORIGVAL
 
@@ -108,10 +119,15 @@ void PathSettingsDialog::done(int r)
                     QMessageBox::Ok, QMessageBox::Cancel) != QMessageBox::Ok)
                 return;
 
+            if (!confirmSaveOverwrite(ui->txtSaveFilePath->text(),
+                                      ui->cbxSaveFileExtension->currentText()))
+                return;
+
             auto& cfg = emuInstance->getLocalConfig();
             cfg.SetQString("SaveFilePath", ui->txtSaveFilePath->text());
             cfg.SetQString("SavestatePath", ui->txtSavestatePath->text());
             cfg.SetQString("CheatFilePath", ui->txtCheatFilePath->text());
+            cfg.SetQString("SaveFileExtension", ui->cbxSaveFileExtension->currentText());
 
             Config::Save();
 
@@ -173,4 +189,24 @@ void PathSettingsDialog::on_btnCheatFileBrowse_clicked()
     }
 
     ui->txtCheatFilePath->setText(dir);
+}
+
+// Retargeting a live SaveManager flushes the in-memory save to the new path, which
+// truncates whatever is there. Name the file rather than let it vanish silently.
+bool PathSettingsDialog::confirmSaveOverwrite(const QString& dir, const QString& ext)
+{
+    if (!emuInstance->emuIsActive()) return true;
+
+    std::string victim = emuInstance->saveOverwrittenBySettings(dir.toStdString(),
+                                                                ext.toStdString());
+    if (victim.empty()) return true;
+
+    QString msg = QString("%1 already exists and will be overwritten with the save "
+                          "data currently in memory. Its contents will be lost.\n\n"
+                          "Continue?")
+                  .arg(QFileInfo(QString::fromStdString(victim)).fileName());
+
+    return QMessageBox::warning(this, "melonDS", msg,
+                                QMessageBox::Yes|QMessageBox::No,
+                                QMessageBox::No) == QMessageBox::Yes;
 }

--- a/src/frontend/qt_sdl/PathSettingsDialog.h
+++ b/src/frontend/qt_sdl/PathSettingsDialog.h
@@ -61,12 +61,18 @@ private slots:
     void on_btnSaveFileBrowse_clicked();
     void on_btnSavestateBrowse_clicked();
     void on_btnCheatFileBrowse_clicked();
+    void on_btnConvertSaves_clicked();
+    void on_btnOpenSaveDir_clicked();
 
 private:
     bool confirmSaveOverwrite(const QString& dir, const QString& ext);
 
     Ui::PathSettingsDialog* ui;
     EmuInstance* emuInstance;
+
+    // set once save files have actually been renamed on disk, so the reset still
+    // happens even if the dialog is then cancelled
+    bool savesConverted = false;
 };
 
 #endif // PATHSETTINGSDIALOG_H

--- a/src/frontend/qt_sdl/PathSettingsDialog.h
+++ b/src/frontend/qt_sdl/PathSettingsDialog.h
@@ -63,6 +63,8 @@ private slots:
     void on_btnCheatFileBrowse_clicked();
 
 private:
+    bool confirmSaveOverwrite(const QString& dir, const QString& ext);
+
     Ui::PathSettingsDialog* ui;
     EmuInstance* emuInstance;
 };

--- a/src/frontend/qt_sdl/PathSettingsDialog.ui
+++ b/src/frontend/qt_sdl/PathSettingsDialog.ui
@@ -118,8 +118,39 @@
      </property>
     </widget>
    </item>
-   <item row="2" column="1">
-    <widget class="QComboBox" name="cbxSaveFileExtension"/>
+   <item row="2" column="1" colspan="2">
+    <layout class="QHBoxLayout" name="layoutSaveFileExtension">
+     <item>
+      <widget class="QComboBox" name="cbxSaveFileExtension"/>
+     </item>
+     <item>
+      <spacer name="spacerSaveFileExtension">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QPushButton" name="btnConvertSaves">
+       <property name="text">
+        <string>Convert...</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="btnOpenSaveDir">
+       <property name="text">
+        <string>Open folder</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
    </item>
    <item row="0" column="0" colspan="3">
     <widget class="QLabel" name="lblInstanceNum">
@@ -134,6 +165,8 @@
   <tabstop>txtSaveFilePath</tabstop>
   <tabstop>btnSaveFileBrowse</tabstop>
   <tabstop>cbxSaveFileExtension</tabstop>
+  <tabstop>btnConvertSaves</tabstop>
+  <tabstop>btnOpenSaveDir</tabstop>
   <tabstop>txtSavestatePath</tabstop>
   <tabstop>btnSavestateBrowse</tabstop>
   <tabstop>txtCheatFilePath</tabstop>

--- a/src/frontend/qt_sdl/PathSettingsDialog.ui
+++ b/src/frontend/qt_sdl/PathSettingsDialog.ui
@@ -7,42 +7,52 @@
     <x>0</x>
     <y>0</y>
     <width>439</width>
-    <height>185</height>
+    <height>245</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Path settings - melonDS</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="3" column="0">
+   <item row="4" column="0">
     <widget class="QLabel" name="label_4">
      <property name="text">
       <string>Cheat files path:</string>
      </property>
     </widget>
    </item>
-   <item row="3" column="2">
+   <item row="4" column="2">
     <widget class="QPushButton" name="btnCheatFileBrowse">
      <property name="text">
       <string>Browse...</string>
      </property>
     </widget>
    </item>
-   <item row="2" column="0">
+   <item row="3" column="0">
     <widget class="QLabel" name="label_3">
      <property name="text">
       <string>Savestates path:</string>
      </property>
     </widget>
    </item>
-   <item row="5" column="0" colspan="3">
+   <item row="6" column="0" colspan="3">
+    <widget class="QLabel" name="label_7">
+     <property name="text">
+      <string>.srm is the same data as .sav - it is the name RetroArch uses. Only the filename differs.</string>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="7" column="0" colspan="3">
     <widget class="QLabel" name="label_5">
      <property name="text">
       <string/>
      </property>
     </widget>
    </item>
-   <item row="2" column="1">
+   <item row="3" column="1">
     <widget class="QLineEdit" name="txtSavestatePath">
      <property name="clearButtonEnabled">
       <bool>true</bool>
@@ -56,14 +66,14 @@
      </property>
     </widget>
    </item>
-   <item row="3" column="1">
+   <item row="4" column="1">
     <widget class="QLineEdit" name="txtCheatFilePath">
      <property name="clearButtonEnabled">
       <bool>true</bool>
      </property>
     </widget>
    </item>
-   <item row="6" column="0" colspan="3">
+   <item row="8" column="0" colspan="3">
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
@@ -73,7 +83,7 @@
      </property>
     </widget>
    </item>
-   <item row="2" column="2">
+   <item row="3" column="2">
     <widget class="QPushButton" name="btnSavestateBrowse">
      <property name="text">
       <string>Browse...</string>
@@ -87,7 +97,7 @@
      </property>
     </widget>
    </item>
-   <item row="4" column="0" colspan="3">
+   <item row="5" column="0" colspan="3">
     <widget class="QLabel" name="label">
      <property name="text">
       <string>Leave a path blank to use the current ROM's path.</string>
@@ -101,6 +111,16 @@
      </property>
     </widget>
    </item>
+   <item row="2" column="0">
+    <widget class="QLabel" name="label_6">
+     <property name="text">
+      <string>Save file extension:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="1">
+    <widget class="QComboBox" name="cbxSaveFileExtension"/>
+   </item>
    <item row="0" column="0" colspan="3">
     <widget class="QLabel" name="lblInstanceNum">
      <property name="text">
@@ -113,6 +133,7 @@
  <tabstops>
   <tabstop>txtSaveFilePath</tabstop>
   <tabstop>btnSaveFileBrowse</tabstop>
+  <tabstop>cbxSaveFileExtension</tabstop>
   <tabstop>txtSavestatePath</tabstop>
   <tabstop>btnSavestateBrowse</tabstop>
   <tabstop>txtCheatFilePath</tabstop>

--- a/src/frontend/qt_sdl/SaveConversionDialog.cpp
+++ b/src/frontend/qt_sdl/SaveConversionDialog.cpp
@@ -1,0 +1,284 @@
+/*
+    Copyright 2016-2026 melonDS team
+
+    This file is part of melonDS.
+
+    melonDS is free software: you can redistribute it and/or modify it under
+    the terms of the GNU General Public License as published by the Free
+    Software Foundation, either version 3 of the License, or (at your option)
+    any later version.
+
+    melonDS is distributed in the hope that it will be useful, but WITHOUT ANY
+    WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+    FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with melonDS. If not, see http://www.gnu.org/licenses/.
+*/
+
+#include <cctype>
+#include <set>
+
+#include <QListWidgetItem>
+#include <QPushButton>
+
+#include "SaveConversionDialog.h"
+#include "ui_SaveConversionDialog.h"
+
+namespace fs = std::filesystem;
+
+SaveConversionDialog::SaveConversionDialog(QWidget* parent, const QString& dir,
+                                           const QString& fromext, const QString& toext,
+                                           bool willResetEmu)
+    : QDialog(parent), ui(new Ui::SaveConversionDialog),
+      dirPath(dir), fromExt(fromext), toExt(toext), resetsEmu(willResetEmu)
+{
+    ui->setupUi(this);
+
+    // no WA_DeleteOnClose: the caller reads renamedCount() after exec() returns
+
+    QFont warnfont = ui->lblResetWarning->font();
+    warnfont.setBold(true);
+    warnfont.setUnderline(true);
+    ui->lblResetWarning->setFont(warnfont);
+
+    ui->buttonBox->button(QDialogButtonBox::Ok)->setText("Rename");
+
+    // Enter must not rename a whole directory unread
+    ui->buttonBox->button(QDialogButtonBox::Cancel)->setDefault(true);
+
+    connect(ui->buttonBox, &QDialogButtonBox::accepted, this, &SaveConversionDialog::onRename);
+    connect(ui->buttonBox, &QDialogButtonBox::rejected, this, &QDialog::reject);
+
+    scan();
+    showPreview();
+}
+
+SaveConversionDialog::~SaveConversionDialog()
+{
+    delete ui;
+}
+
+void SaveConversionDialog::addHeading(const QString& text)
+{
+    QListWidgetItem* item = new QListWidgetItem(text, ui->lstFiles);
+    QFont font = item->font();
+    font.setBold(true);
+    item->setFont(font);
+}
+
+void SaveConversionDialog::addLine(const QString& text)
+{
+    new QListWidgetItem("    " + text, ui->lstFiles);
+}
+
+// Collects candidates and their destinations. Nothing is renamed here.
+void SaveConversionDialog::scan()
+{
+    std::string olde = fromExt.toStdString();
+    std::string newe = toExt.toStdString();
+
+    std::error_code ec;
+    fs::path base = fs::u8path(dirPath.toStdString());
+
+    std::set<fs::path> pending;  // destinations already claimed by an earlier candidate
+
+    fs::directory_iterator it(base, ec);
+    if (ec)
+    {
+        skipped.push_back("(could not read the save directory - "
+                          + QString::fromLocal8Bit(ec.message().c_str()) + ")");
+        return;
+    }
+
+    for (fs::directory_iterator end; it != end; it.increment(ec))
+    {
+        if (ec)
+        {
+            // report rather than silently truncating the listing
+            skipped.push_back("(directory listing stopped early - "
+                              + QString::fromLocal8Bit(ec.message().c_str()) + ")");
+            break;
+        }
+
+        const fs::directory_entry& entry = *it;
+
+        std::string name = entry.path().filename().u8string();
+
+        // match <name><fromExt>, optionally followed by ".<digits>" (instance suffix)
+        size_t pos = name.rfind(olde);
+        if (pos == std::string::npos) continue;
+
+        std::string tail = name.substr(pos + olde.length());
+        if (!tail.empty())
+        {
+            // capped so a dated backup like game.sav.20240101 isn't matched
+            if (tail[0] != '.') continue;
+            if (tail.length() < 2 || tail.length() > 3) continue;
+            bool alldigits = true;
+            for (size_t i = 1; i < tail.length(); i++)
+                if (!isdigit((unsigned char)tail[i])) { alldigits = false; break; }
+            if (!alldigits) continue;
+        }
+
+        std::string newname = name.substr(0, pos) + newe + tail;
+        fs::path to = base / fs::u8path(newname);
+
+        QString qname = QString::fromStdString(name);
+        QString qnew = QString::fromStdString(newname);
+
+        // error_code overloads throughout: a filesystem_error would escape this slot
+        std::error_code stc;
+        fs::file_status st = entry.symlink_status(stc);
+        if (stc || !fs::status_known(st))
+        {
+            skipped.push_back(qname + " - could not read file type");
+            continue;
+        }
+
+        // symlinks are left alone: renaming a link moves the link, not its target
+        if (fs::is_symlink(st))
+        {
+            skipped.push_back(qname + " - is a symlink");
+            continue;
+        }
+
+        if (!fs::is_regular_file(st))
+        {
+            skipped.push_back(qname + " - not a regular file");
+            continue;
+        }
+
+        // symlink_status, not exists(): a dangling link reports false from exists()
+        // and fs::rename would replace it. Unknown status counts as occupied too.
+        std::error_code dec;
+        fs::file_status dst = fs::symlink_status(to, dec);
+        if (!fs::status_known(dst) || fs::exists(dst))
+        {
+            skipped.push_back(qname + " - " + qnew + " already exists");
+            continue;
+        }
+
+        if (pending.count(to))
+        {
+            skipped.push_back(qname + " - another file would be renamed to " + qnew);
+            continue;
+        }
+
+        renames.push_back({entry.path(), to});
+        pending.insert(to);
+        if (!tail.empty()) touchesInstanceFiles = true;
+    }
+}
+
+void SaveConversionDialog::showPreview()
+{
+    ui->lblHeader->setText(QString("Rename %1 save files to %2?\n\n"
+                                   "These files will be renamed immediately:\n%3")
+                           .arg(fromExt, toExt, dirPath));
+
+    ui->lblResetWarning->setText(resetsEmu
+        ? "The running game will be restarted so it picks up the new file names. "
+          "Save in-game first if you have unsaved progress."
+        : "");
+    ui->lblResetWarning->setVisible(resetsEmu);
+
+    ui->lstFiles->clear();
+
+    if (renames.empty() && skipped.empty())
+    {
+        addHeading(QString("No %1 save files were found in this directory.").arg(fromExt));
+        ui->buttonBox->button(QDialogButtonBox::Ok)->setEnabled(false);
+        return;
+    }
+
+    if (!renames.empty())
+    {
+        addHeading(QString("Will be renamed (%1)").arg(renames.size()));
+        for (const Rename& r : renames)
+            addLine(QString::fromStdString(r.from.filename().u8string())
+                    + "  ->  " + QString::fromStdString(r.to.filename().u8string()));
+    }
+
+    if (!skipped.empty())
+    {
+        addHeading(QString("Will be skipped (%1)").arg(skipped.size()));
+        for (const QString& s : skipped)
+            addLine(s);
+    }
+
+    // the extension setting is per-instance, so renaming another instance's file
+    // leaves that instance still configured for the old one
+    if (touchesInstanceFiles)
+    {
+        addHeading("Note");
+        addLine("Files ending in .2, .3 and so on belong to other melonDS instances.");
+        addLine("Their own save file extension setting is not changed by this.");
+    }
+
+    ui->buttonBox->button(QDialogButtonBox::Ok)->setEnabled(!renames.empty());
+}
+
+void SaveConversionDialog::onRename()
+{
+    for (const Rename& r : renames)
+    {
+        QString qold = QString::fromStdString(r.from.filename().u8string());
+        QString qnew = QString::fromStdString(r.to.filename().u8string());
+
+        // re-check: the preview has no time bound and fs::rename replaces silently
+        std::error_code dec;
+        fs::file_status dst = fs::symlink_status(r.to, dec);
+        if (!fs::status_known(dst) || fs::exists(dst))
+        {
+            skipped.push_back(qold + " - " + qnew + " appeared while this window was open");
+            continue;
+        }
+
+        std::error_code rec;
+        fs::rename(r.from, r.to, rec);
+        if (rec)
+            skipped.push_back(qold + " - " + QString::fromLocal8Bit(rec.message().c_str()));
+        else
+            renamed.push_back(qold + "  ->  " + qnew);
+    }
+
+    showResults();
+}
+
+void SaveConversionDialog::showResults()
+{
+    ui->lblHeader->setText(QString("Renamed %1, skipped %2, of %3 file(s) found in:\n%4")
+                           .arg(renamed.size())
+                           .arg(skipped.size())
+                           .arg(renamed.size() + skipped.size())
+                           .arg(dirPath));
+
+    bool willreset = resetsEmu && !renamed.empty();
+    ui->lblResetWarning->setText(willreset
+        ? "The running game will be restarted when path settings closes."
+        : "");
+    ui->lblResetWarning->setVisible(willreset);
+
+    ui->lstFiles->clear();
+
+    // results can hold error text worth copying; the preview had nothing to act on
+    ui->lstFiles->setSelectionMode(QAbstractItemView::ExtendedSelection);
+    ui->lstFiles->setFocusPolicy(Qt::StrongFocus);
+
+    if (!renamed.empty())
+    {
+        addHeading(QString("Renamed (%1)").arg(renamed.size()));
+        for (const QString& r : renamed)
+            addLine(r);
+    }
+
+    if (!skipped.empty())
+    {
+        addHeading(QString("Skipped (%1)").arg(skipped.size()));
+        for (const QString& s : skipped)
+            addLine(s);
+    }
+
+    ui->buttonBox->setStandardButtons(QDialogButtonBox::Close);
+}

--- a/src/frontend/qt_sdl/SaveConversionDialog.h
+++ b/src/frontend/qt_sdl/SaveConversionDialog.h
@@ -1,0 +1,77 @@
+/*
+    Copyright 2016-2026 melonDS team
+
+    This file is part of melonDS.
+
+    melonDS is free software: you can redistribute it and/or modify it under
+    the terms of the GNU General Public License as published by the Free
+    Software Foundation, either version 3 of the License, or (at your option)
+    any later version.
+
+    melonDS is distributed in the hope that it will be useful, but WITHOUT ANY
+    WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+    FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with melonDS. If not, see http://www.gnu.org/licenses/.
+*/
+
+#ifndef SAVECONVERSIONDIALOG_H
+#define SAVECONVERSIONDIALOG_H
+
+#include <filesystem>
+#include <vector>
+
+#include <QDialog>
+#include <QString>
+
+namespace Ui { class SaveConversionDialog; }
+class SaveConversionDialog;
+
+// Renames cart save files in one directory from one extension to the other. Only ever
+// renames onto a free destination: fs::rename would replace an existing file silently,
+// which for a save means destroying it with no undo.
+class SaveConversionDialog : public QDialog
+{
+    Q_OBJECT
+
+public:
+    SaveConversionDialog(QWidget* parent, const QString& dir,
+                         const QString& fromext, const QString& toext,
+                         bool willResetEmu);
+    ~SaveConversionDialog();
+
+    // renames are already on disk once exec() returns, whatever the user does next
+    int renamedCount() const { return (int)renamed.size(); }
+
+private slots:
+    void onRename();
+
+private:
+    struct Rename
+    {
+        std::filesystem::path from;
+        std::filesystem::path to;
+    };
+
+    void scan();
+    void showPreview();
+    void showResults();
+
+    void addHeading(const QString& text);
+    void addLine(const QString& text);
+
+    Ui::SaveConversionDialog* ui;
+
+    QString dirPath;
+    QString fromExt;
+    QString toExt;
+    bool resetsEmu;
+
+    std::vector<Rename> renames;
+    bool touchesInstanceFiles = false;  // a rename target carries a .N instance suffix
+    std::vector<QString> skipped;  // "file - reason"
+    std::vector<QString> renamed;  // "old -> new", filled once the renames have run
+};
+
+#endif // SAVECONVERSIONDIALOG_H

--- a/src/frontend/qt_sdl/SaveConversionDialog.ui
+++ b/src/frontend/qt_sdl/SaveConversionDialog.ui
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>SaveConversionDialog</class>
+ <widget class="QDialog" name="SaveConversionDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>540</width>
+    <height>440</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Convert save files - melonDS</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QLabel" name="lblHeader">
+     <property name="text">
+      <string/>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLabel" name="lblResetWarning">
+     <property name="text">
+      <string/>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QListWidget" name="lstFiles">
+     <property name="alternatingRowColors">
+      <bool>true</bool>
+     </property>
+     <property name="selectionMode">
+      <enum>QAbstractItemView::NoSelection</enum>
+     </property>
+     <property name="focusPolicy">
+      <enum>Qt::NoFocus</enum>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/frontend/qt_sdl/Window.cpp
+++ b/src/frontend/qt_sdl/Window.cpp
@@ -30,6 +30,9 @@
 #include <QProcess>
 #include <QApplication>
 #include <QMessageBox>
+#include <QCheckBox>
+#include <QFileInfo>
+#include <QPushButton>
 #include <QMenuBar>
 #include <QMimeDatabase>
 #include <QFileDialog>
@@ -1271,6 +1274,46 @@ QStringList MainWindow::pickROM(bool gba)
     return ret;
 }
 
+void MainWindow::checkSaveExtFallback(bool gba)
+{
+    // taken before the suppression check: a stale record would surface later
+    EmuInstance::SavePathInfo fb;
+    if (!emuInstance->takeSaveExtFallback(gba, fb))
+        return;
+
+    if (!globalCfg.GetBool("ShowSaveExtWarning"))
+        return;
+
+    emuThread->emuPause();
+
+    QString msg = QString("Detected %1 save data for this game, but melonDS is set to "
+                          "use %2. It was loaded, and future saves will be written as %2.\n\n"
+                          "Save files can be converted in Config > Path settings.")
+                  .arg(QString::fromStdString(fb.readExt),
+                       QString::fromStdString(fb.writeExt));
+
+    QMessageBox box(QMessageBox::Information, "melonDS", msg, QMessageBox::Ok, this);
+
+    QPushButton* btnsettings = box.addButton("Path settings...", QMessageBox::ActionRole);
+
+    QCheckBox* suppress = new QCheckBox("Don't show this again", &box);
+    box.setCheckBox(suppress);
+
+    box.exec();
+
+    if (suppress->isChecked())
+    {
+        globalCfg.SetBool("ShowSaveExtWarning", false);
+        Config::Save();
+    }
+
+    // before our unpause: pauses stack, so the emulator never resumes in between
+    if (box.clickedButton() == btnsettings)
+        onOpenPathSettings();
+
+    emuThread->emuUnpause();
+}
+
 void MainWindow::updateCartInserted(bool gba)
 {
     bool inserted;
@@ -1304,6 +1347,8 @@ void MainWindow::updateCartInserted(bool gba)
             win->actRAMInfo->setEnabled(inserted);
         });
     }
+
+    checkSaveExtFallback(gba);
 }
 
 void MainWindow::onOpenFile()
@@ -1604,7 +1649,7 @@ void MainWindow::onImportSavefile()
     QString path = QFileDialog::getOpenFileName(this,
                                             "Select savefile",
                                             globalCfg.GetQString("LastROMFolder"),
-                                            "Savefiles (*.sav *.bin *.dsv);;Any file (*.*)");
+                                            "Savefiles (*.sav *.srm *.bin *.dsv);;Any file (*.*)");
 
     if (path.isEmpty())
         return;

--- a/src/frontend/qt_sdl/Window.h
+++ b/src/frontend/qt_sdl/Window.h
@@ -198,6 +198,7 @@ private:
     QString pickFileFromArchive(QString archiveFileName);
     QStringList pickROM(bool gba);
     void updateCartInserted(bool gba);
+    void checkSaveExtFallback(bool gba);
 
     void createScreenPanel();
 


### PR DESCRIPTION
I use both the standalone melonDS as well as the RetroArch core, and realized the `.sav` files melonDS creates and the `.srm` files RA uses are the same files, just with a different extension. For my personal usage I don't really mind setting up softlinks but it is a bit annoying and from researching this online it's confusing for others who have to manually rename files.

This PR has 2 parts, and I think many of the UX decisions I'm very open to changing based on feedback.

### Part 1: .srm selection
The first commit allows a user to set `.srm` as the save file extension. From a fresh setup with zero saves, this basically just equates to allowing users to point their melonDS save path to the same as where RA saves, and if you set `.srm` then you can seamlessly use the same saves (assuming the ROM name matches as well).

The decision this opens which I think is very much a UX decision that can change is whether to read the other file extension if it exists. Say a `.srm` file exists but you are using `.sav` then should this be detected and prompt the user to help with confusion? The decision I made was a dialogue box to tell the user that they're using a different save file extension than what's detected. (The exact wording is a result of Part 2)

<img width="500" height="195" alt="image" src="https://github.com/user-attachments/assets/934ad82a-81a6-4a2e-a1de-20b5d606e2b8" />

### Part 2: file conversion
"File conversion" is really just file extension renaming, and it's done using `fs::rename` which is an atomic operation and should be the safest way to perform this operation. I think this is both a nice UX as well as prevents file renaming mistakes. This does open some other questions about what to do when there's name collisions, such as if you had an existing `filename.sav` and `filename.srm`, and the decision here is to show in the dialogue that these files will be skipped.

The other thing this handles properly is when you use the multiple instance feature of melonDS, where files like `filename.sav.2` will be properly renamed as `filename.srm.2`,

<img width="541" height="467" alt="image" src="https://github.com/user-attachments/assets/1b3cbba4-ac21-4a38-b41d-f9519ec65a36" />

A small last detail is that an "open folder" option is added to give a convenient UX to manually copy/fix saves.

<img width="440" height="309" alt="image" src="https://github.com/user-attachments/assets/823e7752-e29f-4ba3-8442-ef0139379a90" />

### Testing
All four CI platforms build, and tested the rename semantics on Linux, Windows, and MacOS including case-insensitive collision (`filename.srm` and `FILENAME.srm`).

I tested this the most with the Qt Linux build, but I will update this when I am able to build and test manually in Windows. I also made a github actions test file to test some of the platform differences, but I'm not sure if we want that to be included in this PR or not. I'm happy to share it if it's helpful.
