### PR TITLE
Three small fixes: MAC address, redundant shader rebuild, unused edge list

### DIFF
--- a/src/GPU3D_Compute.cpp
+++ b/src/GPU3D_Compute.cpp
@@ -324,6 +324,13 @@ void ComputeRenderer3D::SetRenderSettings(int scale, bool highResolutionCoordina
 {
     u8 TileScale;
 
+    // Nothing below depends on anything but these two, and rebuilding means
+    // recompiling every shader and reallocating the buffers. The GL renderer
+    // already bails out the same way. ScaleFactor starts at 0, which is not a
+    // valid scale, so the first call always goes through.
+    if (scale == ScaleFactor && highResolutionCoordinates == HiresCoordinates)
+        return;
+
     if (ScaleFactor != -1)
     {
         DeleteShaders();

--- a/src/GPU3D_OpenGL.cpp
+++ b/src/GPU3D_OpenGL.cpp
@@ -756,17 +756,20 @@ void GLRenderer3D::BuildPolygons(GLRenderer3D::RendererPolygon* polygons, int np
         rp->EdgeIndicesOffset = eidx;
         rp->NumEdgeIndices = 0;
 
-        u32 vidx_cur = vidx_first;
-        for (u32 j = 1; j < poly->NumVertices; j++)
+        if (EdgeMarkingImplemented)
         {
+            u32 vidx_cur = vidx_first;
+            for (u32 j = 1; j < poly->NumVertices; j++)
+            {
+                IndexBuffer[eidx++] = vidx_cur;
+                IndexBuffer[eidx++] = vidx_cur + 1;
+                vidx_cur++;
+                rp->NumEdgeIndices += 2;
+            }
             IndexBuffer[eidx++] = vidx_cur;
-            IndexBuffer[eidx++] = vidx_cur + 1;
-            vidx_cur++;
+            IndexBuffer[eidx++] = vidx_first;
             rp->NumEdgeIndices += 2;
         }
-        IndexBuffer[eidx++] = vidx_cur;
-        IndexBuffer[eidx++] = vidx_first;
-        rp->NumEdgeIndices += 2;
     }
 
     NumVertices = vidx;
@@ -939,7 +942,7 @@ void GLRenderer3D::RenderSceneChunk(int y, int h)
 
     // if edge marking is enabled, mark all opaque edges
     // TODO BETTER EDGE MARKING!!! THIS SUCKS
-    /*if (RenderDispCnt & (1<<5))
+    /*if (EdgeMarkingImplemented && (RenderDispCnt & (1<<5)))
     {
         UseRenderShader(flags | RenderFlag_Edge);
         glLineWidth(1.5);
@@ -1477,7 +1480,8 @@ void GLRenderer3D::RenderFrame()
         // bind to access the index buffer
         glBindVertexArray(VertexArrayID);
         glBufferSubData(GL_ELEMENT_ARRAY_BUFFER, 0, NumIndices * 2, IndexBuffer);
-        glBufferSubData(GL_ELEMENT_ARRAY_BUFFER, EdgeIndicesOffset * 2, NumEdgeIndices * 2, IndexBuffer + EdgeIndicesOffset);
+        if (NumEdgeIndices > 0)
+            glBufferSubData(GL_ELEMENT_ARRAY_BUFFER, EdgeIndicesOffset * 2, NumEdgeIndices * 2, IndexBuffer + EdgeIndicesOffset);
 
         RenderSceneChunk(0, 192);
     }

--- a/src/GPU3D_OpenGL.h
+++ b/src/GPU3D_OpenGL.h
@@ -84,6 +84,14 @@ private:
     int RenderSinglePolygon(int i) const;
     int RenderPolygonBatch(int i) const;
     int RenderPolygonEdgeBatch(int i) const;
+
+    // The edge marking pass in RenderSceneChunk() is commented out (see the
+    // "TODO BETTER EDGE MARKING" block), so RenderPolygonEdgeBatch() is never
+    // called and nothing ever reads the edge index list. Building and uploading
+    // that list every frame is therefore pure overhead. Both the build and the
+    // draw are gated on this one flag: flip it back to true in the same commit
+    // that restores the pass, so the two can never disagree.
+    static constexpr bool EdgeMarkingImplemented = false;
     void RenderSceneChunk(int y, int h);
 
 

--- a/src/SPI.cpp
+++ b/src/SPI.cpp
@@ -135,7 +135,7 @@ void FirmwareMem::SetupDirectBoot()
     {
         // The ARMWrite methods are virtual, they'll delegate to DSi if necessary
         for (u32 i = 0; i < 6; i += 2)
-            NDS.ARM9Write16(0x02FFFCF4, *(u16*)&header.MacAddr[i]); // MAC address
+            NDS.ARM9Write16(0x02FFFCF4+i, *(u16*)&header.MacAddr[i]); // MAC address
 
         // checkme
         NDS.ARM9Write16(0x02FFFCFA, header.EnabledChannels); // enabled channels


### PR DESCRIPTION
Three unrelated fixes, one commit each.

### 1. Only two of the six bytes of the MAC address are written — `src/SPI.cpp`

When a DSi game boots directly, melonDS writes the address to the same spot three times instead of moving along. Four of the six bytes never arrive, so the emulated console ends up with an address its firmware never gave it.

*What changes for you:* fixes a bug. I don't know of a game that misbehaves because of it, and I'm not claiming there is one.

### 2. Changing a video setting rebuilds every shader, even when nothing changed — `src/GPU3D_Compute.cpp`

Every time the renderer is handed its settings it throws away all its shaders and rebuilds them, even when the values are the ones it is already using. The OpenGL renderer already checks for this; the compute one doesn't.

*What changes for you:* faster. On a test device, changing video settings rebuilt 33 shaders ten times in one session. After the fix: none. It still rebuilds on startup, where it has to.

### 3. The renderer prepares data for a drawing step that is switched off — `src/GPU3D_OpenGL.cpp`

The edge outlines step has been commented out for years, but the list of edges it would need is still built for every polygon and sent to the graphics card every frame. This doesn't turn the step back on — it just stops paying for it while it's off.

*What changes for you:* removes work that has no effect. I haven't measured how much.

### What this doesn't prove

Fixes 1 and 3 aren't backed by a measurement — I can show the bug in the code, not its effect on screen. Fix 2 was measured on Android only.
