### PR TITLE
Fix SPU bit depth and stale JIT state

### DIFF
--- a/src/ARMJIT.cpp
+++ b/src/ARMJIT.cpp
@@ -941,7 +941,7 @@ void ARMJIT::InvalidateByAddr(u32 localAddr) noexcept
 
     AddressRange* region = CodeMemRegions[localAddr >> 27];
     AddressRange* range = &region[(localAddr & 0x7FFFFFF) / 512];
-    u32 mask = 1 << ((localAddr & 0x1FF) / 16);
+    u32 invalidationMask = 1 << ((localAddr & 0x1FF) / 16);
 
     range->Code = 0;
     for (int i = 0; i < range->Blocks.Length;)
@@ -955,7 +955,7 @@ void ARMJIT::InvalidateByAddr(u32 localAddr) noexcept
             if (block->AddressRanges()[j] == (localAddr & ~0x1FF))
             {
                 mask = block->AddressMasks()[j];
-                invalidated = block->AddressMasks()[j] & mask;
+                invalidated = mask & invalidationMask;
                 assert(mask);
                 break;
             }

--- a/src/ARMJIT.cpp
+++ b/src/ARMJIT.cpp
@@ -1032,6 +1032,36 @@ void ARMJIT::CheckAndInvalidateITCM() noexcept
     }
 }
 
+void ARMJIT::CheckAndInvalidateSWRAM(bool invalidateARM7WRAM) noexcept
+{
+    for (u32 i = 0; i < SharedWRAMSize; i += 512)
+    {
+        if (CodeIndexSWRAM[i / 512].Code)
+        {
+            for (u32 j = 0; j < 512; j += 16)
+            {
+                if (CodeIndexSWRAM[i / 512].Code & (1 << ((j & 0x1FF) / 16)))
+                    InvalidateByAddr((i + j) | (ARMJIT_Memory::memregion_SharedWRAM << 27));
+            }
+        }
+    }
+
+    if (!invalidateARM7WRAM)
+        return;
+
+    for (u32 i = 0; i < ARM7WRAMSize; i += 512)
+    {
+        if (CodeIndexARM7WRAM[i / 512].Code)
+        {
+            for (u32 j = 0; j < 512; j += 16)
+            {
+                if (CodeIndexARM7WRAM[i / 512].Code & (1 << ((j & 0x1FF) / 16)))
+                    InvalidateByAddr((i + j) | (ARMJIT_Memory::memregion_WRAM7 << 27));
+            }
+        }
+    }
+}
+
 void ARMJIT::CheckAndInvalidateWVRAM(int bank) noexcept
 {
     u32 start = bank == 1 ? 0x20000 : 0;

--- a/src/ARMJIT.cpp
+++ b/src/ARMJIT.cpp
@@ -561,8 +561,7 @@ void ARMJIT::CompileBlock(ARM* cpu) noexcept
         }
 
         // some memory has been remapped
-        RetireJitBlock(existingBlockIt->second);
-        map.erase(existingBlockIt);
+        InvalidateByAddr(otherLocalAddr);
     }
 
     FetchedInstr instrs[MaxBlockSize];
@@ -852,7 +851,9 @@ void ARMJIT::CompileBlock(ARM* cpu) noexcept
         prevBlock = prevBlockIt->second;
         RestoreCandidates.erase(prevBlockIt);
 
-        mayRestore = prevBlock->StartAddr == blockAddr && prevBlock->LiteralHash == literalHash;
+        mayRestore = prevBlock->Num == cpu->Num
+            && prevBlock->StartAddr == blockAddr
+            && prevBlock->LiteralHash == literalHash;
 
         if (mayRestore && prevBlock->NumAddresses == numAddressRanges)
         {

--- a/src/ARMJIT.cpp
+++ b/src/ARMJIT.cpp
@@ -362,7 +362,7 @@ bool IsIdleLoop(bool thumb, FetchedInstr* instrs, int instrsCount)
     for (int i = 0; i < instrsCount; i++)
     {
         JIT_DEBUGPRINT("instr %d %08x regs(%x %x) %x %x\n", i, instrs[i].Instr, instrs[i].Info.DstRegs, instrs[i].Info.SrcRegs, regsWrittenTo, regsDisallowedToWrite);
-        if (instrs[i].Info.SpecialKind == ARMInstrInfo::special_WriteMem)
+        if (instrs[i].Info.WritesMemory)
             return false;
         if (!thumb && instrs[i].Info.Kind >= ARMInstrInfo::ak_MSR_IMM && instrs[i].Info.Kind <= ARMInstrInfo::ak_MRC)
             return false;
@@ -581,9 +581,6 @@ void ARMJIT::CompileBlock(ARM* cpu) noexcept
     // due to instruction merging i might not reflect the amount of actual instructions
     u32 numInstrs = 0;
 
-    u32 writeAddrs[MaxBlockSize];
-    u32 numWriteAddrs = 0, writeAddrsTranslated = 0;
-
     cpu->FillPipeline();
     u32 nextInstr[2] = {cpu->NextInstr[0], cpu->NextInstr[1]};
     u32 nextInstrAddr[2] = {blockAddr, r15};
@@ -595,6 +592,7 @@ void ARMJIT::CompileBlock(ARM* cpu) noexcept
     bool hasLink = false;
 
     bool hasMemoryInstr = false;
+    bool blockMayWrite = false;
 
     do
     {
@@ -602,6 +600,7 @@ void ARMJIT::CompileBlock(ARM* cpu) noexcept
 
         instrs[i].BranchFlags = 0;
         instrs[i].SetFlags = 0;
+        instrs[i].MayFoldLiteral = false;
         instrs[i].Instr = nextInstr[0];
         nextInstr[0] = nextInstr[1];
 
@@ -657,6 +656,7 @@ void ARMJIT::CompileBlock(ARM* cpu) noexcept
             instrs[i].CodeCycles = cpu->CodeCycles;
         }
         instrs[i].Info = ARMInstrInfo::Decode(thumb, cpu->Num, instrs[i].Instr, LiteralOptimizations);
+        blockMayWrite |= instrs[i].Info.WritesMemory;
 
         hasMemoryInstr |= thumb
             ? (instrs[i].Info.Kind >= ARMInstrInfo::tk_LDR_PCREL && instrs[i].Info.Kind <= ARMInstrInfo::tk_STMIA)
@@ -709,7 +709,7 @@ void ARMJIT::CompileBlock(ARM* cpu) noexcept
             {
                 Log(LogLevel::Warn,"literal in non executable memory?\n");
             }
-            if (InvalidLiterals.Find(translatedAddr) == -1)
+            else if (InvalidLiterals.Find(translatedAddr) == -1)
             {
                 u32 translatedAddrRounded = translatedAddr & ~0x1FF;
 
@@ -723,10 +723,9 @@ void ARMJIT::CompileBlock(ARM* cpu) noexcept
                 JIT_DEBUGPRINT("literal loading %08x %08x %08x %08x\n", literalAddr, translatedAddr, addressMasks[j], addressRanges[j]);
                 cpu->DataRead32(literalAddr, &literalValues[numLiterals]);
                 literalLoadAddrs[numLiterals++] = translatedAddr;
+                instrs[i].MayFoldLiteral = true;
             }
         }
-        else if (instrs[i].Info.SpecialKind == ARMInstrInfo::special_WriteMem)
-            writeAddrs[numWriteAddrs++] = instrs[i].DataRegion;
         else if (thumb && instrs[i].Info.Kind == ARMInstrInfo::tk_BL_LONG_2 && i > 0
             && instrs[i - 1].Info.Kind == ARMInstrInfo::tk_BL_LONG_1)
         {
@@ -820,24 +819,10 @@ void ARMJIT::CompileBlock(ARM* cpu) noexcept
             FloodFillSetFlags(instrs, i - 2, !secondaryFlagReadCond ? instrs[i - 1].Info.ReadFlags : 0xF);
     } while(!instrs[i - 1].Info.EndBlock && i < MaxBlockSize && !cpu->Halted && (!cpu->IRQ || (cpu->CPSR & 0x80)));
 
-    if (numLiterals)
+    if (blockMayWrite)
     {
-        for (u32 j = 0; j < numWriteAddrs; j++)
-        {
-            u32 translatedAddr = LocaliseCodeAddress(cpu->Num, writeAddrs[j]);
-            if (translatedAddr)
-            {
-                for (u32 k = 0; k < numLiterals; k++)
-                {
-                    if (literalLoadAddrs[k] == translatedAddr)
-                    {
-                        if (InvalidLiterals.Find(translatedAddr) == -1)
-                            InvalidLiterals.Add(translatedAddr);
-                        break;
-                    }
-                }
-            }
-        }
+        for (int j = 0; j < i; j++)
+            instrs[j].MayFoldLiteral = false;
     }
 
     u32 literalHash = (u32)XXH3_64bits(literalValues, numLiterals * 4);

--- a/src/ARMJIT.h
+++ b/src/ARMJIT.h
@@ -49,6 +49,7 @@ public:
     void InvalidateByAddr(u32) noexcept;
     void CheckAndInvalidateWVRAM(int) noexcept;
     void CheckAndInvalidateITCM() noexcept;
+    void CheckAndInvalidateSWRAM(bool invalidateARM7WRAM) noexcept;
     void Reset() noexcept;
     void JitEnableWrite() noexcept;
     void JitEnableExecute() noexcept;
@@ -189,6 +190,7 @@ public:
     void InvalidateByAddr(u32) noexcept {}
     void CheckAndInvalidateWVRAM(int) noexcept {}
     void CheckAndInvalidateITCM() noexcept {}
+    void CheckAndInvalidateSWRAM(bool) noexcept {}
     void Reset() noexcept {}
     void JitEnableWrite() noexcept {}
     void JitEnableExecute() noexcept {}
@@ -203,4 +205,3 @@ public:
 #endif // JIT_ENABLED
 
 #endif // ARMJIT_H
-

--- a/src/ARMJIT_A64/ARMJIT_LoadStore.cpp
+++ b/src/ARMJIT_A64/ARMJIT_LoadStore.cpp
@@ -114,7 +114,7 @@ void Compiler::Comp_MemAccess(int rd, int rn, Op2 offset, int size, int flags)
 
     if (NDS.JIT.LiteralOptimizationsEnabled() && rn == 15 && rd != 15 && offset.IsImm && !(flags & (memop_Post|memop_Store|memop_Writeback)))
     {
-        u32 addr = R15 + offset.Imm * ((flags & memop_SubtractOffset) ? -1 : 1);
+        u32 addr = (Thumb ? (R15 & ~0x2) : R15) + offset.Imm * ((flags & memop_SubtractOffset) ? -1 : 1);
         
         if (Comp_MemLoadLiteral(size, flags & memop_SignExtend, rd, addr))
             return;

--- a/src/ARMJIT_A64/ARMJIT_LoadStore.cpp
+++ b/src/ARMJIT_A64/ARMJIT_LoadStore.cpp
@@ -63,6 +63,9 @@ u8* Compiler::RewriteMemAccess(u8* pc)
 
 bool Compiler::Comp_MemLoadLiteral(int size, bool signExtend, int rd, u32 addr)
 {
+    if (!CurInstr.MayFoldLiteral)
+        return false;
+
     u32 localAddr = NDS.JIT.LocaliseCodeAddress(Num, addr);
 
     int invalidLiteralIdx = NDS.JIT.InvalidLiterals.Find(localAddr);

--- a/src/ARMJIT_Internal.h
+++ b/src/ARMJIT_Internal.h
@@ -69,6 +69,7 @@ struct FetchedInstr
     u8 DataCycles;
     u16 CodeCycles;
     u32 DataRegion;
+    bool MayFoldLiteral;
 
     ARMInstrInfo::Info Info;
 };

--- a/src/ARMJIT_x64/ARMJIT_LoadStore.cpp
+++ b/src/ARMJIT_x64/ARMJIT_LoadStore.cpp
@@ -69,6 +69,9 @@ u8* Compiler::RewriteMemAccess(u8* pc)
 
 bool Compiler::Comp_MemLoadLiteral(int size, bool signExtend, int rd, u32 addr)
 {
+    if (!CurInstr.MayFoldLiteral)
+        return false;
+
     u32 localAddr = NDS.JIT.LocaliseCodeAddress(Num, addr);
 
     int invalidLiteralIdx = NDS.JIT.InvalidLiterals.Find(localAddr);

--- a/src/ARM_InstrInfo.cpp
+++ b/src/ARM_InstrInfo.cpp
@@ -386,8 +386,8 @@ Info Decode(bool thumb, u32 num, u32 instr, bool literaloptimizations)
         {
             if (res.Kind == tk_LDR_PCREL)
             {
-                if (!literaloptimizations)
-                    res.SrcRegs |= 1 << 15;
+                // Invalidated literals fall back to a load that still needs PC.
+                res.SrcRegs |= 1 << 15;
                 res.SpecialKind = special_LoadLiteral;
             }
             else

--- a/src/ARM_InstrInfo.cpp
+++ b/src/ARM_InstrInfo.cpp
@@ -379,7 +379,8 @@ Info Decode(bool thumb, u32 num, u32 instr, bool literaloptimizations)
         if (data & T_SetC)
             res.WriteFlags |= flag_C;
 
-        if (data & T_WriteMem)
+        res.WritesMemory = data & T_WriteMem;
+        if (res.WritesMemory)
             res.SpecialKind = special_WriteMem;
 
         if (data & T_LoadMem)
@@ -520,7 +521,8 @@ Info Decode(bool thumb, u32 num, u32 instr, bool literaloptimizations)
             || ((data & A_SetCImm) && ((instr >> 7) & 0x1E)))
             res.WriteFlags |= flag_C;
 
-        if (data & A_WriteMem)
+        res.WritesMemory = data & A_WriteMem;
+        if (res.WritesMemory)
             res.SpecialKind = special_WriteMem;
 
         if (data & A_LoadMem)

--- a/src/ARM_InstrInfo.h
+++ b/src/ARM_InstrInfo.h
@@ -267,6 +267,7 @@ struct Info
     // upper 4 bits - might set flag
     u8 WriteFlags;
 
+    bool WritesMemory;
     bool EndBlock;
     bool Branches() const
     {

--- a/src/NDS.cpp
+++ b/src/NDS.cpp
@@ -1296,6 +1296,11 @@ void NDS::MapSharedWRAM(u8 val)
     if (val == WRAMCnt)
         return;
 
+    JIT.CheckAndInvalidateSWRAM((WRAMCnt & 0x3) == 0 || (val & 0x3) == 0);
+#ifdef JIT_ENABLED
+    ARM9.FastBlockLookupSize = 0;
+    ARM7.FastBlockLookupSize = 0;
+#endif
     JIT.Memory.RemapSWRAM();
 
     WRAMCnt = val;

--- a/src/SPU.cpp
+++ b/src/SPU.cpp
@@ -206,14 +206,13 @@ SPU::SPU(melonDS::NDS& nds, AudioBitDepth bitdepth, AudioInterpolation interpola
         SPUCaptureUnit(1, nds),
     },
     AudioLock(Platform::Mutex_Create()),
-    Degrade10Bit(bitdepth == AudioBitDepth::_10Bit || (nds.ConsoleType == 1 && bitdepth == AudioBitDepth::Auto)),
     OutputSampleRate(outputSampleRate),
     OutputBuffer(nullptr)
 {
     NDS.RegisterEventFuncs(Event_SPU, this, {MakeEventThunk(SPU, Mix)});
 
     ApplyBias = true;
-    Degrade10Bit = false;
+    SetDegrade10Bit(bitdepth);
 
     BlipLeft = blip_new(512);
     BlipRight = blip_new(512);


### PR DESCRIPTION
## Problem

The core can keep using settings or compiled code after they are no longer valid:

- SPU startup overwrites the selected audio bit depth.
- The JIT can reuse code for the wrong CPU, keep old memory links, discard unrelated code, or reload a Thumb value from the wrong address.
- A compiled block can hard-code a memory value, change that memory, and continue using the old value.
- Remapping Shared WRAM can leave compiled readers and lookup tables connected to the previous layout.

## Why the existing fixes are not enough

[PR #2745](https://github.com/melonDS-emu/melonDS/pull/2745) and [PR #2746](https://github.com/melonDS-emu/melonDS/pull/2746) cover only the unrelated-code and Thumb-address errors. [PR #2747](https://github.com/melonDS-emu/melonDS/pull/2747) only combines those two changes. All three are closed and unmerged, and none covers the other stale-state paths.

The safeguard in [`55ec724f`](https://github.com/melonDS-emu/melonDS/commit/55ec724fee5cdc5ed91226f3e4f1aad11a3bcfb2) only sees exact write addresses observed while compiling. It misses changing or conditional addresses, overlapping byte writes, and exchange instructions. The WVRAM fix in [`32609bbc`](https://github.com/melonDS-emu/melonDS/commit/32609bbc980d2a496b40f29c41ac2e39f7651230) only covers ARM7 video WRAM, not Shared WRAM, its ARM7 alias, or both CPU lookup tables.

## Fix

- Apply the existing audio bit-depth policy during SPU startup.
- Reuse compiled code only for the same CPU and remove all old memory links when mappings change.
- Select affected code using the address actually written and use the correct aligned address for Thumb reloads.
- Read values at runtime whenever a block may write memory; read-only blocks keep the existing optimization.
- Invalidate Shared WRAM users and clear both CPU lookup tables before changing the mapping.

JIT and no-JIT Release builds and all 104 focused test processes pass.
