### PR TITLE
Qt: add command-line configuration profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,27 @@ DS BIOS dumps from a DSi or 3DS can be used with no compatibility issues. DSi BI
 
 As for the rest, the interface should be pretty straightforward. If you have a question, don't hesitate to ask, though!
 
+### Command-line configuration profiles
+
+Use a specific configuration file instead of the default `melonDS.toml`:
+
+```
+melonDS --config profile.toml
+```
+
+Apply a temporary configuration over the default or selected configuration:
+
+```
+melonDS --append-config game.toml "game.nds"
+melonDS --config profile.toml --append-config game.toml "game.nds"
+```
+
+`--config` saves configuration changes to the selected file. `--append-config`
+recursively merges TOML tables while replacing scalar and array values. To keep
+temporary values out of the base configuration, no configuration changes are
+saved while an additional configuration is active. `--appendconfig` is accepted
+as an alias for compatibility with existing launchers.
+
 ## How to build
 See [BUILD.md](./BUILD.md) for build instructions.
 

--- a/src/frontend/qt_sdl/CLI.cpp
+++ b/src/frontend/qt_sdl/CLI.cpp
@@ -43,7 +43,7 @@ CommandLineOptions* ManageArgs(QApplication& melon)
 
     parser.addOption(QCommandLineOption({"b", "boot"}, "Whether to boot firmware on startup. Defaults to \"auto\" (boot if NDS rom given)", "auto/always/never", "auto"));
     parser.addOption(QCommandLineOption({"c", "config"}, "Use the specified TOML configuration file", "file"));
-    parser.addOption(QCommandLineOption({"append-config", "appendconfig"}, "Temporarily override settings with an additional TOML configuration file", "file"));
+    parser.addOption(QCommandLineOption({"append-config", "appendconfig"}, "Temporarily override settings without saving configuration changes", "file"));
     parser.addOption(QCommandLineOption({"f", "fullscreen"}, "Start melonDS in fullscreen mode"));
 
 #ifdef ARCHIVE_SUPPORT_ENABLED

--- a/src/frontend/qt_sdl/CLI.cpp
+++ b/src/frontend/qt_sdl/CLI.cpp
@@ -42,6 +42,7 @@ CommandLineOptions* ManageArgs(QApplication& melon)
     parser.addPositionalArgument("gba", "GBA ROM (or an archive file which contains it) to load into Slot-2");
 
     parser.addOption(QCommandLineOption({"b", "boot"}, "Whether to boot firmware on startup. Defaults to \"auto\" (boot if NDS rom given)", "auto/always/never", "auto"));
+    parser.addOption(QCommandLineOption({"c", "config"}, "Use the specified TOML configuration file", "file"));
     parser.addOption(QCommandLineOption({"f", "fullscreen"}, "Start melonDS in fullscreen mode"));
 
 #ifdef ARCHIVE_SUPPORT_ENABLED
@@ -54,6 +55,8 @@ CommandLineOptions* ManageArgs(QApplication& melon)
     CommandLineOptions* options = new CommandLineOptions;
 
     options->fullscreen = parser.isSet("fullscreen");
+    if (parser.isSet("config"))
+        options->configPath = parser.value("config");
 
     QStringList posargs = parser.positionalArguments();
     switch (posargs.size())

--- a/src/frontend/qt_sdl/CLI.cpp
+++ b/src/frontend/qt_sdl/CLI.cpp
@@ -43,6 +43,7 @@ CommandLineOptions* ManageArgs(QApplication& melon)
 
     parser.addOption(QCommandLineOption({"b", "boot"}, "Whether to boot firmware on startup. Defaults to \"auto\" (boot if NDS rom given)", "auto/always/never", "auto"));
     parser.addOption(QCommandLineOption({"c", "config"}, "Use the specified TOML configuration file", "file"));
+    parser.addOption(QCommandLineOption({"append-config", "appendconfig"}, "Temporarily override settings with an additional TOML configuration file", "file"));
     parser.addOption(QCommandLineOption({"f", "fullscreen"}, "Start melonDS in fullscreen mode"));
 
 #ifdef ARCHIVE_SUPPORT_ENABLED
@@ -57,6 +58,8 @@ CommandLineOptions* ManageArgs(QApplication& melon)
     options->fullscreen = parser.isSet("fullscreen");
     if (parser.isSet("config"))
         options->configPath = parser.value("config");
+    if (parser.isSet("append-config"))
+        options->appendConfigPath = parser.value("append-config");
 
     QStringList posargs = parser.positionalArguments();
     switch (posargs.size())

--- a/src/frontend/qt_sdl/CLI.h
+++ b/src/frontend/qt_sdl/CLI.h
@@ -32,6 +32,7 @@ struct CommandLineOptions
     std::optional<QString> dsRomArchivePath;
     std::optional<QString> gbaRomPath;
     std::optional<QString> gbaRomArchivePath;
+    std::optional<QString> configPath;
     bool fullscreen;
     bool boot;
 };

--- a/src/frontend/qt_sdl/CLI.h
+++ b/src/frontend/qt_sdl/CLI.h
@@ -33,6 +33,7 @@ struct CommandLineOptions
     std::optional<QString> gbaRomPath;
     std::optional<QString> gbaRomArchivePath;
     std::optional<QString> configPath;
+    std::optional<QString> appendConfigPath;
     bool fullscreen;
     bool boot;
 };

--- a/src/frontend/qt_sdl/Config.cpp
+++ b/src/frontend/qt_sdl/Config.cpp
@@ -47,6 +47,7 @@ const char* kLegacyUniqueConfigFile = "melonDS.%d.ini";
 toml::value RootTable;
 static std::optional<std::string> ActiveConfigPath;
 static std::string LastError;
+static bool SaveEnabled = true;
 
 DefaultList<int> DefaultInts =
 {
@@ -784,9 +785,32 @@ bool LoadLegacy()
     return true;
 }
 
-bool Load(const std::optional<std::string>& configPath)
+static void MergeConfig(toml::value& base, const toml::value& overlay)
+{
+    if (!base.is_table() || !overlay.is_table())
+    {
+        base = overlay;
+        return;
+    }
+
+    for (const auto& item : overlay.as_table())
+    {
+        const std::string& key = item.first;
+        const toml::value& overlayValue = item.second;
+        toml::value& baseValue = base[key];
+
+        if (baseValue.is_table() && overlayValue.is_table())
+            MergeConfig(baseValue, overlayValue);
+        else
+            baseValue = overlayValue;
+    }
+}
+
+bool Load(const std::optional<std::string>& configPath,
+          const std::optional<std::string>& appendConfigPath)
 {
     LastError.clear();
+    SaveEnabled = !appendConfigPath.has_value();
 
     const bool customConfig = configPath.has_value();
     std::string cfgpath = customConfig ? *configPath : Platform::GetLocalFilePath(kConfigFile);
@@ -807,17 +831,42 @@ bool Load(const std::optional<std::string>& configPath)
     RootTable = toml::value();
 
     if (!Platform::FileExists(cfgpath))
-        return LoadLegacy();
-
-    try
     {
-        RootTable = toml::parse(std::filesystem::u8path(cfgpath));
+        if (!LoadLegacy())
+            return false;
     }
-    catch (toml::exception& err)
+    else
     {
-        if (customConfig)
+        try
         {
-            LastError = "Unable to parse the specified configuration file:\n" + cfgpath + "\n\n" + err.what();
+            RootTable = toml::parse(std::filesystem::u8path(cfgpath));
+        }
+        catch (toml::exception& err)
+        {
+            if (customConfig || appendConfigPath)
+            {
+                LastError = "Unable to parse configuration file:\n" + cfgpath + "\n\n" + err.what();
+                return false;
+            }
+        }
+    }
+
+    if (appendConfigPath)
+    {
+        if (!Platform::FileExists(*appendConfigPath))
+        {
+            LastError = "The specified additional configuration file does not exist:\n" + *appendConfigPath;
+            return false;
+        }
+
+        try
+        {
+            toml::value overlay = toml::parse(std::filesystem::u8path(*appendConfigPath));
+            MergeConfig(RootTable, overlay);
+        }
+        catch (toml::exception& err)
+        {
+            LastError = "Unable to parse the specified additional configuration file:\n" + *appendConfigPath + "\n\n" + err.what();
             return false;
         }
     }
@@ -827,6 +876,9 @@ bool Load(const std::optional<std::string>& configPath)
 
 void Save()
 {
+    if (!SaveEnabled)
+        return;
+
     std::string cfgpath = ActiveConfigPath.value_or(Platform::GetLocalFilePath(kConfigFile));
     if (!Platform::CheckFileWritable(cfgpath))
         return;

--- a/src/frontend/qt_sdl/Config.cpp
+++ b/src/frontend/qt_sdl/Config.cpp
@@ -822,7 +822,7 @@ bool Load(const std::optional<std::string>& configPath,
         return false;
     }
 
-    if (!Platform::CheckFileWritable(cfgpath))
+    if (SaveEnabled && !Platform::CheckFileWritable(cfgpath))
     {
         LastError = "Unable to write to configuration file:\n" + cfgpath;
         return false;

--- a/src/frontend/qt_sdl/Config.cpp
+++ b/src/frontend/qt_sdl/Config.cpp
@@ -810,6 +810,9 @@ bool Load(const std::optional<std::string>& configPath,
           const std::optional<std::string>& appendConfigPath)
 {
     LastError.clear();
+
+    // Runtime changes and overlay values share the same table, so suppress all
+    // writes to prevent temporary values from leaking into the base config.
     SaveEnabled = !appendConfigPath.has_value();
 
     const bool customConfig = configPath.has_value();

--- a/src/frontend/qt_sdl/Config.cpp
+++ b/src/frontend/qt_sdl/Config.cpp
@@ -45,6 +45,8 @@ const char* kLegacyConfigFile = "melonDS.ini";
 const char* kLegacyUniqueConfigFile = "melonDS.%d.ini";
 
 toml::value RootTable;
+static std::optional<std::string> ActiveConfigPath;
+static std::string LastError;
 
 DefaultList<int> DefaultInts =
 {
@@ -782,12 +784,25 @@ bool LoadLegacy()
     return true;
 }
 
-bool Load()
+bool Load(const std::optional<std::string>& configPath)
 {
-    auto cfgpath = Platform::GetLocalFilePath(kConfigFile);
+    LastError.clear();
+
+    const bool customConfig = configPath.has_value();
+    std::string cfgpath = customConfig ? *configPath : Platform::GetLocalFilePath(kConfigFile);
+    ActiveConfigPath = cfgpath;
+
+    if (customConfig && !Platform::FileExists(cfgpath))
+    {
+        LastError = "The specified configuration file does not exist:\n" + cfgpath;
+        return false;
+    }
 
     if (!Platform::CheckFileWritable(cfgpath))
+    {
+        LastError = "Unable to write to configuration file:\n" + cfgpath;
         return false;
+    }
 
     RootTable = toml::value();
 
@@ -798,9 +813,13 @@ bool Load()
     {
         RootTable = toml::parse(std::filesystem::u8path(cfgpath));
     }
-    catch (toml::syntax_error& err)
+    catch (toml::exception& err)
     {
-        //RootTable = toml::table();
+        if (customConfig)
+        {
+            LastError = "Unable to parse the specified configuration file:\n" + cfgpath + "\n\n" + err.what();
+            return false;
+        }
     }
 
     return true;
@@ -808,7 +827,7 @@ bool Load()
 
 void Save()
 {
-    auto cfgpath = Platform::GetLocalFilePath(kConfigFile);
+    std::string cfgpath = ActiveConfigPath.value_or(Platform::GetLocalFilePath(kConfigFile));
     if (!Platform::CheckFileWritable(cfgpath))
         return;
 
@@ -816,6 +835,11 @@ void Save()
     file.open(std::filesystem::u8path(cfgpath), std::ofstream::out | std::ofstream::trunc);
     file << RootTable;
     file.close();
+}
+
+const std::string& GetLastError()
+{
+    return LastError;
 }
 
 

--- a/src/frontend/qt_sdl/Config.h
+++ b/src/frontend/qt_sdl/Config.h
@@ -19,6 +19,7 @@
 #ifndef CONFIG_H
 #define CONFIG_H
 
+#include <optional>
 #include <variant>
 #include <string>
 #include <QString>
@@ -130,8 +131,9 @@ private:
 };
 
 
-bool Load();
+bool Load(const std::optional<std::string>& configPath = std::nullopt);
 void Save();
+const std::string& GetLastError();
 
 Table GetLocalTable(int instance);
 inline Table GetGlobalTable() { return GetLocalTable(-1); }

--- a/src/frontend/qt_sdl/Config.h
+++ b/src/frontend/qt_sdl/Config.h
@@ -131,7 +131,8 @@ private:
 };
 
 
-bool Load(const std::optional<std::string>& configPath = std::nullopt);
+bool Load(const std::optional<std::string>& configPath = std::nullopt,
+          const std::optional<std::string>& appendConfigPath = std::nullopt);
 void Save();
 const std::string& GetLastError();
 

--- a/src/frontend/qt_sdl/main.cpp
+++ b/src/frontend/qt_sdl/main.cpp
@@ -367,13 +367,17 @@ int main(int argc, char** argv)
     if (options->configPath)
         configPath = options->configPath->toStdString();
 
-    if (!Config::Load(configPath))
+    std::optional<std::string> appendConfigPath;
+    if (options->appendConfigPath)
+        appendConfigPath = options->appendConfigPath->toStdString();
+
+    if (!Config::Load(configPath, appendConfigPath))
     {
         QString error = QString::fromStdString(Config::GetLastError());
         fprintf(stderr, "%s\n", Config::GetLastError().c_str());
         QMessageBox::critical(nullptr, "melonDS", error);
 
-        if (configPath)
+        if (configPath || appendConfigPath)
         {
             delete options;
             SDL_Quit();

--- a/src/frontend/qt_sdl/main.cpp
+++ b/src/frontend/qt_sdl/main.cpp
@@ -363,10 +363,23 @@ int main(int argc, char** argv)
     SDL_InitSubSystem(SDL_INIT_VIDEO);
     SDL_EnableScreenSaver(); SDL_DisableScreenSaver();
 
-    if (!Config::Load())
-        QMessageBox::critical(nullptr,
-                              "melonDS",
-                              "Unable to write to config.\nPlease check the write permissions of the folder you placed melonDS in.");
+    std::optional<std::string> configPath;
+    if (options->configPath)
+        configPath = options->configPath->toStdString();
+
+    if (!Config::Load(configPath))
+    {
+        QString error = QString::fromStdString(Config::GetLastError());
+        fprintf(stderr, "%s\n", Config::GetLastError().c_str());
+        QMessageBox::critical(nullptr, "melonDS", error);
+
+        if (configPath)
+        {
+            delete options;
+            SDL_Quit();
+            return 1;
+        }
+    }
 
     camStarted[0] = false;
     camStarted[1] = false;

--- a/src/frontend/qt_sdl/main.cpp
+++ b/src/frontend/qt_sdl/main.cpp
@@ -29,6 +29,7 @@
 #include <QMessageBox>
 #include <QMenuBar>
 #include <QFileDialog>
+#include <QFileInfo>
 #include <QInputDialog>
 #include <QPainter>
 #include <QKeyEvent>
@@ -365,11 +366,11 @@ int main(int argc, char** argv)
 
     std::optional<std::string> configPath;
     if (options->configPath)
-        configPath = options->configPath->toStdString();
+        configPath = QFileInfo(*options->configPath).absoluteFilePath().toStdString();
 
     std::optional<std::string> appendConfigPath;
     if (options->appendConfigPath)
-        appendConfigPath = options->appendConfigPath->toStdString();
+        appendConfigPath = QFileInfo(*options->appendConfigPath).absoluteFilePath().toStdString();
 
     if (!Config::Load(configPath, appendConfigPath))
     {


### PR DESCRIPTION
## Summary

Adds command-line configuration profiles for launchers and multi-instance setups:

- `-c` / `--config` selects an existing TOML configuration file instead of the default `melonDS.toml` and saves configuration changes to that file.
- `--append-config` / `--appendconfig` recursively merges a temporary TOML configuration over the default or selected base configuration.
- Overlay sessions suppress configuration writes so temporary values cannot leak into the base profile.
- Explicit profile paths are normalized at startup and missing or malformed files fail safely.
- The new options and their save behavior are documented in the README.

Closes #1617.
Closes #2278.
Related to #2237 by allowing separate melonDS processes to select separate configuration files.

## Prior work and credit

The `--config` implementation builds on the earlier work by [@Lemento](https://github.com/Lemento) in [PR #2458](https://github.com/melonDS-emu/melonDS/pull/2458). The first commit in this branch preserves that contribution with a `Co-authored-by` trailer.

This branch extends that earlier implementation with explicit error handling, stable relative paths, temporary recursive overlays, write suppression, documentation, and additional testing.

## Configuration behavior

With `--config`, the selected file becomes the read/write base configuration for the session. It must already exist.

With `--append-config`, TOML tables merge recursively while scalar values and arrays replace their base values. The base and overlay may both be read-only. No configuration changes are saved while an overlay is active.

Examples:

```
melonDS --config profile.toml
melonDS --append-config game.toml "game.nds"
melonDS --config profile.toml --append-config game.toml "game.nds"
```

## Testing

Tested on Windows using MSYS2 UCRT64, Qt 6, and GCC 15.2:

- Full debug build completed successfully.
- Both options and the compatibility alias appear in `--help`.
- A custom profile with a relative path containing spaces loaded successfully and saved back to the selected file without modifying the default configuration.
- A temporary overlay changed `ScreenLayout` and `ScreenGap` while preserving `ScreenSizing` from the base profile, confirming recursive table merging.
- Read-only base and overlay files launched successfully and remained byte-for-byte unchanged.
- Overlay shutdown completed normally with exit code 0.
- `git diff --check` passes.

## Feedback requested

The overlay and runtime settings share the same in-memory TOML table. This implementation therefore suppresses all configuration writes while an overlay is active, which prevents temporary values from being written into the base profile. Feedback on that behavior is welcome while this PR is in draft.